### PR TITLE
First pass at allowing users to reorder the creators

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -129,9 +129,9 @@ class WorksController < ApplicationController
 
   private
 
-    def new_creator(given_name, family_name, orcid)
+    def new_creator(given_name, family_name, orcid, sequence)
       return if family_name.blank? && given_name.blank? && orcid.blank?
-      PULDatacite::Creator.new_person(given_name, family_name, orcid)
+      PULDatacite::Creator.new_person(given_name, family_name, orcid, sequence)
     end
 
     def datacite_resource_from_form
@@ -156,7 +156,7 @@ class WorksController < ApplicationController
 
       # Process the creators
       for i in 1..params["creator_count"].to_i do
-        creator = new_creator(params["given_name_#{i}"], params["family_name_#{i}"], params["orcid_#{i}"])
+        creator = new_creator(params["given_name_#{i}"], params["family_name_#{i}"], params["orcid_#{i}"], params["sequence_#{i}"])
         resource.creators << creator unless creator.nil?
       end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,8 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.min.js" integrity="sha384-QJHtvGhmr9XOIpI6YVutG+2QOK9T+ZnN4kzFN1RtK3zEFEIsxhlmWl5/YESvpZ13" crossorigin="anonymous"></script>
 
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <!-- Provides https://jqueryui.com/sortable/ -->
+    <script src="https://code.jquery.com/ui/1.13.1/jquery-ui.js"></script>
   </head>
 
   <body>

--- a/app/views/works/_creators_form.html.erb
+++ b/app/views/works/_creators_form.html.erb
@@ -1,26 +1,32 @@
 <b>Creator(s)<span class="required-field" title="At least one creator must be indicated">*</span></b>
 
 <!--
-  Render the list of creators a hidden SPANs that are then added to
+  Render the list of creators a hidden SPANs that are then added below
   the HTML TABLE via JavaScript. This is so that we have a single way
   of rendering creators already on the record *and* creators added
   on the fly.
 -->
 <table id="creators-table">
-  <tr>
-    <th>ORCID</th>
-    <th>Given name</th>
-    <th>Family name</th>
-    <th>&nbsp;</th>
-  </tr>
-  <% @work.datacite_resource.creators.each_with_index do |creator, i| %>
-    <span class="hidden creator-data"
-      data-num="<%= i + 1 %>"
-      data-orcid="<%= creator.orcid %>"
-      data-given-name="<%= creator.given_name %>"
-      data-family-name="<%= creator.family_name %>"></span>
-  <% end %>
+  <tbody id="creators-table-sortable">
+    <tr class="header-row">
+      <th>ORCID</th>
+      <th>Given name</th>
+      <th>Family name</th>
+      <th>&nbsp;</th> <!-- move icon-->
+      <th>&nbsp;</th> <!-- delete icon-->
+    </tr>
+  </tbody>
 </table>
+
+<% @work.datacite_resource.creators.each_with_index do |creator, i| %>
+<span class="hidden creator-data"
+  data-num="<%= i + 1 %>"
+  data-orcid="<%= creator.orcid %>"
+  data-given-name="<%= creator.given_name %>"
+  data-family-name="<%= creator.family_name %>"
+  data-sequence="<%= creator.sequence %>"
+  ></span>
+<% end %>
 
 <!-- Let the user add new creators -->
 <div>

--- a/app/views/works/_edit_javascript.html.erb
+++ b/app/views/works/_edit_javascript.html.erb
@@ -12,20 +12,27 @@
       return counter
     }
 
-    var addCreatorHtml = function(num, orcid, givenName, familyName) {
+    var addCreatorHtml = function(num, orcid, givenName, familyName, sequence) {
       var rowId = `creator_row_${num}`;
       var orcidId = `orcid_${num}`;
       var givenNameId = `given_name_${num}`;
       var familyNameId = `family_name_${num}`;
-      var rowHtml = `<tr id="${rowId}">
+      var sequenceId = `sequence_${num}`;
+      var rowHtml = `<tr id="${rowId}" class="creators-table-row">
         <td>
           <input class="orcid-entry" type="text" id="${orcidId}" name="${orcidId}" value="${orcid}" data-num="${num}" placeholder="0000-0000-0000-0000" />
         </td>
         <td>
           <input type="text" id="${givenNameId}" name="${givenNameId}" value="${givenName}" />
         </td>
-        <td>
+        <td class="creators-table-row-family-name">
           <input type="text" id="${familyNameId}" name="${familyNameId}" value="${familyName}" />
+        </td>
+        <td>
+          <input class="sequence hidden" type="text" id="${sequenceId}" name="${sequenceId}" value="${sequence}" />
+        </td>
+        <td>
+          <i class="bi bi-arrow-down-up" style="color: gray;" title="Click and drag to reorder"></i>
         </td>
         <td>
           <span>
@@ -37,6 +44,34 @@
       </tr>`;
       $("#creators-table").append(rowHtml);
       $("#" + orcidId).focus();
+    }
+
+    var deleteCreator = function(num) {
+      var rowToDelete = `#creator_row_${num}`;
+      var orcidId = `#orcid_${num}`;
+      var givenNameId = `#given_name_${num}`;
+      var familyNameId = `#family_name_${num}`;
+      var name = $(orcidId).val() + " " + $(givenNameId).val() + " " + $(familyNameId).val();
+      var emptyName = (name === undefined) || (name.trim().length == 0);
+      if (emptyName) {
+        // delete it without asking
+        $(rowToDelete).remove();
+      } else {
+        if (confirm(`Remove creator ${name}`)) {
+          $(rowToDelete).remove();
+        }
+      }
+    }
+
+    // Updates the creators sequence value to match the order
+    // in which they are displayed. This is needed if the user
+    // reordered the creators (via drag and drop).
+    var updateCreatorsSequence = function() {
+      var i;
+      var sequences = $(".creators-table-row > td > input.sequence")
+      for(i = 0; i < sequences.length; i++) {
+        sequences[i].value = i + 1;
+      }
     }
 
     var addTitlePlaceholder = function(_el) {
@@ -77,22 +112,9 @@
       return false;
     });
 
-    var deleteCreator = function(num) {
-      var rowToDelete = `#creator_row_${num}`;
-      var orcidId = `#orcid_${num}`;
-      var givenNameId = `#given_name_${num}`;
-      var familyNameId = `#family_name_${num}`;
-      var name = $(orcidId).val() + " " + $(givenNameId).val() + " " + $(familyNameId).val();
-      var emptyName = (name === undefined) || (name.trim().length == 0);
-      if (emptyName) {
-        // delete it without asking
-        $(rowToDelete).remove();
-      } else {
-        if (confirm(`Remove creator ${name}`)) {
-          $(rowToDelete).remove();
-        }
-      }
-    }
+    $("#btn-submit").on("click", function(el) {
+      updateCreatorsSequence();
+    });
 
     // Delete button for creators.
     //
@@ -121,7 +143,8 @@
         var orcid = $(el).data("orcid");
         var givenName = $(el).data("given-name");
         var familyName = $(el).data("family-name");
-        addCreatorHtml(num, orcid, givenName, familyName);
+        var sequence = $(el).data("sequence");
+        addCreatorHtml(num, orcid, givenName, familyName, sequence);
       });
     }
 
@@ -146,6 +169,12 @@
           console.log(`Error fetching ORCID for ${errorThrown}`);
         });
       }
+    });
+
+    // Allows the creators to be reordered via drag and drop.
+    // The `cancel` property is used to prevent reordering the header (https://stackoverflow.com/a/17897706/446681)
+    $("#creators-table-sortable").sortable({
+      cancel: "tr:has(th)"
     });
   });
 </script>

--- a/app/views/works/_form.html.erb
+++ b/app/views/works/_form.html.erb
@@ -35,7 +35,7 @@
     <hr />
     <div class="actions">
       <%= link_to 'Cancel', @work, class: "btn btn-secondary" %>
-      <%= form.submit "Save Work", class: "btn btn-primary wizard-next-button" %>
+      <%= form.submit "Save Work", class: "btn btn-primary wizard-next-button", id: "btn-submit" %>
     </div>
 
     <%= render 'form_hidden_fields' %>

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -69,6 +69,55 @@ RSpec.describe WorksController, mock_ezid_api: true do
       expect(response.location).to eq "http://test.host/works/#{work.id}"
     end
 
+    it "handles the update page" do
+      params = {
+        "title_main" => "test dataset updated",
+        "collection_id" => work.collection.id,
+        "commit" => "Update Dataset",
+        "controller" => "works",
+        "action" => "update",
+        "id" => work.id.to_s,
+        "publisher" => "Princeton University",
+        "publication_year" => "2022",
+        "given_name_1" => "Jane",
+        "family_name_1" => "Smith",
+        "sequence_1" => "1",
+        "given_name_2" => "Ada",
+        "family_name_2" => "Lovelace",
+        "sequence_2" => "2",
+        "creator_count" => "2"
+      }
+      sign_in user
+      post :update, params: params
+
+      saved_work = Work.find(work.id)
+      expect(saved_work.datacite_resource.creators[0].value).to eq "Smith, Jane"
+      expect(saved_work.datacite_resource.creators[1].value).to eq "Lovelace, Ada"
+
+      params_reordered = {
+        "title_main" => "test dataset updated",
+        "collection_id" => work.collection.id,
+        "commit" => "Update Dataset",
+        "controller" => "works",
+        "action" => "update",
+        "id" => work.id.to_s,
+        "publisher" => "Princeton University",
+        "publication_year" => "2022",
+        "given_name_1" => "Jane",
+        "family_name_1" => "Smith",
+        "sequence_1" => "2",
+        "given_name_2" => "Ada",
+        "family_name_2" => "Lovelace",
+        "sequence_2" => "1",
+        "creator_count" => "2"
+      }
+
+      post :update, params: params_reordered
+      reordered_work = Work.find(work.id)
+      expect(reordered_work.datacite_resource.creators[0].value).to eq "Lovelace, Ada"
+      expect(reordered_work.datacite_resource.creators[1].value).to eq "Smith, Jane"
+    end
+
     it "renders view to select the kind of attachment to use" do
       sign_in user
       get :attachment_select, params: { id: work.id }


### PR DESCRIPTION
Allows a user to change the order of the creators. Data is saved and rendered respecting the order.

Below is an animated GIF showing it in action (it's a bit slow, but it does animate)

![reorder](https://user-images.githubusercontent.com/568286/173869374-1db0458d-20e2-4bfc-a717-c846ecd41af6.gif)

Note the the user cannot pick the creators table header (ORCID/Given name/Family name) and drag it, but they can put a creator row on top of the header as they drag it. It looks ugly if they do, but it causes no harm. I did not find an easy way to prevent this behavior so I am submitting this PR with this possible bug, but I think it's OK.

