### PR TITLE
Add button to delete creators

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -16,3 +16,7 @@
 .hidden {
   display: none;
 }
+
+.delete_icon {
+  color: #bb6c6c;
+}

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -79,6 +79,9 @@ class WorksController < ApplicationController
     def datacite_resource_from_form
       resource = Datacite::Resource.new
 
+      resource.publisher = params["publisher"]
+      resource.publication_year = params["publication_year"]
+
       # Process the titles
       resource.titles << Datacite::Title.new(title: params["title_main"])
       for i in 1..params["existing_title_count"].to_i do

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -94,13 +94,8 @@ class WorksController < ApplicationController
       end
 
       # Process the creators
-      for i in 1..params["existing_creator_count"].to_i do
+      for i in 1..params["creator_count"].to_i do
         creator = new_creator(params["given_name_#{i}"], params["family_name_#{i}"], params["orcid_#{i}"])
-        resource.creators << creator unless creator.nil?
-      end
-
-      for i in 1..params["new_creator_count"].to_i do
-        creator = new_creator(params["new_given_name_#{i}"], params["new_family_name_#{i}"], params["new_orcid_#{i}"])
         resource.creators << creator unless creator.nil?
       end
 

--- a/app/models/datacite.rb
+++ b/app/models/datacite.rb
@@ -13,7 +13,7 @@ module Datacite
       @creators = []
       @resource_type = resource_type || "Dataset"
       @publisher = "Princeton University"
-      @publication_year = Date.today.year
+      @publication_year = Time.zone.today.year
     end
 
     def main_title

--- a/app/models/datacite.rb
+++ b/app/models/datacite.rb
@@ -12,6 +12,8 @@ module Datacite
       @titles << Datacite::Title.new(title: title) unless title.nil?
       @creators = []
       @resource_type = resource_type || "Dataset"
+      @publisher = "Princeton University"
+      @publication_year = Date.today.year
     end
 
     def main_title
@@ -71,6 +73,12 @@ module Datacite
               end
             end
           end
+          xml.publisher do
+            xml.text @publisher
+          end
+          xml.publicationYear do
+            xml.text @publication_year
+          end
         end
       end
       builder.to_xml
@@ -90,6 +98,8 @@ module Datacite
         orcid = creator.dig("name_identifier", "scheme") == "ORCID" ? creator.dig("name_identifier", "value") : nil
         resource.creators << Datacite::Creator.new_person(creator["given_name"], creator["family_name"], orcid)
       end
+      resource.publisher = hash["publisher"]
+      resource.publication_year = hash["publication_year"]
       resource
     end
   end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -40,10 +40,12 @@ class Work < ApplicationRecord
       work.errors.add(:base, "Invalid ARK provided for the Work: #{work.ark}") unless Ark.valid?(work.ark)
     end
 
-    work.errors.add(:base, "Must provide Title") if work.title.blank?
-    work.errors.add(:base, "Must provide at least one Creator") if work.datacite_resource.creators.count == 0
-    work.errors.add(:base, "Must indicate the Publisher") if work.datacite_resource.publisher.blank?
-    work.errors.add(:base, "Must indicate the Publication Year") if work.datacite_resource.publication_year.blank?
+    if work.data_cite.present?
+      work.errors.add(:base, "Must provide a title") if work.title.blank?
+      work.errors.add(:base, "Must provide at least one Creator") if work.datacite_resource.creators.count == 0
+      work.errors.add(:base, "Must indicate the Publisher") if work.datacite_resource.publisher.blank?
+      work.errors.add(:base, "Must indicate the Publication Year") if work.datacite_resource.publication_year.blank?
+    end
   end
 
   def self.create_skeleton(title, user_id, collection_id, work_type, profile)
@@ -60,7 +62,8 @@ class Work < ApplicationRecord
   end
 
   # Convenience method to create Datasets with the DataCite profile
-  def self.create_dataset(title, user_id, collection_id)
+  def self.create_dataset(title, user_id, collection_id, datacite_resource = nil)
+    datacite_resource = Datacite::Resource.new(title: title) if datacite_resource.nil?
     work = Work.new(
       title: title,
       created_by_user_id: user_id,
@@ -68,9 +71,10 @@ class Work < ApplicationRecord
       work_type: "DATASET",
       state: "AWAITING-APPROVAL",
       profile: "DATACITE",
-      data_cite: Datacite::Resource.new(title: title).to_json
+      data_cite: datacite_resource.to_json
     )
-    work.save!
+    # We skip the validation since we don't have all the required fields yet
+    work.save!(validate: false)
     work
   end
 

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -40,9 +40,10 @@ class Work < ApplicationRecord
       work.errors.add(:base, "Invalid ARK provided for the Work: #{work.ark}") unless Ark.valid?(work.ark)
     end
 
-    if work.title.blank?
-      work.errors.add(:base, "Must provide a title")
-    end
+    work.errors.add(:base, "Must provide Title") if work.title.blank?
+    work.errors.add(:base, "Must provide at least one Creator") if work.datacite_resource.creators.count == 0
+    work.errors.add(:base, "Must indicate the Publisher") if work.datacite_resource.publisher.blank?
+    work.errors.add(:base, "Must indicate the Publication Year") if work.datacite_resource.publication_year.blank?
   end
 
   def self.create_skeleton(title, user_id, collection_id, work_type, profile)

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -1,7 +1,3 @@
-<style>
-  .delete_icon {
-    color: #bb6c6c;
-  }
 </style>
 <h1><%= @collection.title.strip %></h1>
 

--- a/app/views/works/_creators_form.html.erb
+++ b/app/views/works/_creators_form.html.erb
@@ -6,9 +6,10 @@
     <th>ORCID</th>
     <th>Given name</th>
     <th>Family name</th>
+    <th>&nbsp;</th>
   </tr>
   <% @work.datacite_resource.creators.each_with_index do |creator, i| %>
-    <tr>
+    <tr id="existing_creator_<%= i %>">
       <td>
         <input type="text" id="orcid_<%= i %>" name="orcid_<%= i + 1 %>" value="<%= creator.orcid %>" />
       </td>
@@ -17,6 +18,13 @@
       </td>
       <td>
         <input type="text" id="family_name_<%= i %>" name="family_name_<%= i + 1 %>" value="<%= creator.family_name %>" />
+      </td>
+      <td>
+        <span>
+          <a class="delete-existing-creator" data-creator-num="<%= i %>" href="#" title="Remove this creator">
+            <i class="bi bi-trash delete_icon" data-creator-num="<%= i %>"></i>
+          </a>
+        </span>
       </td>
     </tr>
   <% end %>

--- a/app/views/works/_creators_form.html.erb
+++ b/app/views/works/_creators_form.html.erb
@@ -1,25 +1,28 @@
 <h2>Creator(s)</h2>
 
 <!-- Render the existing creators in the record -->
-<% @work.datacite_resource.creators.each_with_index do |creator, i| %>
-  <div class="field">
-    ORCID:<br>
-    <input type="text" id="orcid_<%= i %>" name="orcid_<%= i + 1 %>" value="<%= creator.orcid %>" />
-  </div>
-
-  <div class="field">
-    Given name:<br>
-    <input type="text" id="given_name_<%= i %>" name="given_name_<%= i + 1 %>" value="<%= creator.given_name %>" />
-  </div>
-
-  <div class="field">
-    Family name:<br>
-    <input type="text" id="family_name_<%= i %>" name="family_name_<%= i + 1 %>" value="<%= creator.family_name %>" />
-  </div>
-<% end %>
+<table id="new-creators-anchor">
+  <tr>
+    <th>ORCID</th>
+    <th>Given name</th>
+    <th>Family name</th>
+  </tr>
+  <% @work.datacite_resource.creators.each_with_index do |creator, i| %>
+    <tr>
+      <td>
+        <input type="text" id="orcid_<%= i %>" name="orcid_<%= i + 1 %>" value="<%= creator.orcid %>" />
+      </td>
+      <td>
+        <input type="text" id="given_name_<%= i %>" name="given_name_<%= i + 1 %>" value="<%= creator.given_name %>" />
+      </td>
+      <td>
+        <input type="text" id="family_name_<%= i %>" name="family_name_<%= i + 1 %>" value="<%= creator.family_name %>" />
+      </td>
+    </tr>
+  <% end %>
+</table>
 
 <!-- Let the user add new creators -->
 <div>
   <%= link_to "Add Creator", "#", id: "btn-add-creator", class: "btn btn-secondary" %>
 </div>
-<div id="new-creators-anchor">...</div>

--- a/app/views/works/_creators_form.html.erb
+++ b/app/views/works/_creators_form.html.erb
@@ -1,7 +1,12 @@
 <h2>Creator(s)</h2>
 
-<!-- Render the existing creators in the record -->
-<table id="new-creators-anchor">
+<!--
+  Render the list of creators a hidden SPANs that are then added to
+  the HTML TABLE via JavaScript. This is so that we have a single way
+  of rendering creators already on the record *and* creators added
+  on the fly.
+-->
+<table id="creators-table">
   <tr>
     <th>ORCID</th>
     <th>Given name</th>
@@ -9,24 +14,11 @@
     <th>&nbsp;</th>
   </tr>
   <% @work.datacite_resource.creators.each_with_index do |creator, i| %>
-    <tr id="existing_creator_<%= i %>">
-      <td>
-        <input type="text" id="orcid_<%= i %>" name="orcid_<%= i + 1 %>" value="<%= creator.orcid %>" />
-      </td>
-      <td>
-        <input type="text" id="given_name_<%= i %>" name="given_name_<%= i + 1 %>" value="<%= creator.given_name %>" />
-      </td>
-      <td>
-        <input type="text" id="family_name_<%= i %>" name="family_name_<%= i + 1 %>" value="<%= creator.family_name %>" />
-      </td>
-      <td>
-        <span>
-          <a class="delete-existing-creator" data-creator-num="<%= i %>" href="#" title="Remove this creator">
-            <i class="bi bi-trash delete_icon" data-creator-num="<%= i %>"></i>
-          </a>
-        </span>
-      </td>
-    </tr>
+    <span class="hidden creator-data"
+      data-num="<%= i + 1 %>"
+      data-orcid="<%= creator.orcid %>"
+      data-given-name="<%= creator.given_name %>"
+      data-family-name="<%= creator.family_name %>"></span>
   <% end %>
 </table>
 

--- a/app/views/works/_form.html.erb
+++ b/app/views/works/_form.html.erb
@@ -68,8 +68,7 @@
     <div>
       <input type="text" id="existing_title_count" name="existing_title_count" value="<%= @work.datacite_resource.titles.count %>" class="hidden" />
       <input type="text" id="new_title_count" name="new_title_count" value="0" class="hidden" />
-      <input type="text" id="existing_creator_count" name="existing_creator_count" value="<%= @work.datacite_resource.creators.count %>" class="hidden" />
-      <input type="text" id="new_creator_count" name="new_creator_count" value="0" class="hidden" />
+      <input type="text" id="creator_count" name="creator_count" value="<%= @work.datacite_resource.creators.count %>" class="hidden" />
     </div>
   <% end %>
 </div>
@@ -83,31 +82,30 @@
       return counter
     }
 
-    var addCreatorPlaceholder = function(_el) {
-      var newCreatorCount = incrementCounter("#new_creator_count");
-      var rowId = `new_creator_${newCreatorCount}`;
-      var orcidId = `new_orcid_${newCreatorCount}`;
-      var familyNameId = `new_family_name_${newCreatorCount}`;
-      var givenNameId = `new_given_name_${newCreatorCount}`;
-      var html = `<tr id="${rowId}">
+    var addCreatorHtml = function(num, orcid, givenName, familyName) {
+      var rowId = `creator_row_${num}`;
+      var orcidId = `orcid_${num}`;
+      var givenNameId = `given_name_${num}`;
+      var familyNameId = `family_name_${num}`;
+      var rowHtml = `<tr id="${rowId}">
         <td>
-          <input type="text" id="${orcidId}" name="${orcidId}" value="" />
+          <input type="text" id="${orcidId}" name="${orcidId}" value="${orcid}" />
         </td>
         <td>
-          <input type="text" id="${givenNameId}" name="${givenNameId}" value="" />
+          <input type="text" id="${givenNameId}" name="${givenNameId}" value="${givenName}" />
         </td>
         <td>
-          <input type="text" id="${familyNameId}" name="${familyNameId}" value="" />
+          <input type="text" id="${familyNameId}" name="${familyNameId}" value="${familyName}" />
         </td>
         <td>
           <span>
-            <a class="delete-new-creator" data-creator-num="${newCreatorCount}" href="#" title="Remove this creator">
-              <i class="bi bi-trash delete_icon" data-creator-num="${newCreatorCount}"></i>
+            <a class="delete-creator" data-creator-num="${num}" href="#" title="Remove this creator">
+              <i class="bi bi-trash delete_icon" data-creator-num="${num}"></i>
             </a>
           </span>
         </td>
       </tr>`;
-      $("#new-creators-anchor").append(html);
+      $("#creators-table").append(rowHtml);
       $("#" + orcidId).focus();
     }
 
@@ -130,7 +128,8 @@
     }
 
     $("#btn-add-creator").on("click", function(el) {
-      addCreatorPlaceholder(el);
+      var num = incrementCounter("#creator_count");
+      addCreatorHtml(num, "", "", "");
       return false;
     });
 
@@ -140,24 +139,19 @@
     });
 
     var deleteCreator = function(num, existing) {
-      var rowToDelete = "";
-      var orcidId, givenNameId, familyNameId;
-      if (existing) {
-        rowToDelete = `#existing_creator_${num}`;
-        orcidId = `#orcid_${num}`;
-        givenNameId = `#given_name_${num}`;
-        familyNameId = `#family_name_${num}`;
-      } else {
-        rowToDelete = `#new_creator_${num}`;
-        orcidId = `#new_orcid_${num}`;
-        givenNameId = `#new_given_name_${num}`;
-        familyNameId = `#new_family_name_${num}`;
-      }
-
+      var rowToDelete = `#creator_row_${num}`;
+      var orcidId = `#orcid_${num}`;
+      var givenNameId = `#given_name_${num}`;
+      var familyNameId = `#family_name_${num}`;
       var name = $(orcidId).val() + " " + $(givenNameId).val() + " " + $(familyNameId).val();
-      var message = `Remove creator ${name}`;
-      if (confirm(message)) {
+      var emptyName = name.trim().length == 0;
+      if (emptyName) {
+        // delete it without asking
         $(rowToDelete).remove();
+      } else {
+        if (confirm(`Remove creator ${name}`)) {
+          $(rowToDelete).remove();
+        }
       }
     }
 
@@ -168,16 +162,19 @@
     // we can detect the click even on HTML elements _added on the fly_ which
     // is the case when a user adds a new creator.
     // Reference: https://stackoverflow.com/a/17086311/446681
-    $(document).on("click", ".delete-existing-creator", function(el) {
+    $(document).on("click", ".delete-creator", function(el) {
       var num = $(el.target).data("creator-num");
-      deleteCreator(num, true);
+      deleteCreator(num);
       return false;
     });
 
-    $(document).on("click", ".delete-new-creator", function(el) {
-      var num = $(el.target).data("creator-num");
-      deleteCreator(num, false);
-      return false;
+    // Display the initial list of creators
+    $(".creator-data").each(function(ix, el) {
+      var num = $(el).data("num");
+      var orcid = $(el).data("orcid");
+      var givenName = $(el).data("given-name");
+      var familyName = $(el).data("family-name");
+      addCreatorHtml(num, orcid, givenName, familyName);
     });
 
   });

--- a/app/views/works/_form.html.erb
+++ b/app/views/works/_form.html.erb
@@ -83,30 +83,27 @@
       return counter
     }
 
-    var addCreatorPlaceholder = function(el) {
+    var addCreatorPlaceholder = function(_el) {
       var newCreatorCount = incrementCounter("#new_creator_count");
       var orcidId = `new_orcid_${newCreatorCount}`;
       var familyNameId = `new_family_name_${newCreatorCount}`;
       var givenNameId = `new_given_name_${newCreatorCount}`;
-      var html = `
-      <div class="field">
-        ORCID:<br>
-        <input type="text" id="${orcidId}" name="${orcidId}" value="" />
-      </div>
-
-      <div class="field">
-        Given name:<br>
-        <input type="text" id="${givenNameId}" name="${givenNameId}" value="" />
-      </div>
-
-      <div class="field">
-        Family name:<br>
-        <input type="text" id="${familyNameId}" name="${familyNameId}" value="" />
-      </div>`;
+      var html = `<tr>
+        <td>
+          <input type="text" id="${orcidId}" name="${orcidId}" value="" />
+        </td>
+        <td>
+          <input type="text" id="${givenNameId}" name="${givenNameId}" value="" />
+        </td>
+        <td>
+          <input type="text" id="${familyNameId}" name="${familyNameId}" value="" />
+        </td>
+      </tr>`;
       $("#new-creators-anchor").append(html);
+      $("#" + orcidId).focus();
     }
 
-    var addTitlePlaceholder = function(el) {
+    var addTitlePlaceholder = function(_el) {
       var newTitleCount = incrementCounter("#new_title_count");
       var titleId = `new_title_${newTitleCount}`;
       var typeId = `new_title_type_${newTitleCount}`;

--- a/app/views/works/_form.html.erb
+++ b/app/views/works/_form.html.erb
@@ -9,9 +9,7 @@
   <div class="nav flex-column nav-pills me-3" id="v-pills-tab" role="tablist" aria-orientation="vertical">
     <button class="nav-link active" id="v-pills-title-tab" data-bs-toggle="pill" data-bs-target="#v-pills-title" type="button" role="tab" aria-controls="v-pills-title" aria-selected="true">Title</button>
     <button class="nav-link" id="v-pills-creator-tab" data-bs-toggle="pill" data-bs-target="#v-pills-creator" type="button" role="tab" aria-controls="v-pills-creator" aria-selected="false">Creator(s)</button>
-    <button class="nav-link" id="v-pills-identifiers-tab" data-bs-toggle="pill" data-bs-target="#v-pills-identifiers" type="button" role="tab" aria-controls="v-pills-identifiers" aria-selected="false">Identifiers</button>
-    <button class="nav-link" id="v-pills-publisher-tab" data-bs-toggle="pill" data-bs-target="#v-pills-publisher" type="button" role="tab" aria-controls="v-pills-publisher" aria-selected="false">Publisher</button>
-    <button class="nav-link" id="v-pills-type-tab" data-bs-toggle="pill" data-bs-target="#v-pills-type" type="button" role="tab" aria-controls="v-pills-type" aria-selected="false">Resource Type</button>
+    <button class="nav-link" id="v-pills-additional-tab" data-bs-toggle="pill" data-bs-target="#v-pills-additional" type="button" role="tab" aria-controls="v-pills-additional" aria-selected="false">Additional Metadata</button>
   </div>
 
   <%= form_with(model: @work) do |form| %>
@@ -42,19 +40,13 @@
         <%= render 'creators_form' %>
       </div>
 
-      <div class="tab-pane fade" id="v-pills-identifiers" role="tabpanel" aria-labelledby="v-pills-identifiers-tab">
-        identifiers go here
-      </div>
-
-      <div class="tab-pane fade" id="v-pills-publisher" role="tabpanel" aria-labelledby="v-pills-publisher-tab">
-        publisher goes here
-      </div>
-
-      <div class="tab-pane fade" id="v-pills-type" role="tabpanel" aria-labelledby="v-pills-type-tab">
-        resource type goes here
+      <div class="tab-pane fade" id="v-pills-additional" role="tabpanel" aria-labelledby="v-pills-additional-tab">
+        <h2>Additional Metadata</h2>
+        <p>yada yada yada</p>
       </div>
     </div>
 
+    <hr />
     <div class="actions">
       <%= form.submit class: "btn btn-primary" %>
       <%= link_to 'Cancel', @work, class: "btn btn-secondary" %>
@@ -89,7 +81,7 @@
       var familyNameId = `family_name_${num}`;
       var rowHtml = `<tr id="${rowId}">
         <td>
-          <input type="text" id="${orcidId}" name="${orcidId}" value="${orcid}" />
+          <input type="text" id="${orcidId}" name="${orcidId}" value="${orcid}" placeholder="0000-0000-0000-0000" />
         </td>
         <td>
           <input type="text" id="${givenNameId}" name="${givenNameId}" value="${givenName}" />
@@ -168,7 +160,10 @@
       return false;
     });
 
-    // Display the initial list of creators
+    // Display the initial list of creators.
+    //
+    // Eventually we will need to render them in a predefined
+    // order but we don't have order data availble yet.
     $(".creator-data").each(function(ix, el) {
       var num = $(el).data("num");
       var orcid = $(el).data("orcid");

--- a/app/views/works/_form.html.erb
+++ b/app/views/works/_form.html.erb
@@ -85,10 +85,11 @@
 
     var addCreatorPlaceholder = function(_el) {
       var newCreatorCount = incrementCounter("#new_creator_count");
+      var rowId = `new_creator_${newCreatorCount}`;
       var orcidId = `new_orcid_${newCreatorCount}`;
       var familyNameId = `new_family_name_${newCreatorCount}`;
       var givenNameId = `new_given_name_${newCreatorCount}`;
-      var html = `<tr>
+      var html = `<tr id="${rowId}">
         <td>
           <input type="text" id="${orcidId}" name="${orcidId}" value="" />
         </td>
@@ -97,6 +98,13 @@
         </td>
         <td>
           <input type="text" id="${familyNameId}" name="${familyNameId}" value="" />
+        </td>
+        <td>
+          <span>
+            <a class="delete-new-creator" data-creator-num="${newCreatorCount}" href="#" title="Remove this creator">
+              <i class="bi bi-trash delete_icon" data-creator-num="${newCreatorCount}"></i>
+            </a>
+          </span>
         </td>
       </tr>`;
       $("#new-creators-anchor").append(html);
@@ -130,5 +138,47 @@
       addTitlePlaceholder(el);
       return false;
     });
+
+    var deleteCreator = function(num, existing) {
+      var rowToDelete = "";
+      var orcidId, givenNameId, familyNameId;
+      if (existing) {
+        rowToDelete = `#existing_creator_${num}`;
+        orcidId = `#orcid_${num}`;
+        givenNameId = `#given_name_${num}`;
+        familyNameId = `#family_name_${num}`;
+      } else {
+        rowToDelete = `#new_creator_${num}`;
+        orcidId = `#new_orcid_${num}`;
+        givenNameId = `#new_given_name_${num}`;
+        familyNameId = `#new_family_name_${num}`;
+      }
+
+      var name = $(orcidId).val() + " " + $(givenNameId).val() + " " + $(familyNameId).val();
+      var message = `Remove creator ${name}`;
+      if (confirm(message)) {
+        $(rowToDelete).remove();
+      }
+    }
+
+    // Delete button for creators.
+    //
+    // Notice the use of $(document).on("click", selector, ...) instead of the
+    // typical $(selector).on("click", ...). This syntax is required so that
+    // we can detect the click even on HTML elements _added on the fly_ which
+    // is the case when a user adds a new creator.
+    // Reference: https://stackoverflow.com/a/17086311/446681
+    $(document).on("click", ".delete-existing-creator", function(el) {
+      var num = $(el.target).data("creator-num");
+      deleteCreator(num, true);
+      return false;
+    });
+
+    $(document).on("click", ".delete-new-creator", function(el) {
+      var num = $(el.target).data("creator-num");
+      deleteCreator(num, false);
+      return false;
+    });
+
   });
 </script>

--- a/app/views/works/_titles_form.html.erb
+++ b/app/views/works/_titles_form.html.erb
@@ -1,26 +1,24 @@
 <h2>Title(s)</h2>
 
-<!-- Render the existing titles in the record -->
-<% @work.datacite_resource.titles.each_with_index do |title, i| %>
-  <% if title.main? %>
-    <div class="field">
-      <!-- notice that we don't display a dropdown to select a title type for the main title -->
-      Title:<br>
-      <input type="text" id="title_main" name="title_main" value="<%= title.title %>" />
-    </div>
-  <% else %>
-    <div class="field">
-      <!-- todo: this should go into a helper -->
-      <select id="title_type_<%= i + 1 %>" name="title_type_<%= i + 1 %>">
-        <option value="AlternativeTitle" <%= title.title_type == "AlternativeTitle" ? "selected" : "" %>>Alternative</option>
-        <option value="Subtitle" <%= title.title_type == "Subtitle" ? "selected" : "" %> >Subtitle</option>
-        <option value="TranslatedTitle" <%= title.title_type == "TranslatedTitle" ? "selected" : "" %>>Translated</option>
-        <option value="Other" <%= title.title_type == "Other" ? "selected" : "" %>>Other</option>
-      </select>
-      <br>
-      <input type="text" id="title_<%= i + 1 %>" name="title_<%= i + 1 %>" value="<%= title.title %>" />
-    </div>
-  <% end %>
+<!-- Render the main title (notice that we don't display a dropdown for this title) -->
+<div class="field">
+  Title:<br>
+  <input type="text" id="title_main" name="title_main" value="<%= @work.datacite_resource.main_title %>" />
+</div>
+
+<!-- Render other titles in the record -->
+<% @work.datacite_resource.other_titles.each_with_index do |title, i| %>
+  <div class="field">
+    <!-- todo: this should go into a helper -->
+    <select id="title_type_<%= i + 1 %>" name="title_type_<%= i + 1 %>">
+      <option value="AlternativeTitle" <%= title.title_type == "AlternativeTitle" ? "selected" : "" %>>Alternative</option>
+      <option value="Subtitle" <%= title.title_type == "Subtitle" ? "selected" : "" %> >Subtitle</option>
+      <option value="TranslatedTitle" <%= title.title_type == "TranslatedTitle" ? "selected" : "" %>>Translated</option>
+      <option value="Other" <%= title.title_type == "Other" ? "selected" : "" %>>Other</option>
+    </select>
+    <br>
+    <input type="text" id="title_<%= i + 1 %>" name="title_<%= i + 1 %>" value="<%= title.title %>" />
+  </div>
 <% end %>
 
 <div id="new-titles-anchor"></div>

--- a/app/views/works/_titles_form.html.erb
+++ b/app/views/works/_titles_form.html.erb
@@ -23,13 +23,24 @@
   <% end %>
 <% end %>
 
+<div id="new-titles-anchor"></div>
+
 <!-- Let the user add new titles -->
 <div>
-<%= link_to "Add Title", "#", id: "btn-add-title", class: "btn btn-secondary" %>
+  <%= link_to "Add Title", "#", id: "btn-add-title", class: "btn btn-secondary" %>
 </div>
-<div id="new-titles-anchor">...</div>
 
-<!-- Collection field (unrelated to title) -->
+<div class="field">
+  Publisher:<br>
+  <input type="text" id="publisher" name="publisher" value="<%= @work.datacite_resource.publisher %>" />
+</div>
+
+<div class="field">
+  Publication Year:<br>
+  <input type="text" id="publication_year" name="publication_year" value="<%= @work.datacite_resource.publication_year %>" />
+</div>
+
+<!-- Collection field -->
 <div class="field">
   Collection<br>
   <select id="collection_id" name="collection_id">
@@ -39,7 +50,7 @@
   </select>
 </div>
 
-<!-- ARK field (unrelated to title) -->
+<!-- ARK field  -->
 <div class="field">
   ARK: <%= @work.ark %>
 </div>

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -7,6 +7,8 @@
 <p><%= @work.datacite_resource.creators.map(&:value).join("; ") %></p>
 
 <div>
+  <p>Publisher: <%= @work.datacite_resource.publisher %></p>
+  <p>Publication Year: <%= @work.datacite_resource.publication_year %></p>
   <p>DOI: <%= link_to(@work.doi, @work.doi) %></p>
   <p>ARK: <%= link_to(@work.ark, @work.ark_url) %></p>
   <p>Added by: <%= @work.created_by_user.uid %></p>

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -9,7 +9,11 @@ RSpec.describe WorksController, mock_ezid_api: true do
   end
   let(:user) { FactoryBot.create(:user) }
   let(:collection) { Collection.first }
-  let(:work) { Work.create_dataset("test dataset", user.id, collection.id) }
+  let(:work) do
+    datacite_resource = Datacite::Resource.new
+    datacite_resource.creators << Datacite::Creator.new_person("Harriet", "Tubman")
+    Work.create_dataset("test dataset", user.id, collection.id, datacite_resource)
+  end
 
   context "valid user login" do
     it "handles the index page" do
@@ -44,7 +48,12 @@ RSpec.describe WorksController, mock_ezid_api: true do
         "commit" => "Update Dataset",
         "controller" => "works",
         "action" => "update",
-        "id" => work.id.to_s
+        "id" => work.id.to_s,
+        "publisher" => "Princeton University",
+        "publication_year" => "2022",
+        "given_name_1" => "Jane",
+        "family_name_1" => "Smith",
+        "creator_count" => "1"
       }
       sign_in user
       post :update, params: params

--- a/spec/factories/work.rb
+++ b/spec/factories/work.rb
@@ -7,6 +7,12 @@ FactoryBot.define do
       collection { Collection.research_data }
       doi { "https://doi.org/10.34770/pe9w-x904" }
       ark { "ark:/88435/dsp01zc77st047" }
+      data_cite do
+        # Works must have at least one creator
+        datacite_resource = Datacite::Resource.new
+        datacite_resource.creators << Datacite::Creator.new_person("Harriet", "Tubman")
+        datacite_resource.to_json
+      end
       created_by_user_id { FactoryBot.create(:user).id }
     end
 

--- a/spec/fixtures/files/datacite_basic.xml
+++ b/spec/fixtures/files/datacite_basic.xml
@@ -15,4 +15,6 @@
       <creatorName>Princeton University</creatorName>
     </creator>
   </creators>
+  <publisher>Princeton University</publisher>
+  <publicationYear>2022</publicationYear>
 </resource>


### PR DESCRIPTION
Added the ability to delete creators and several validations (e.g. must have at least one creator, must have a publisher and a publication year)

![title](https://user-images.githubusercontent.com/568286/169316096-378ed600-a8c2-4ad5-ae49-9cd5f6bda9aa.png)

![creator](https://user-images.githubusercontent.com/568286/169316161-ca8ea445-e422-44f8-ba50-eb21f3932d28.png)

Notice that I also updated the way creators are rendered on the page so that they are always rendered via JavaScript (instead of existing creators via Ruby and new creators via JavaScript). This way we have a single way to rendering, testing, and maintaining this code.

Closes #112
