### PR TITLE
Handles gracefully when no collections are pre-defined

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -13,11 +13,13 @@ class Collection < ApplicationRecord
   # Returns the default collection.
   # Used when we don't have anything else to determine a more specific collection for a user.
   def self.default
+    create_defaults
     Collection.where(code: "RD").first
   end
 
   # Returns the default collection for a given department number.
   def self.default_for_department(department_number)
+    create_defaults
     # Reference: https://docs.google.com/spreadsheets/d/1_Elxs3Ex-2wCbbKUzD4ii3k16zx36sYf/edit#gid=1484576831
     if department_number.nil?
       default

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -18,4 +18,14 @@ RSpec.describe Collection, type: :model do
     described_class.create_defaults
     expect(described_class.count).to be default_count
   end
+
+  it "creates defaults when not defined" do
+    described_class.delete_all
+    expect(described_class.count).to be 0
+    expect(Collection.default).to_not be nil
+
+    described_class.delete_all
+    expect(described_class.count).to be 0
+    expect(Collection.default_for_department("41000")).to_not be nil
+  end
 end


### PR DESCRIPTION
If no collections are defined it will define the default system collections on the spot.

Fixes #59 

