### PR TITLE
Adding the datacite-ruby gem and creating a test spike

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,8 @@ gem "friendly_id", "~> 5.4.0"
 
 gem "faraday"
 
+gem "datacite"
+
 group :development, :test do
   gem "bixby"
   gem "byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,11 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
+    datacite (0.3.0)
+      dry-monads (~> 1.3)
+      faraday (~> 2.0)
+      json_schema (~> 0.21.0)
+      zeitwerk (~> 2.4)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     devise (4.8.1)
@@ -158,6 +163,11 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
     docile (1.4.0)
+    dry-core (0.7.1)
+      concurrent-ruby (~> 1.0)
+    dry-monads (1.4.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 0.7)
     dumb_delegator (1.0.0)
     erubi (1.10.0)
     factory_bot (6.2.1)
@@ -186,6 +196,7 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     jmespath (1.6.1)
+    json_schema (0.21.0)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -428,6 +439,7 @@ DEPENDENCIES
   capistrano-rails (~> 1.4)
   capybara (>= 3.26)
   coveralls_reborn (~> 0.24)
+  datacite
   devise
   ezid-client!
   factory_bot_rails

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -75,26 +75,26 @@ class WorksController < ApplicationController
 
     def new_creator(given_name, family_name, orcid)
       return if family_name.blank? && given_name.blank? && orcid.blank?
-      Datacite::Creator.new_person(given_name, family_name, orcid)
+      PULDatacite::Creator.new_person(given_name, family_name, orcid)
     end
 
     def datacite_resource_from_form
-      resource = Datacite::Resource.new
+      resource = PULDatacite::Resource.new
 
       resource.publisher = params["publisher"]
       resource.publication_year = params["publication_year"]
 
       # Process the titles
-      resource.titles << Datacite::Title.new(title: params["title_main"])
+      resource.titles << PULDatacite::Title.new(title: params["title_main"])
       for i in 1..params["existing_title_count"].to_i do
         if params["title_#{i}"].present?
-          resource.titles << Datacite::Title.new(title: params["title_#{i}"], title_type: params["title_type_#{i}"])
+          resource.titles << PULDatacite::Title.new(title: params["title_#{i}"], title_type: params["title_type_#{i}"])
         end
       end
 
       for i in 1..params["new_title_count"].to_i do
         if params["new_title_#{i}"].present?
-          resource.titles << Datacite::Title.new(title: params["new_title_#{i}"], title_type: params["new_title_type_#{i}"])
+          resource.titles << PULDatacite::Title.new(title: params["new_title_#{i}"], title_type: params["new_title_type_#{i}"])
         end
       end
 

--- a/app/models/pul_datacite.rb
+++ b/app/models/pul_datacite.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-module Datacite
-  # Represents a Datacite resource
+module PULDatacite
+  # Represents a PUL Datacite resource
   # https://support.datacite.org/docs/datacite-metadata-schema-v44-properties-overview
   class Resource
     attr_accessor :identifier, :identifier_type, :creators, :titles, :publisher, :publication_year, :resource_type
@@ -9,7 +9,7 @@ module Datacite
       @identifier = identifier
       @identifier_type = identifier_type
       @titles = []
-      @titles << Datacite::Title.new(title: title) unless title.nil?
+      @titles << PULDatacite::Title.new(title: title) unless title.nil?
       @creators = []
       @resource_type = resource_type || "Dataset"
       @publisher = "Princeton University"
@@ -87,16 +87,16 @@ module Datacite
     # rubocop:enable Metrics/BlockLength
     # rubocop:enable Metrics/AbcSize
 
-    # Creates a Datacite::Resource from a JSON string
+    # Creates a PULDatacite::Resource from a JSON string
     def self.new_from_json(json_string)
-      resource = Datacite::Resource.new
+      resource = PULDatacite::Resource.new
       hash = json_string.blank? ? {} : JSON.parse(json_string)
       hash["titles"]&.each do |title|
-        resource.titles << Datacite::Title.new(title: title["title"], title_type: title["title_type"])
+        resource.titles << PULDatacite::Title.new(title: title["title"], title_type: title["title_type"])
       end
       hash["creators"]&.each do |creator|
         orcid = creator.dig("name_identifier", "scheme") == "ORCID" ? creator.dig("name_identifier", "value") : nil
-        resource.creators << Datacite::Creator.new_person(creator["given_name"], creator["family_name"], orcid)
+        resource.creators << PULDatacite::Creator.new_person(creator["given_name"], creator["family_name"], orcid)
       end
       resource.publisher = hash["publisher"]
       resource.publication_year = hash["publication_year"]

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -63,7 +63,7 @@ class Work < ApplicationRecord
 
   # Convenience method to create Datasets with the DataCite profile
   def self.create_dataset(title, user_id, collection_id, datacite_resource = nil)
-    datacite_resource = Datacite::Resource.new(title: title) if datacite_resource.nil?
+    datacite_resource = PULDatacite::Resource.new(title: title) if datacite_resource.nil?
     work = Work.new(
       title: title,
       created_by_user_id: user_id,
@@ -129,7 +129,7 @@ class Work < ApplicationRecord
   end
 
   def datacite_resource
-    @datacite_resource ||= Datacite::Resource.new_from_json(data_cite)
+    @datacite_resource ||= PULDatacite::Resource.new_from_json(data_cite)
   end
 
   def ark_url

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -15,3 +15,6 @@
 # ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.acronym 'RESTful'
 # end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym "PUL"
+end

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe WorksController, mock_ezid_api: true do
   let(:user) { FactoryBot.create(:user) }
   let(:collection) { Collection.first }
   let(:work) do
-    datacite_resource = Datacite::Resource.new
-    datacite_resource.creators << Datacite::Creator.new_person("Harriet", "Tubman")
+    datacite_resource = PULDatacite::Resource.new
+    datacite_resource.creators << PULDatacite::Creator.new_person("Harriet", "Tubman")
     Work.create_dataset("test dataset", user.id, collection.id, datacite_resource)
   end
 

--- a/spec/factories/work.rb
+++ b/spec/factories/work.rb
@@ -9,8 +9,8 @@ FactoryBot.define do
       ark { "ark:/88435/dsp01zc77st047" }
       data_cite do
         # Works must have at least one creator
-        datacite_resource = Datacite::Resource.new
-        datacite_resource.creators << Datacite::Creator.new_person("Harriet", "Tubman")
+        datacite_resource = PULDatacite::Resource.new
+        datacite_resource.creators << PULDatacite::Creator.new_person("Harriet", "Tubman")
         datacite_resource.to_json
       end
       created_by_user_id { FactoryBot.create(:user).id }

--- a/spec/models/doi_spec.rb
+++ b/spec/models/doi_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe "DOI", type: :model do
+  describe "SPIKE" do
+    let(:response) do
+      <<~JSON
+        {
+          "data": {
+            "id": "10.34770/doc-1",
+            "type": "dois",
+            "attributes": {
+              "doi": "10.34770/doc-1",
+              "prefix": "10.34770",
+              "suffix": "0012",
+              "identifiers": [{
+                "identifier": "https://doi.org/10.34770/doc-1",
+                "identifierType": "DOI"
+              }],
+              "creators": [],
+              "titles": [],
+              "publisher": null,
+              "container": {},
+              "publicationYear": null,
+              "subjects": [],
+              "contributors": [],
+              "dates": [],
+              "language": null,
+              "types": {},
+              "relatedIdentifiers": [],
+              "sizes": [],
+              "formats": [],
+              "version": null,
+              "rightsList": [],
+              "descriptions": [],
+              "geoLocations": [],
+              "fundingReferences": [],
+              "xml": null,
+              "url":null,
+              "contentUrl": null,
+              "metadataVersion": 1,
+              "schemaVersion": "http://datacite.org/schema/kernel-4",
+              "source": null,
+              "isActive": true,
+              "state": "draft",
+              "reason": null,
+              "created": "2016-09-19T21:53:56.000Z",
+              "registered": null,
+              "updated": "2019-02-06T14:31:27.000Z"
+            },
+            "relationships": {
+              "client": {
+                "data": {
+                  "id": "datacite.datacite",
+                  "type": "clients"
+                }
+              },
+              "media": {
+                "data": []
+              }
+            }
+          },
+          "included": [{
+            "id": "datacite.datacite",
+            "type": "clients",
+            "attributes": {
+              "name": "DataCite",
+              "symbol": "DATACITE.DATACITE",
+              "year": 2011,
+              "contactName": "DataCite",
+              "contactEmail": "support@datacite.org",
+              "description": null,
+              "domains": "*",
+              "url": null,
+              "created": "2011-12-07T13:43:39.000Z",
+              "updated": "2019-01-02T17:33:06.000Z",
+              "isActive": true,
+              "hasPassword": true
+            },
+            "relationships": {
+              "provider": {
+                "data": {
+                  "id": "datacite",
+                  "type": "providers"
+                }
+              },
+              "prefixes": {
+                "data": [{
+                  "id": "10.34770",
+                  "type": "prefixes"
+                }]
+              }
+            }
+          }]
+        }
+      JSON
+    end
+
+    it "mints a new DOI" do
+      stub_request(:post, "https://api.datacite.org/dois")
+        .with(
+        body: "{\"data\":{\"type\":\"dois\",\"attributes\":{\"prefix\":\"10.34770\"}}}",
+        headers: {
+          "Accept" => "*/*",
+          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "Authorization" => "Basic Zm9vOmJhcg==",
+          "Content-Type" => "application/vnd.api+json",
+          "User-Agent" => "Datacite Ruby client version 0.3.0"
+        }
+      )
+        .to_return(status: 200, body: response, headers: { "Content-Type" => "application/json" })
+      client = Datacite::Client.new(username: "foo",
+                                    password: "bar",
+                                    host: "api.datacite.org")
+      #
+      # Comment out the above stub and uncomment the below code to send a real request and create an DOI
+      # you must have the datacite user name and password in your environment
+      #
+      # WebMock.enable_net_connect!
+      # client = Datacite::Client.new(username: ENV["DATACITE_USER"],
+      #   password: ENV["DATACITE_PASSWORD"],
+      #   host: "api.datacite.org")
+
+      result = client.autogenerate_doi(prefix: "10.34770")
+      doi = result.either(
+              ->(response) { response.doi },
+              ->(response) { raise("Something went wrong", response.status) }
+            )
+      puts doi
+      expect(doi).to be_present
+    end
+  end
+end

--- a/spec/models/pul_datacite_spec.rb
+++ b/spec/models/pul_datacite_spec.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 require "rails_helper"
 
-RSpec.describe Datacite::Resource, type: :model do
+RSpec.describe PULDatacite::Resource, type: :model do
   let(:creatorPerson) do
-    Datacite::Creator.new_person("Elizabeth", "Miller", "1234-5678-9012-1234")
+    PULDatacite::Creator.new_person("Elizabeth", "Miller", "1234-5678-9012-1234")
   end
 
   let(:creatorOrganization) do
-    org = Datacite::Creator.new(value: "Princeton University", name_type: "Organization")
-    org.affiliations << Datacite::Affiliation.new(value: "Some affiliation", identifier: "https://ror.org/04aj4c181", scheme: "ROR", scheme_uri: "https://ror.org/")
+    org = PULDatacite::Creator.new(value: "Princeton University", name_type: "Organization")
+    org.affiliations << PULDatacite::Affiliation.new(value: "Some affiliation", identifier: "https://ror.org/04aj4c181", scheme: "ROR", scheme_uri: "https://ror.org/")
     org
   end
 
@@ -28,7 +28,7 @@ RSpec.describe Datacite::Resource, type: :model do
   end
 
   it "supports more than one title" do
-    ds.titles << Datacite::Title.new(title: "hola mundo", title_type: "TranslatedTitle")
+    ds.titles << PULDatacite::Title.new(title: "hola mundo", title_type: "TranslatedTitle")
     expect(ds.titles.count).to be 2
   end
 
@@ -42,7 +42,7 @@ RSpec.describe Datacite::Resource, type: :model do
     expect(creatorPerson.orcid).to eq "1234-5678-9012-1234"
     expect(creatorPerson.orcid_url).to eq "https://orcid.org/1234-5678-9012-1234"
 
-    no_orcid = Datacite::Creator.new_person("Elizabeth", "Miller")
+    no_orcid = PULDatacite::Creator.new_person("Elizabeth", "Miller")
     expect(no_orcid.orcid).to be nil
   end
 end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Work, type: :model, mock_ezid_api: true do
   let(:superadmin_user) { User.from_cas(OmniAuth::AuthHash.new(provider: "cas", uid: "fake1", extra: { mail: "fake@princeton.edu" })) }
   let(:doi) { "https://doi.org/10.34770/0q6b-cj27" }
   let(:work) do
-    datacite_resource = Datacite::Resource.new
-    datacite_resource.creators << Datacite::Creator.new_person("Harriet", "Tubman")
+    datacite_resource = PULDatacite::Resource.new
+    datacite_resource.creators << PULDatacite::Creator.new_person("Harriet", "Tubman")
     described_class.create_dataset("test title", user.id, collection.id, datacite_resource)
   end
 

--- a/spec/system/accessibility_spec.rb
+++ b/spec/system/accessibility_spec.rb
@@ -55,8 +55,8 @@ describe "application accessibility", type: :system, js: true do
 
   context "when viewing an individual work show page" do
     it "complies with WCAG 2.0 AA and Section 508" do
-      datacite_resource = Datacite::Resource.new(title: "Test dataset")
-      datacite_resource.creators << Datacite::Creator.new_person("Harriet", "Tubman", "1234-5678-9012-3456")
+      datacite_resource = PULDatacite::Resource.new(title: "Test dataset")
+      datacite_resource.creators << PULDatacite::Creator.new_person("Harriet", "Tubman", "1234-5678-9012-3456")
       work = Work.create_dataset("Test dataset", user.id, user.default_collection_id, datacite_resource)
       visit work_path(work)
       expect(page).to be_axe_clean

--- a/spec/system/work_spec.rb
+++ b/spec/system/work_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe "Creating and updating works", mock_ezid_api: true do
   end
 
   it "Renders ORCID links for creators", js: true do
-    datacite_resource = Datacite::Resource.new(title: "Test dataset")
-    datacite_resource.creators << Datacite::Creator.new_person("Harriet", "Tubman", "1234-5678-9012-3456")
+    datacite_resource = PULDatacite::Resource.new(title: "Test dataset")
+    datacite_resource.creators << PULDatacite::Creator.new_person("Harriet", "Tubman", "1234-5678-9012-3456")
     work = Work.create_dataset("Test dataset", user.id, user.default_collection_id, datacite_resource)
 
     sign_in user


### PR DESCRIPTION
We really need to get a hold of an account on [the test doi system](https://doi.datacite.org/) for testing the ability to publish DOIs, but this spike does create draft DOIs in the live system if the client is switched and environment variables are set.  I have deleted the two DOIs that I created in the live system.  Draft DOIs can be deleted, but published ones can not.

The JSON response in the test was taken directly from the gem test.

refs #108 