### PR TITLE
Configure superadmins

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -354,6 +354,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES
@@ -392,4 +393,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   2.2.21
+   2.2.32

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,4 +23,14 @@ class User < ApplicationRecord
     end
     user
   end
+
+  ##
+  # Is this user a superadmin? Superadmins automatically get admin status in every
+  # collection, and they can make new collections.
+  # @return [Boolean]
+  def superadmin?
+    Rails.configuration.superadmins.include? uid
+  rescue
+    false
+  end
 end

--- a/config/initializers/load_superadmins.rb
+++ b/config/initializers/load_superadmins.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+module PdcDescribe
+  class Application < Rails::Application
+    config.superadmins = config_for(:superadmins)
+  end
+end

--- a/config/superadmins.yml
+++ b/config/superadmins.yml
@@ -1,0 +1,20 @@
+---
+production:
+  - bs3097 # Bess Sadler
+  - jrg5 # James Griffin
+  - kl37 # Kate Lynch
+  - hc8719 # Hector Correa
+  - hh4079 # Hannah Hadley
+staging:
+  - bs3097 # Bess Sadler
+  - jrg5 # James Griffin
+  - kl37 # Kate Lynch
+  - hc8719 # Hector Correa
+  - hh4079 # Hannah Hadley
+development:
+  - bs3097 # Bess Sadler
+  - jrg5 # James Griffin
+  - kl37 # Kate Lynch
+  - hc8719 # Hector Correa
+test:
+  - fake1 # Fake user for testing

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,4 +11,18 @@ RSpec.describe User, type: :model do
       expect(described_class.from_cas(access_token)).to be_a described_class
     end
   end
+
+  describe "#superadmin?" do
+    let(:superadmin_access_token) { OmniAuth::AuthHash.new(provider: "cas", uid: "fake1", extra: { mail: "fake@princeton.edu" }) }
+    let(:superadmin) { described_class.from_cas(superadmin_access_token) }
+    let(:normal_user) { described_class.from_cas(access_token) }
+
+    it "is true if the user is in the superadmin config" do
+      expect(superadmin.superadmin?).to eq true
+    end
+
+    it "is false if the user is not in the superadmin config" do
+      expect(normal_user.superadmin?).to eq false
+    end
+  end
 end


### PR DESCRIPTION
Establish a config file for superadmins.
Every User object responds to #superadmin? which returns true if the
user with this netid is configured as a superadmin in this environment,
otherwise false.

Fixes #21 