### PR TITLE
Mint ARK only once and make it read-only

### DIFF
--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -59,7 +59,7 @@ class DatasetsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def form_params
-      params.require(:dataset).permit([:title, :work_id, :collection_id, :ark])
+      params.require(:dataset).permit([:title, :work_id, :collection_id])
     end
 
     def work_params

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -7,6 +7,12 @@ class Dataset < ApplicationRecord
   delegate :created_by_user, to: :work
   delegate :state, to: :work
 
+  before_update do |ds|
+    if ds.ark.blank?
+      ds.ark = Ark.mint
+    end
+  end
+
   def self.my_datasets(user)
     datasets = []
     Work.where(created_by_user_id: user).find_each do |work|
@@ -57,11 +63,7 @@ class Dataset < ApplicationRecord
     work = Work.create_skeleton(title, user_id, collection_id, "DATASET")
 
     # ...and then the dataset
-    ds = Dataset.new(
-      work_id: work.id,
-      profile: "DublinCore",
-      ark: Ark.mint
-    )
+    ds = Dataset.new(work_id: work.id, profile: "DublinCore")
     ds.save!
     ds
   end

--- a/app/views/datasets/_form.html.erb
+++ b/app/views/datasets/_form.html.erb
@@ -22,11 +22,11 @@
     <%= form.collection_select :collection_id, current_user.submitter_collections, :id, :title, {:include_blank => true}, {:class => 'form-control'} %>
   </div>
 
-  <div class="field">
-    <%= form.label :ark %><br>
-    <%= form.text_field :ark %>
-  </div>
-
+  <% if form.object.ark.present? %>
+    <div class="field">
+      ARK: <%= form.object.ark %>
+    </div>
+  <% end %>
   <br />
 
   <div class="actions">

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -13,7 +13,17 @@ RSpec.describe Dataset, type: :model do
     ds = described_class.create_skeleton("test title", user.id, collection.id)
     expect(ds.created_by_user.id).to eq user.id
     expect(ds.work.collection.id).to eq collection.id
+    expect(ds.ark).to be_blank
+  end
+
+  it "mints an ARK on save (and only when needed)" do
+    ds = described_class.create_skeleton("test title", user.id, collection.id)
+    expect(ds.ark).to be_blank
+    ds.save
     expect(ds.ark).to be_present
+    original_ark = ds.ark
+    ds.save
+    expect(ds.ark).to eq original_ark
   end
 
   it "returns datasets waiting for approval depending on the user" do

--- a/spec/system/dataset_spec.rb
+++ b/spec/system/dataset_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe "Creating and updating datasets" do
+  # Notice that we manually create a user for this test (rather the one from FactoryBot)
+  # because we need to make sure the user also has a list of collections where they can
+  # submit datasets (UserCollection table) and the FactoryBot stub does not account for
+  # that where as creating a user via `User.from_cas()` does.
+  let(:user) do
+    hash = OmniAuth::AuthHash.new(provider: "cas", uid: "who", extra: { mail: "who@princeton.edu", departmentnumber: "31000" })
+    User.from_cas(hash)
+  end
+
+  it "Creates ARK when a new dataset is saved", js: true do
+    sign_in user
+    visit new_dataset_path
+    expect(page).to_not have_content "ARK"
+    click_on "Update Dataset"
+    expect(page).to have_content "ARK"
+  end
+end


### PR DESCRIPTION
The ARK is now only minted once and it's read only.

Closes #65 
Closes #68