### PR TITLE
Use a known DOI to by pass the S3 service

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -113,7 +113,7 @@ class Work < ApplicationRecord
   end
 
   def draft_doi
-    self.doi ||= "10.34770/doc-1"
+    self.doi ||= "10.34770/tbd"
     # TODO: Set up the doi to have  a variable prefix.  Test and production do not have the same one
     # self.doi ||= begin
     #                result = data_cite_connection.autogenerate_doi(prefix: "10.34770")

--- a/app/services/s3_query_service.rb
+++ b/app/services/s3_query_service.rb
@@ -45,7 +45,7 @@ class S3QueryService
   # * https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/S3/Client.html#get_object_attributes-instance_method
   # @return [<S3File>] An Array of S3File objects
   def data_profile
-    return [] if @doi == "10.1234/tbd"
+    return [] if @doi == "10.34770/tbd"
     objects = []
     resp = client.list_objects_v2({ bucket: bucket_name, max_keys: 1000, prefix: prefix })
     resp.to_h[:contents].each do |object|

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Work, type: :model, mock_ezid_api: true do
   end
 
   it "drafts a doi only once" do
-    expect(work.doi).to eq("10.34770/doc-1")
+    expect(work.doi).to eq("10.34770/tbd")
     work.draft_doi
     work.draft_doi # Doing this multiple times on purpose to make sure the api is only called once
     # TODO: Set up the doi to have  a variable prefix.  Test and production do not have the same one


### PR DESCRIPTION
This updates the workaround that Carolyn did on PR https://github.com/pulibrary/pdc_describe/pull/165 to use a known DOI value that skips the fetching of data from S3 https://github.com/pulibrary/pdc_describe/blob/main/app/services/s3_query_service.rb#L48 since we don't want to fetch values from S3 for this fake DOI.

