### PR TITLE
Display super administrators in Collections

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -22,6 +22,10 @@ class Collection < ApplicationRecord
     UserCollection.where(collection_id: id, role: "ADMIN").map(&:user)
   end
 
+  def super_administrators
+    Rails.configuration.superadmins.map { |uid| User.new_for_uid(uid) }
+  end
+
   def submitters
     UserCollection.where(collection_id: id, role: "SUBMITTER").map(&:user)
   end

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -47,6 +47,15 @@
     data-can-delete="<%= @can_edit && user.uid != current_user.uid %>"
     data-you="<%= user.uid == current_user.uid %>"></span>
 <% end %>
+
+<% @collection.super_administrators.each do |user| %>
+  <span class="hidden admin-data"
+    data-uid="<%= user.uid %>"
+    data-collection-id="<%= @collection.id %>"
+    data-can-delete="false"
+    data-super-admin="true"
+    data-you="<%= user.uid == current_user.uid %>"></span>
+<% end %>
 </ul>
 
 <% if @can_edit == true %>
@@ -87,12 +96,15 @@ $(function() {
   // Adds the information for a given user to the lists of administrators/submitters
   // for the collection.
   // `elList` is the reference to the <ul> HTML element that hosts the list.
-  var addUserHtml = function(elList, uid, collectionId, role, canDelete, isYou) {
+  var addUserHtml = function(elList, uid, collectionId, role, canDelete, isYou, isSuperAdmin) {
     var base_user_url = "<%= user_path('user-placeholder') %>";
     var show_user_url = base_user_url.replace("user-placeholder", uid);
     var html = `<li class="li-user-${uid}"> <a href="${show_user_url}">${uid}</a>`;
     if (isYou == true) {
       html += ` (you)`;
+    }
+    if (isSuperAdmin == true) {
+      html += ` <i title="This is a system administrator, access cannot be changed." class="bi bi-person-workspace"></i>`;
     }
     if (canDelete == true) {
       html += `
@@ -124,7 +136,8 @@ $(function() {
         $(elError).text("");
         var canDelete = true;
         var isYou = false;
-        addUserHtml(elList, uid, collectionId, role, canDelete, isYou);
+        var isSuperAdmin = false;
+        addUserHtml(elList, uid, collectionId, role, canDelete, isYou, isSuperAdmin);
       },
       error: function(x) {
         $(elError).text(x.responseJSON.message);
@@ -146,25 +159,33 @@ $(function() {
     return false;
   });
 
-  // Displays the initial list of submitters.
-  $(".submitter-data").each(function(ix, el) {
-    var elList = $("#submitter-list");
-    var uid = $(el).data("uid");
-    var collectionId = $(el).data("collectionId");
-    var canDelete = $(el).data("canDelete");
-    var isYou = $(el).data("you");
-    addUserHtml(elList, uid, collectionId, "submit", canDelete, isYou);
-  });
+  if ($("#data-loaded").text() != "true") {
+    // Displays the initial list of submitters.
+    $(".submitter-data").each(function(ix, el) {
+      var elList = $("#submitter-list");
+      var uid = $(el).data("uid");
+      var collectionId = $(el).data("collectionId");
+      var canDelete = $(el).data("canDelete");
+      var isYou = $(el).data("you");
+      var isSuperAdmin = false;
+      addUserHtml(elList, uid, collectionId, "submit", canDelete, isYou, isSuperAdmin);
+    });
 
-  // Displays the initial list of administrators.
-  $(".admin-data").each(function(ix, el) {
-    var elList = $("#admin-list");
-    var uid = $(el).data("uid");
-    var collectionId = $(el).data("collectionId");
-    var canDelete = $(el).data("canDelete");
-    var isYou = $(el).data("you");
-    addUserHtml(elList, uid, collectionId, "admin", canDelete, isYou);
-  });
+    // Displays the initial list of administrators.
+    $(".admin-data").each(function(ix, el) {
+      var elList = $("#admin-list");
+      var uid = $(el).data("uid");
+      var collectionId = $(el).data("collectionId");
+      var canDelete = $(el).data("canDelete");
+      var isYou = $(el).data("you") == "true";
+      var isSuperAdmin = $(el).data("super-admin");
+      addUserHtml(elList, uid, collectionId, "admin", canDelete, isYou, isSuperAdmin);
+    });
+
+    // Track that we have displayed this information. This prevents re-display when
+    // user click the Back/Forward button on their browser.
+    $('<span id="data-loaded" class="hidden">true</span>').appendTo("body");
+  }
 
   // Wire up the delete button for all users listed in the collection.
   //

--- a/spec/system/collection_edit_spec.rb
+++ b/spec/system/collection_edit_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Editing collections" do
   before { Collection.create_defaults }
 
   let(:user) { FactoryBot.create :user }
-  let(:user_admin) { FactoryBot.create :super_admin_user }
+  let(:super_admin_user) { User.new_for_uid("fake1") }
   let(:collection) { Collection.first }
   let(:collection_other) { Collection.second }
 
@@ -18,7 +18,7 @@ RSpec.describe "Editing collections" do
   end
 
   it "allows super admin to edit collections", js: true do
-    sign_in user_admin
+    sign_in super_admin_user
     visit collection_path(collection)
     click_on "Edit"
     expect(page).to have_content "Editing Collection"
@@ -59,5 +59,11 @@ RSpec.describe "Editing collections" do
     visit collection_path(collection_other)
     expect(page).to have_content collection_other.title
     expect(page).to_not have_content "Edit"
+  end
+
+  it "display super admins", js: true do
+    sign_in user
+    visit collection_path(collection)
+    expect(page).to have_content super_admin_user.uid
   end
 end


### PR DESCRIPTION
Always display the super administrators for a collection (and make them not-editable)

![Screen Shot 2022-04-29 at 1 17 42 PM](https://user-images.githubusercontent.com/568286/165992391-d174c531-f49e-4b91-a5fa-7707ca659b20.png)

Fixes #89 
