### PR TITLE
Added test for Ark.update

### DIFF
--- a/spec/models/ark_spec.rb
+++ b/spec/models/ark_spec.rb
@@ -11,6 +11,22 @@ RSpec.describe Ark, type: :model, mock_ezid_api: true do
     end
   end
 
+  describe ".update" do
+    let(:ark) { "ark:/88435/dsp01qb98mj541" }
+    let(:old_target) { "https://dataspace.princeton.edu/handle/88435/dsp01qb98mj541" }
+    let(:new_target) { "https://dataspace.princeton.edu/handle/88435/dsp01qb98mj541-new" }
+
+    it "makes the call to EZID" do
+      described_class.update(ark, new_target)
+      expect(@identifier).to have_received(:save!)
+    end
+
+    it "does not make the call to EZID" do
+      described_class.update(ark, old_target)
+      expect(@identifier).to_not have_received(:save!)
+    end
+  end
+
   describe ".valid?" do
     let(:id) { "id" }
 

--- a/spec/support/ezid_specs.rb
+++ b/spec/support/ezid_specs.rb
@@ -29,5 +29,8 @@ RSpec.configure do |config|
     allow(@identifier).to receive(:metadata).and_return(@ezid_metadata)
     allow(@identifier).to receive(:id).and_return(@ezid)
     allow(@identifier).to receive(:modify)
+    allow(@identifier).to receive(:target).and_return(@ezid_metadata_values["_target"])
+    allow(@identifier).to receive(:target=)
+    allow(@identifier).to receive(:save!)
   end
 end


### PR DESCRIPTION
Added test for Ark class `update` method that was missing in PR #136.

Fixes #146 