### PR TITLE
Integrates a11y analysis into the RSpec test suites

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ group :development do
 end
 
 group :test do
+  gem "axe-core-rspec"
   # Adds support for Capybara system testing and selenium driver
   gem "capybara", ">= 3.26"
   gem "coveralls_reborn", "~> 0.24", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,17 @@ GEM
     airbrussh (1.4.0)
       sshkit (>= 1.6.1, != 1.7.0)
     ast (2.4.2)
+    axe-core-api (4.4.0)
+      dumb_delegator
+      virtus
+    axe-core-rspec (4.4.0)
+      axe-core-api
+      dumb_delegator
+      virtus
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
     bindex (0.8.1)
     bixby (3.0.2)
       rubocop (= 0.85.1)
@@ -100,6 +111,8 @@ GEM
     childprocess (4.1.0)
     chronic (0.10.2)
     coderay (1.1.3)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.1.10)
     coveralls_reborn (0.24.0)
       simplecov (>= 0.18.1, < 0.22.0)
@@ -107,8 +120,11 @@ GEM
       thor (>= 0.20.3, < 2.0)
       tins (~> 1.16)
     crass (1.0.6)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.5.0)
     docile (1.4.0)
+    dumb_delegator (1.0.0)
     erubi (1.10.0)
     ffi (1.15.5)
     foreman (0.87.2)
@@ -117,6 +133,7 @@ GEM
     honeybadger (4.11.0)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -272,6 +289,7 @@ GEM
     term-ansicolor (1.7.1)
       tins (~> 1.0)
     thor (1.2.1)
+    thread_safe (0.3.6)
     tilt (2.0.10)
     tins (1.31.0)
       sync
@@ -281,6 +299,10 @@ GEM
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.8.0)
+    virtus (2.0.0)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
     web-console (4.2.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -309,6 +331,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  axe-core-rspec
   bixby
   bootsnap (>= 1.4.4)
   capistrano (~> 3.10)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,3 +1,9 @@
 # frozen_string_literal: true
 module ApplicationHelper
+  ##
+  # Attributes to add to the <html> tag (e.g. lang and dir)
+  # @return [Hash]
+  def html_tag_attributes
+    { lang: I18n.locale }
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
-<html>
+<%= content_tag :html, **html_tag_attributes do %>
   <head>
-    <title>DrdsRailsTemplate</title>
+    <title>Princeton Data Commons Describe</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -14,4 +14,4 @@
     <%= yield %>
     <%= render partial: 'shared/footer' %>
   </body>
-</html>
+<% end %>

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,6 +10,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 # Add additional requires below this line. Rails is not loaded until this point!
 
 require "rspec/rails"
+require "axe-rspec"
 require "simplecov"
 require "coveralls"
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(

--- a/spec/system/accessibility_spec.rb
+++ b/spec/system/accessibility_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+describe "application accessibility", type: :system, js: true do
+  context "when browsing the homepage" do
+    it "complies with WCAG 2.0 AA and Section 508" do
+      visit "/"
+      expect(page).to be_axe_clean
+        .according_to(:wcag2a, :wcag2aa, :wcag21a, :wcag21aa, :section508)
+        .skipping(:'color-contrast') # false positives
+        .excluding(".tt-hint") # Issue is in typeahead.js library
+    end
+  end
+end


### PR DESCRIPTION
Resolves #6 by addressing the following:

- Adding the axe-core-rspec Gem dependency for a11y analysis
- Implementing an initial test suite for assessing the WCAG 2.0 AA and Section 508 compliance of the app
- Implementing ApplicationHelper#html_tag_attributes to provide `lang` attributes for the `html` element