### PR TITLE
Adds per collection user authorization

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,3 +41,6 @@ RSpec/DescribeClass:
 
 RSpec/ExampleLength:
   Enabled: false
+
+Style/NumericPredicate:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -68,9 +68,10 @@ group :test do
   gem "selenium-webdriver"
   # Use simplecov for coverage analysis
   gem "simplecov", require: false
+  # Used for detecting what a controller rendered
+  gem "rails-controller-testing"
   # Easy installation and use of web drivers to run system tests with browsers
   gem "webdrivers"
-  gem "rails-controller-testing"
 end
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,7 @@ group :test do
   gem "simplecov", require: false
   # Easy installation and use of web drivers to run system tests with browsers
   gem "webdrivers"
+  gem "rails-controller-testing"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,6 +228,10 @@ GEM
       bundler (>= 1.15.0)
       railties (= 6.1.5)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -393,6 +397,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.3, >= 6.1.3.2)
+  rails-controller-testing
   rspec-rails (~> 5.0.0)
   sass-rails (>= 6)
   selenium-webdriver

--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -8,11 +8,35 @@ class DatasetsController < ApplicationController
   def new
     default_collection_id = current_user.default_collection.id
     @dataset = Dataset.create_skeleton("New Dataset", current_user.id, default_collection_id)
-    redirect_to dataset_url(@dataset)
+    render "edit"
   end
 
   def show
     id = params[:id]
     @dataset = Dataset.find(id)
   end
+
+  def edit
+    @dataset = Dataset.find(params[:id])
+  end
+
+  def update
+    @dataset = Dataset.find(params[:id])
+    respond_to do |format|
+      if @dataset.update(dataset_params)
+        format.html { redirect_to dataset_url(@dataset), notice: "Dataset was successfully updated." }
+        format.json { render :show, status: :ok, location: @dataset }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @dataset.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  private
+
+    # Only allow a list of trusted parameters through.
+    def dataset_params
+      params.require(:dataset).permit([:title, :collection_id, :ark])
+    end
 end

--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 class DatasetsController < ApplicationController
   def index
+    @datasets = Dataset.all
+  end
+
+  def dashboard
     @my_datasets = Dataset.where(created_by_user_id: current_user.id)
-    @other_datasets = Dataset.where("created_by_user_id != :user_id", { user_id: current_user.id })
+    @my_collections = current_user.submitter_collections
   end
 
   def new

--- a/app/controllers/demo_controller.rb
+++ b/app/controllers/demo_controller.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-class DemoController < ApplicationController
-  def index; end
-end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class Collection < ApplicationRecord
-  # rubocop:disable Style/NumericPredicate
   def self.create_defaults
     return if Collection.count > 0
     Rails.logger.info "Creating default Collections"
@@ -10,7 +9,6 @@ class Collection < ApplicationRecord
     Collection.create(title: "Electronic Theses and Dissertations", code: "ETD")
     Collection.create(title: "Library Resources", code: "LIB")
   end
-  # rubocop:enable Style/NumericPredicate
 
   # Returns the default collection.
   # Used when we don't have anything else to determine a more specific collection for a user.

--- a/app/models/user_collection.rb
+++ b/app/models/user_collection.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class UserCollection < ApplicationRecord
+  belongs_to :collection
+
+  def self.add_submitter(user_id, collection_id)
+    uc = UserCollection.new(user_id: user_id, collection_id: collection_id, role: "SUBMITTER")
+    uc.save!
+  end
+
+  def can_submit?
+    role.in?(["SUBMITTER", "ADMIN"])
+  end
+
+  def self.can_submit?(user_id, collection_id)
+    user_collection = UserCollection.where(user_id: user_id, collection_id: collection_id).first
+    return false if user_collection.nil?
+    user_collection.can_submit?
+  end
+
+  def self.can_admin?(user_id, collection_id)
+    user_collection = UserCollection.where(user_id: user_id, collection_id: collection_id).first
+    return false if user_collection.nil?
+    user_collection.role == "ADMIN"
+  end
+end

--- a/app/views/datasets/_form.html.erb
+++ b/app/views/datasets/_form.html.erb
@@ -1,0 +1,31 @@
+<%= form_with(model: dataset) do |form| %>
+  <% if dataset.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(dataset.errors.count, "error") %> prohibited this dataset from being saved:</h2>
+      <ul>
+        <% dataset.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :title %><br>
+    <%= form.text_field :title %>
+  </div>
+
+  <div class="field">
+    <%= form.label :collection %><br>
+    <%= form.collection_select :collection_id, current_user.submitter_collections, :id, :title, {:include_blank => true}, {:class => 'form-control'} %>
+  </div>
+
+  <div class="field">
+    <%= form.label :ark %><br>
+    <%= form.text_field :ark %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/app/views/datasets/_form.html.erb
+++ b/app/views/datasets/_form.html.erb
@@ -25,7 +25,10 @@
     <%= form.text_field :ark %>
   </div>
 
+  <br />
+
   <div class="actions">
     <%= form.submit class: "btn btn-primary" %>
+    <%= link_to 'Cancel', @dataset, class: "btn btn-secondary" %>
   </div>
 <% end %>

--- a/app/views/datasets/dashboard.html.erb
+++ b/app/views/datasets/dashboard.html.erb
@@ -1,0 +1,22 @@
+<h1>My Dashboard</h1>
+<p>Hi <%= current_user.email %></p>
+
+<% if @my_datasets.count > 0 %>
+  <h2>My Datasets</h2>
+  <% @my_datasets.each do |ds| %>
+    <p><%= link_to(ds.title, dataset_path(ds)) %></p>
+  <% end %>
+<% end %>
+<div>
+  <%= link_to "Create New Dataset", new_dataset_path, class: "btn btn-primary" %>
+</div>
+
+<% if @my_collections.count > 0 %>
+  <h2>My Collections</h2>
+  <% @my_collections.each do |c| %>
+    <p><%= link_to(c.title, "#") %></p>
+  <% end %>
+<% end %>
+
+
+<hr />

--- a/app/views/datasets/edit.html.erb
+++ b/app/views/datasets/edit.html.erb
@@ -1,0 +1,10 @@
+<h1>Editing Dataset</h1>
+
+<%= render 'form', dataset: @dataset %>
+
+<div>
+    <%= link_to 'Show', @dataset, class: "btn btn-secondary" %> |
+    <%= link_to 'Home', root_path %>
+</div>
+
+

--- a/app/views/datasets/edit.html.erb
+++ b/app/views/datasets/edit.html.erb
@@ -2,9 +2,6 @@
 
 <%= render 'form', dataset: @dataset %>
 
-<div>
-    <%= link_to 'Show', @dataset, class: "btn btn-secondary" %> |
-    <%= link_to 'Home', root_path %>
-</div>
+
 
 

--- a/app/views/datasets/index.html.erb
+++ b/app/views/datasets/index.html.erb
@@ -1,18 +1,7 @@
 <h1>Datasets</h1>
-<p>Hi <%= current_user.email %></p>
 
-<% if @my_datasets.count > 0 %>
-  <h2>Your Datasets</h2>
-  <% @my_datasets.each do |ds| %>
-    <p><%= link_to(ds.title, dataset_path(ds)) %></p>
-  <% end %>
-<% end %>
-
-<% if @other_datasets.count > 0 %>
-  <h2>All Other Datasets</h2>
-  <% @other_datasets.each do |ds| %>
-    <p><%= link_to(ds.title, dataset_path(ds)) %> (<%= ds.created_by_user.uid %>)</p>
-  <% end %>
+<% @datasets.each do |ds| %>
+  <p><%= link_to(ds.title, dataset_path(ds)) %> (<%= ds.created_by_user.uid %>)</p>
 <% end %>
 
 <div>

--- a/app/views/datasets/index.html.erb
+++ b/app/views/datasets/index.html.erb
@@ -15,7 +15,7 @@
   <% end %>
 <% end %>
 
-<h2>Options</h2>
-<%= link_to "Create a New Dataset", new_dataset_path %>
-
+<div>
+  <%= link_to "New Dataset", new_dataset_path, class: "btn btn-primary" %>
+</div>
 <hr />

--- a/app/views/datasets/show.html.erb
+++ b/app/views/datasets/show.html.erb
@@ -5,3 +5,8 @@
   <p>Created by: <%= @dataset.created_by_user.uid %></p>
   <p>Collection: <%= @dataset.collection.title %></p>
 </div>
+
+<div>
+  <%= link_to("Edit", edit_dataset_path(@dataset), class: "btn btn-primary") %>
+  <%= link_to 'Home', root_path %>
+</div>

--- a/app/views/datasets/show.html.erb
+++ b/app/views/datasets/show.html.erb
@@ -8,5 +8,4 @@
 
 <div>
   <%= link_to("Edit", edit_dataset_path(@dataset), class: "btn btn-primary") %>
-  <%= link_to 'Home', root_path %>
 </div>

--- a/app/views/demo/index.html.erb
+++ b/app/views/demo/index.html.erb
@@ -1,3 +1,0 @@
-<h1>Authenticated Demo</h1>
-<p>Hi <%= current_user.email %></p>
-<p>This page is only available to authenticated users</p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,7 @@
   </head>
 
   <body>
+    <%= render partial: 'shared/header' %>
     <%= yield %>
     <%= render partial: 'shared/footer' %>
   </body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,8 @@
 
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
   </head>
 
   <body>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,3 +1,4 @@
+<hr />
 <div class="lux">
   <div class="deployment-version" >
     <text-style variation="strong">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,0 +1,3 @@
+<h1>PDC Describe</h1>
+<%= link_to "Home", root_url %>
+<hr />

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,12 +1,14 @@
-<h1>Welcome to PDC Describe</h1>
-
 <% if current_user %>
   <div>
     Welcome: <%= current_user.email %>
+    <div>
+      <%= link_to "My Dashboard", datasets_dashboard_path, class: "btn btn-primary" %>
+    </div>
   </div>
 <% else %>
   <div>
-    <%= button_to "Login", user_cas_omniauth_authorize_path %>
+    <p>Welcome to PDC Describe, please login to view or create new datasets</p>
+    <%= button_to "Login", user_cas_omniauth_authorize_path, class: "btn btn-primary" %>
   </div>
 <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
     get "sign_out", to: "devise/sessions#destroy", as: :destroy_user_session
   end
 
+  get "/datasets/dashboard", to: "datasets#dashboard", as: :datasets_dashboard
   resources :datasets
 
   get "demo", to: "demo#index"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,8 +15,6 @@ Rails.application.routes.draw do
   get "/datasets/dashboard", to: "datasets#dashboard", as: :datasets_dashboard
   resources :datasets
 
-  get "demo", to: "demo#index"
-
   # Anything still unmatched by the end of the routes file should go to the not_found page
   # match '*a', to: redirect('/404'), via: :get
 end

--- a/db/migrate/20220414155700_create_user_collections.rb
+++ b/db/migrate/20220414155700_create_user_collections.rb
@@ -1,4 +1,4 @@
-class CreateUsersCollections < ActiveRecord::Migration[6.1]
+class CreateUserCollections < ActiveRecord::Migration[6.1]
     def change
       create_table :user_collections do |t|
         t.string :role # submitter, approver, admin

--- a/db/migrate/20220414155700_create_user_collections.rb
+++ b/db/migrate/20220414155700_create_user_collections.rb
@@ -1,0 +1,14 @@
+class CreateUsersCollections < ActiveRecord::Migration[6.1]
+    def change
+      create_table :user_collections do |t|
+        t.string :role # submitter, approver, admin
+        t.integer :user_id
+        t.integer :collection_id
+
+        t.timestamps
+      end
+
+      add_foreign_key :user_collections, :collections
+      add_foreign_key :user_collections, :users
+    end
+  end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_14_130226) do
+ActiveRecord::Schema.define(version: 2022_04_14_155700) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,6 +28,14 @@ ActiveRecord::Schema.define(version: 2022_04_14_130226) do
     t.string "profile"
     t.string "ark"
     t.integer "created_by_user_id"
+    t.integer "collection_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "user_collections", force: :cascade do |t|
+    t.string "role"
+    t.integer "user_id"
     t.integer "collection_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -53,5 +61,7 @@ ActiveRecord::Schema.define(version: 2022_04_14_130226) do
 
   add_foreign_key "datasets", "collections"
   add_foreign_key "datasets", "users", column: "created_by_user_id"
+  add_foreign_key "user_collections", "collections"
+  add_foreign_key "user_collections", "users"
   add_foreign_key "users", "collections", column: "default_collection_id"
 end

--- a/spec/controllers/datasets_controller_spec.rb
+++ b/spec/controllers/datasets_controller_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe DatasetsController do
       sign_in user
       get :index
       expect(response.status).to eq(200)
+      expect(response).to render_template("index")
     end
 
     it "handles the show page" do
@@ -18,13 +19,14 @@ RSpec.describe DatasetsController do
       sign_in user
       get :show, params: { id: ds.id }
       expect(response.status).to eq(200)
+      expect(response).to render_template("show")
     end
 
-    it "redirects to show page when creating a new dataset" do
+    it "renders the edit page when creating a new dataset" do
       sign_in user
       post :new
-      expect(response.status).to eq(302)
-      expect(response.location.start_with?("http://test.host/datasets/")).to be true
+      expect(response.status).to eq(200)
+      expect(response).to render_template("edit")
     end
   end
 end

--- a/spec/controllers/datasets_controller_spec.rb
+++ b/spec/controllers/datasets_controller_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe DatasetsController do
     it "handles the index page" do
       sign_in user
       get :index
-      expect(response.status).to eq(200)
       expect(response).to render_template("index")
     end
 
@@ -18,15 +17,45 @@ RSpec.describe DatasetsController do
       ds = Dataset.create_skeleton("test dataset", user.id, Collection.first.id)
       sign_in user
       get :show, params: { id: ds.id }
-      expect(response.status).to eq(200)
       expect(response).to render_template("show")
+    end
+
+    it "handles the dashboard page" do
+      sign_in user
+      get :dashboard
+      expect(response).to render_template("dashboard")
     end
 
     it "renders the edit page when creating a new dataset" do
       sign_in user
       post :new
-      expect(response.status).to eq(200)
       expect(response).to render_template("edit")
+    end
+
+    it "renders the edit page on edit" do
+      ds = Dataset.create_skeleton("test dataset", user.id, Collection.first.id)
+      sign_in user
+      get :edit, params: { id: ds.id }
+      expect(response).to render_template("edit")
+    end
+
+    it "handles the update page" do
+      ds = Dataset.create_skeleton("test dataset", user.id, Collection.first.id)
+      params = {
+        "dataset" => {
+          "title" => "test dataset updated",
+          "collection_id" => ds.collection_id.to_s,
+          "ark" => ds.ark
+        },
+        "commit" => "Update Dataset",
+        "controller" => "datasets",
+        "action" => "update",
+        "id" => ds.id.to_s
+      }
+      sign_in user
+      post :update, params: params
+      expect(response.status).to be 302
+      expect(response.location).to eq "http://test.host/datasets/#{ds.id}"
     end
   end
 end

--- a/spec/requests/welcome_spec.rb
+++ b/spec/requests/welcome_spec.rb
@@ -23,26 +23,4 @@ RSpec.describe "Home Page", type: :request do
       end
     end
   end
-
-  # We could replace this demo page and route with a real page once we have more features in the system
-  describe "GET /demo" do
-    context "Authenticated user" do
-      let(:user) { FactoryBot.create :user }
-      before do
-        sign_in user
-      end
-
-      it "displays the page" do
-        get "/demo"
-        expect(response.body.include?("Authenticated Demo")).to be true
-      end
-    end
-    context "Unauthenticated user" do
-      it "redirects the user to the login page" do
-        get "/demo"
-        expect(response.redirect?).to be true
-        expect(response.redirect_url).to eq "http://www.example.com/sign_in"
-      end
-    end
-  end
 end


### PR DESCRIPTION
Allows users to be designated as submitters, administrators, or none for collections. Users can only add new datasets to the collections that they are submitters (or administrators). 

Created a edit form for Datasets that allows users to change title, ark, and collection of a given dataset. The user can only selects from the collections where they are submitters (or admins). Superadmin users can view all collections.

Closes #28

A few screenshots showing the general idea

## Home page
![home](https://user-images.githubusercontent.com/568286/163628030-019fe9e9-22af-44fe-bec6-e86afd674b60.png)

## User's dashboard (aka my datasets)
![dashboard](https://user-images.githubusercontent.com/568286/163628003-3d305f94-bed5-45ee-b08d-5e8c981676ab.png)

## Dataset edit
![edit](https://user-images.githubusercontent.com/568286/163627998-3b9f3a4e-5d89-4830-ab1c-818e157384d7.png)

