### PR TITLE
Preserves the ability to click on the edit textboxes

### DIFF
--- a/app/views/works/_edit_javascript.html.erb
+++ b/app/views/works/_edit_javascript.html.erb
@@ -172,9 +172,15 @@
     });
 
     // Allows the creators to be reordered via drag and drop.
-    // The `cancel` property is used to prevent reordering the header (https://stackoverflow.com/a/17897706/446681)
+    // The `cancel` property "prevents sorting if you start on elements matching the selector"
+    // https://api.jqueryui.com/sortable/#method-cancel
+    //
+    //  tr:has(th)      - prevents reordering the header (https://stackoverflow.com/a/17897706/446681)
+    //  input           - prevents reordering on the textboxes (so they are still editable)
+    //  .delete-creator - prevents reording on the delete icon
+    //
     $("#creators-table-sortable").sortable({
-      cancel: "tr:has(th)"
+      cancel: "tr:has(th), input, .delete-creator"
     });
   });
 </script>


### PR DESCRIPTION
Turns out the jQuery plug-in has a way to account for the issue by telling it not to kick-in on certain elements. In our case I told it not to kick in on textboxes or the delete icon.

Fixes #169

