### PR TITLE
ORCID and user edit validation

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,17 +4,14 @@ class UsersController < ApplicationController
 
   # GET /users/1 or /users/1.json
   def show
-    @my_datasets = []
-    @awaiting_datasets = []
-    @withdrawn_datasets = []
-    @datasets = []
-    @my_dashboard = current_user.id == @user.id
-    if @my_dashboard
+    if current_user.id == @user.id
       @my_datasets = Dataset.my_datasets(current_user)
       @awaiting_datasets = Dataset.admin_awaiting_datasets(current_user)
       @withdrawn_datasets = Dataset.admin_withdrawn_datasets(current_user)
+      render "dashboard"
     else
       @datasets = Dataset.my_datasets(@user)
+      render "show"
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,6 +4,7 @@ class UsersController < ApplicationController
 
   # GET /users/1 or /users/1.json
   def show
+    @can_edit = can_edit?
     if current_user.id == @user.id
       @my_datasets = Dataset.my_datasets(current_user)
       @awaiting_datasets = Dataset.admin_awaiting_datasets(current_user)
@@ -16,18 +17,30 @@ class UsersController < ApplicationController
   end
 
   # GET /users/1/edit
-  def edit; end
+  def edit
+    if can_edit?
+      render "edit"
+    else
+      Rails.logger.warn("Unauthorized to edit user #{@user.id} (current user: #{current_user.id})")
+      redirect_to user_path(@user)
+    end
+  end
 
   # PATCH/PUT /users/1 or /users/1.json
   def update
-    respond_to do |format|
-      if @user.update(user_params)
-        format.html { redirect_to user_url(@user), notice: "User was successfully updated." }
-        format.json { render :show, status: :ok, location: @user }
-      else
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @user.errors, status: :unprocessable_entity }
+    if can_edit?
+      respond_to do |format|
+        if @user.update(user_params)
+          format.html { redirect_to user_url(@user), notice: "User was successfully updated." }
+          format.json { render :show, status: :ok, location: @user }
+        else
+          format.html { render :edit, status: :unprocessable_entity }
+          format.json { render json: @user.errors, status: :unprocessable_entity }
+        end
       end
+    else
+      Rails.logger.warn("Unauthorized to update user #{@user.id} (current user: #{current_user.id})")
+      redirect_to user_path(@user)
     end
   end
 
@@ -41,5 +54,10 @@ class UsersController < ApplicationController
     # Only allow a list of trusted parameters through.
     def user_params
       params.require(:user).permit(:orcid)
+    end
+
+    def can_edit?
+      return true if current_user.id == @user.id
+      current_user.superadmin?
     end
 end

--- a/app/models/ark.rb
+++ b/app/models/ark.rb
@@ -4,6 +4,7 @@ require "ezid-client"
 class Ark
   # Mints a new EZID identifier, returns the id (e.g. "ark:/99999/fk4tq65d6k")
   def self.mint
+    return "ark:/99999/fk4tq65d6k" if Rails.env.test?
     identifier = Ezid::Identifier.mint
     identifier.id
   end

--- a/app/models/orcid.rb
+++ b/app/models/orcid.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require "ezid-client"
+
+class Orcid
+  ORCID_REGEX = /^\d\d\d\d-\d\d\d\d-\d\d\d\d-\d\d\d\d$/.freeze
+
+  def self.valid?(orcid)
+    return false if orcid.blank?
+    ORCID_REGEX.match(orcid).to_s == orcid
+  end
+
+  def self.invalid?(orcid)
+    !valid?(orcid)
+  end
+
+  def self.url(orcid)
+    "https://orcid.org/#{orcid}"
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,12 @@
 class User < ApplicationRecord
   devise :rememberable, :omniauthable
 
+  validate do |user|
+    if user.orcid.present? && Orcid.invalid?(user.orcid)
+      user.errors.add :base, "Invalid format for ORCID"
+    end
+  end
+
   def self.from_cas(access_token)
     user = User.find_by(provider: access_token.provider, uid: access_token.uid)
     if user.nil?

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,7 @@
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
 
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
   </head>
 
   <body>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,3 +1,12 @@
+<style>
+  .hidden {
+    display: none;
+  }
+  .orcid-hint {
+    font-size: smaller;
+  }
+</style>
+
 <%= form_with(model: user) do |form| %>
   <% if user.errors.any? %>
     <div id="error_explanation">
@@ -12,11 +21,45 @@
   <% end %>
 
   <div class="field">
-    <%= form.label :orcid %><br>
-    <%= form.text_field :orcid %>
+    ORCID
+    <span id="orcid-bad" class="hidden text-muted orcid-hint"> - use format 0000-0000-0000-0000</span>
+    <span id="orcid-ok" class="hidden"><img alt="ORCID logo" src="https://info.orcid.org/wp-content/uploads/2019/11/orcid_16x16.png" width="16" height="16" /></span>
+    <br />
+    <%= form.text_field :orcid, placeholder: "0000-0000-0000-0000" %>
   </div>
 
   <div class="actions">
     <%= form.submit %>
   </div>
 <% end %>
+
+<script>
+
+$(function() {
+  var isOrcid = function(value) {
+    const regex = new RegExp(/^\d\d\d\d-\d\d\d\d-\d\d\d\d-\d\d\d\d$/);
+    return regex.test(value);
+  };
+
+  var validateOrcid = function() {
+    var value = $("#user_orcid").val();
+    if (value == "") {
+      $("#orcid-bad").addClass("hidden");
+      $("#orcid-ok").addClass("hidden");
+      return;
+    }
+
+    if (isOrcid(value)) {
+      $("#orcid-bad").addClass("hidden");
+      $("#orcid-ok").removeClass("hidden");
+    } else {
+      $("#orcid-bad").removeClass("hidden");
+      $("#orcid-ok").addClass("hidden");
+    }
+  }
+
+  $("#user_orcid").on("input", function() { validateOrcid(); });
+  validateOrcid();
+});
+
+</script>

--- a/app/views/users/dashboard.html.erb
+++ b/app/views/users/dashboard.html.erb
@@ -3,10 +3,14 @@
 <h2>Welcome, <%= @user.uid %></h2>
 
 <% if @user.orcid.present? %>
-    <p>Your ORCiD is <%= @user.orcid %></p>
+    <p>ORCiD: <%= link_to(@user.orcid, Orcid.url(@user.orcid), target: "_blank") %></p>
 <% else %>
     <p>You do not have an ORCiD on file. Click <%= link_to("here", edit_user_path(@user)) %> to add one to your profile.</p>
 <% end %>
+
+<div class="text-left">
+  <%= link_to 'Edit', edit_user_path(@user), :class => "btn btn-primary", :role => "button" %>
+</div>
 
 <h2>My Datasets</h2>
 <% @my_datasets.each do |ds| %>
@@ -30,6 +34,4 @@
 
 <!-- ETDS, Lib PDFs, and such could be added here as separate sections -->
 
-<div class="p-5 text-left">
-  <%= link_to 'Edit', edit_user_path(@user), :class => "btn btn-primary", :role => "button" %>
-</div>
+

--- a/app/views/users/dashboard.html.erb
+++ b/app/views/users/dashboard.html.erb
@@ -1,0 +1,35 @@
+<p id="notice"><%= notice %></p>
+
+<h2>Welcome, <%= @user.uid %></h2>
+
+<% if @user.orcid.present? %>
+    <p>Your ORCiD is <%= @user.orcid %></p>
+<% else %>
+    <p>You do not have an ORCiD on file. Click <%= link_to("here", edit_user_path(@user)) %> to add one to your profile.</p>
+<% end %>
+
+<h2>My Datasets</h2>
+<% @my_datasets.each do |ds| %>
+    <p><%= link_to(ds.title, dataset_path(ds)) %> (<%= ds.created_by_user.uid %>), <%= ds.state %></p>
+<% end %>
+<%= link_to 'Add New Dataset', new_dataset_path, class: "btn btn-primary" %>
+
+<% if @awaiting_datasets.count > 0 %>
+<h2>Datasets waiting to be approved</h2>
+<% @awaiting_datasets.each do |ds| %>
+    <p><%= link_to(ds.title, dataset_path(ds)) %> (<%= ds.created_by_user.uid %>), <%= ds.state %></p>
+<% end %>
+<% end %>
+
+<% if @withdrawn_datasets.count > 0 %>
+<h2>Datasets to have been withdrawn</h2>
+<% @withdrawn_datasets.each do |ds| %>
+    <p><%= link_to(ds.title, dataset_path(ds)) %> (<%= ds.created_by_user.uid %>), <%= ds.state %></p>
+<% end %>
+<% end %>
+
+<!-- ETDS, Lib PDFs, and such could be added here as separate sections -->
+
+<div class="p-5 text-left">
+  <%= link_to 'Edit', edit_user_path(@user), :class => "btn btn-primary", :role => "button" %>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,46 +1,16 @@
 <p id="notice"><%= notice %></p>
 
-<h2>Welcome, <%= @user.uid %></h2>
+<h2><%= @user.uid %></h2>
 
 <% if @user.orcid.present? %>
-    <p>Your ORCiD is <%= @user.orcid %></p>
-<% else %>
-    <p>You do not have an ORCiD on file. Click <%= link_to("here", edit_user_path(@user)) %> to add one to your profile.</p>
+  <p>ORCiD: <%= @user.orcid %></p>
 <% end %>
 
-<% if @my_dashboard %>
-
-  <h2>My Datasets</h2>
-  <% @my_datasets.each do |ds| %>
-      <p><%= link_to(ds.title, dataset_path(ds)) %> (<%= ds.created_by_user.uid %>), <%= ds.state %></p>
-  <% end %>
-  <%= link_to 'Add New Dataset', new_dataset_path, class: "btn btn-primary" %>
-
-  <% if @awaiting_datasets.count > 0 %>
-    <h2>Datasets waiting to be approved</h2>
-    <% @awaiting_datasets.each do |ds| %>
-      <p><%= link_to(ds.title, dataset_path(ds)) %> (<%= ds.created_by_user.uid %>), <%= ds.state %></p>
-    <% end %>
-  <% end %>
-
-  <% if @withdrawn_datasets.count > 0 %>
-    <h2>Datasets to have been withdrawn</h2>
-    <% @withdrawn_datasets.each do |ds| %>
-        <p><%= link_to(ds.title, dataset_path(ds)) %> (<%= ds.created_by_user.uid %>), <%= ds.state %></p>
-    <% end %>
-  <% end %>
-
-<% else %>
-
-  <!-- Viewing somebody else's user profile -->
-  <h2>Datasets</h2>
-  <% @datasets.each do |ds| %>
-      <p><%= link_to(ds.title, dataset_path(ds)) %> (<%= ds.created_by_user.uid %>), <%= ds.state %></p>
-  <% end %>
-
+<!-- Viewing somebody else's user profile -->
+<h2>Datasets</h2>
+<% @datasets.each do |ds| %>
+    <p><%= link_to(ds.title, dataset_path(ds)) %> (<%= ds.created_by_user.uid %>), <%= ds.state %></p>
 <% end %>
-
-<!-- ETDS, Lib PDFs, and such could be added here as separate sections -->
 
 <div class="p-5 text-left">
   <%= link_to 'Edit', edit_user_path(@user), :class => "btn btn-primary", :role => "button" %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,7 +3,13 @@
 <h2><%= @user.uid %></h2>
 
 <% if @user.orcid.present? %>
-  <p>ORCiD: <%= @user.orcid %></p>
+  <p>ORCiD: <%= link_to(@user.orcid, Orcid.url(@user.orcid)) %></p>
+<% end %>
+
+<% if @can_edit %>
+  <div class="text-left">
+    <%= link_to 'Edit', edit_user_path(@user), :class => "btn btn-primary", :role => "button" %>
+  </div>
 <% end %>
 
 <!-- Viewing somebody else's user profile -->
@@ -11,7 +17,3 @@
 <% @datasets.each do |ds| %>
     <p><%= link_to(ds.title, dataset_path(ds)) %> (<%= ds.created_by_user.uid %>), <%= ds.state %></p>
 <% end %>
-
-<div class="p-5 text-left">
-  <%= link_to 'Edit', edit_user_path(@user), :class => "btn btn-primary", :role => "button" %>
-</div>

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe UsersController do
+  let(:user) { FactoryBot.create(:user) }
+  let(:user_other) { FactoryBot.create(:user) }
+
+  it "renders the user dashboard when viewing my own user page" do
+    sign_in user
+    get :show, params: { id: user.id }
+    expect(response).to render_template("dashboard")
+  end
+
+  it "renders the show page when viewing others' users page" do
+    sign_in user
+    get :show, params: { id: user_other.id }
+    expect(response).to render_template("show")
+  end
+end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -7,6 +7,12 @@ FactoryBot.define do
     provider { :cas }
   end
 
+  factory :admin_user, class: "User" do
+    sequence(:uid) { "fake1" }
+    sequence(:email) { "fake1@princeton.edu" }
+    provider { :cas }
+  end
+
   factory :collection do
     title { "default test collection" }
   end

--- a/spec/models/orcid_spec.rb
+++ b/spec/models/orcid_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe Orcid, type: :model do
+  it "validates ORCIDs" do
+    expect(described_class.valid?("1234-5678-9012-1234")).to be true
+    expect(described_class.valid?("01234-5678-9012-1234")).to be false
+    expect(described_class.valid?("234-5678-9012-1234")).to be false
+    expect(described_class.valid?("ABCD-5678-9012-1234")).to be false
+    expect(described_class.valid?("")).to be false
+  end
+
+  it "produces the expected URL" do
+    expect(described_class.url("1234-5678-9012-1234")).to eq "https://orcid.org/1234-5678-9012-1234"
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -89,4 +89,18 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe "ORCID validation" do
+    let(:user) { described_class.new }
+    it "performs ORCID validation on save" do
+      user.orcid = "1234-1234-1234-1234"
+      expect(user.save).to be true
+
+      user.orcid = "1234-1234-1234-ABCD"
+      expect(user.save).to be false
+
+      user.orcid = ""
+      expect(user.save).to be true
+    end
+  end
 end

--- a/spec/system/add_orcid_spec.rb
+++ b/spec/system/add_orcid_spec.rb
@@ -3,9 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "Add an ORCiD" do
-  before do
-    sign_in user
-  end
+  before { sign_in user }
 
   describe "When the user does not have an ORCiD yet" do
     let(:user) { FactoryBot.create :user }
@@ -19,7 +17,7 @@ RSpec.describe "Add an ORCiD" do
       expect(page).to have_content "Editing User"
       fill_in "user_orcid", with: orcid
       click_on "Update User"
-      expect(page).to have_content "Your ORCiD is #{orcid}"
+      expect(page).to have_content "ORCiD: #{orcid}"
     end
   end
 
@@ -38,7 +36,7 @@ RSpec.describe "Add an ORCiD" do
     it "takes a user to their homepage after login", js: true do
       visit user_path(user)
       expect(page).to have_content "Welcome"
-      expect(page).to have_content "Your ORCiD is #{orcid}"
+      expect(page).to have_content "ORCiD: #{orcid}"
     end
   end
 end

--- a/spec/system/user_edit_spec.rb
+++ b/spec/system/user_edit_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe "Editing users" do
+  describe "Admin users can edit other users data" do
+    before { sign_in user_admin }
+
+    let(:user) { FactoryBot.create :user }
+    let(:user_admin) { FactoryBot.create :admin_user }
+    let(:orcid) { "1234-5678-1234-5678" }
+
+    it "allows an admin to edit other users ORCID", js: true do
+      visit user_path(user)
+      expect(page).to have_content user.uid
+      click_on "Edit"
+      expect(page).to have_content "Editing User"
+      fill_in "user_orcid", with: orcid
+      click_on "Update User"
+      expect(page).to have_content "ORCiD: #{orcid}"
+    end
+  end
+
+  describe "Non-admin users cannot edit others people data" do
+    before { sign_in user }
+
+    let(:user) { FactoryBot.create :user }
+    let(:user_other) { FactoryBot.create :user }
+    let(:orcid) { "1234-5678-1234-5678" }
+
+    it "allows an admin to edit other users ORCID", js: true do
+      visit user_path(user_other)
+      expect(page).to have_content user_other.uid
+      expect(page).to_not have_content "Edit"
+    end
+  end
+end


### PR DESCRIPTION
Validates that users can only edit their own ORCID, but allows super admins to edit other people's ORCIDs. The functionality applies in general to "editing a user profile" not only the ORCID field (hence it also closes issue 49).

Checks that the ORCID entered is in the expected format.

![empty](https://user-images.githubusercontent.com/568286/164294059-572b711b-7860-474d-b83a-3a1cfcd5fdea.png)

![incomplete](https://user-images.githubusercontent.com/568286/164294076-8c49347a-5685-4fa8-8d2b-db3b085ae924.png)

![valid](https://user-images.githubusercontent.com/568286/164294083-2808fa3d-8238-4307-b3da-770390b80f3b.png)


Closes #62 
Closes #49