### PR TITLE
Implementing the #orcid attribute for the User model

### DIFF
--- a/db/migrate/20220406152726_add_orcid_to_user.rb
+++ b/db/migrate/20220406152726_add_orcid_to_user.rb
@@ -1,0 +1,5 @@
+class AddOrcidToUser < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :orcid, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_31_184739) do
+ActiveRecord::Schema.define(version: 2022_04_06_152726) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(version: 2022_03_31_184739) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "provider"
     t.string "uid"
+    t.string "orcid"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["provider"], name: "index_users_on_provider"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -25,4 +25,23 @@ RSpec.describe User, type: :model do
       expect(normal_user.superadmin?).to eq false
     end
   end
+
+  describe "#orcid" do
+    let(:normal_user) { described_class.new }
+    let(:orcid) { "0000-0003-1279-3709" }
+
+    it "mutates the ORCID for a given User" do
+      expect(normal_user.orcid).to be nil
+      normal_user.orcid = orcid
+      expect(normal_user.orcid).to eq(orcid)
+    end
+
+    context "with an existing ORCID" do
+      let(:normal_user) { described_class.new(orcid: orcid) }
+
+      it "accesses an existing ORCID for a given User" do
+        expect(normal_user.orcid).to eq(orcid)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Advances #33 (but the implementation of a user page is still required for adding the ORCiD).