### PR TITLE
Tuned the ORCID validation

### DIFF
--- a/app/models/orcid.rb
+++ b/app/models/orcid.rb
@@ -2,7 +2,9 @@
 require "ezid-client"
 
 class Orcid
-  ORCID_REGEX = /^\d\d\d\d-\d\d\d\d-\d\d\d\d-\d\d\d\d$/.freeze
+  # Notice that we allow for an "X" as the last digit.
+  # Source https://gist.github.com/asencis/644f174855899b873131c2cabcebeb87
+  ORCID_REGEX = /^(\d{4}-){3}\d{3}(\d|X)$/.freeze
 
   def self.valid?(orcid)
     return false if orcid.blank?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
   devise :rememberable, :omniauthable
 
   validate do |user|
-    user.orcid.strip! unless user.orcid.nil?
+    user.orcid&.strip!
     if user.orcid.present? && Orcid.invalid?(user.orcid)
       user.errors.add :base, "Invalid format for ORCID"
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,7 @@ class User < ApplicationRecord
   devise :rememberable, :omniauthable
 
   validate do |user|
+    user.orcid.strip! unless user.orcid.nil?
     if user.orcid.present? && Orcid.invalid?(user.orcid)
       user.errors.add :base, "Invalid format for ORCID"
     end

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -47,12 +47,13 @@
 
 $(function() {
   var isOrcid = function(value) {
-    const regex = new RegExp(/^\d\d\d\d-\d\d\d\d-\d\d\d\d-\d\d\d\d$/);
-    return regex.test(value);
+    // Notice that we allow for an "X" as the last digit.
+    // Source https://gist.github.com/asencis/644f174855899b873131c2cabcebeb87
+    return /^(\d{4}-){3}\d{3}(\d|X)$/.test(value)
   };
 
   var validateOrcid = function() {
-    var value = $("#user_orcid").val();
+    var value = $("#user_orcid").val().trim();
     if (value == "") {
       $("#orcid-bad").addClass("hidden");
       $("#orcid-ok").addClass("hidden");

--- a/app/views/works/_edit_javascript.html.erb
+++ b/app/views/works/_edit_javascript.html.erb
@@ -1,8 +1,9 @@
 <script>
   $(function() {
     var isOrcid = function(value) {
-      const regex = new RegExp(/^\d\d\d\d-\d\d\d\d-\d\d\d\d-\d\d\d\d$/);
-      return regex.test(value);
+      // Notice that we allow for an "X" as the last digit.
+      // Source https://gist.github.com/asencis/644f174855899b873131c2cabcebeb87
+      return /^(\d{4}-){3}\d{3}(\d|X)$/.test(value)
     };
 
     var incrementCounter = function(elementId) {
@@ -63,8 +64,6 @@
             $(rowToDelete).remove();
           }
         }
-      } else {
-        console.log(`${rowToDelete} does not exist - nothing to do`);
       }
     }
 
@@ -211,7 +210,7 @@
     // Fetch name information for a given ORCID via ORCID's public API
     $(document).on("input", ".orcid-entry", function(el) {
       var num = el.target.attributes["data-num"].value;
-      var orcid = $(el.target).val();
+      var orcid = $(el.target).val().trim();
       if (isOrcid(orcid)) {
         $.ajax({
           url: `<%= ORCID_URL %>/${orcid}`,

--- a/spec/models/orcid_spec.rb
+++ b/spec/models/orcid_spec.rb
@@ -4,6 +4,8 @@ require "rails_helper"
 RSpec.describe Orcid, type: :model do
   it "validates ORCIDs" do
     expect(described_class.valid?("1234-5678-9012-1234")).to be true
+    expect(described_class.valid?("1234-5678-9012-123X")).to be true
+    expect(described_class.valid?("x1234-5678-9012-1234")).to be false
     expect(described_class.valid?("01234-5678-9012-1234")).to be false
     expect(described_class.valid?("234-5678-9012-1234")).to be false
     expect(described_class.valid?("ABCD-5678-9012-1234")).to be false


### PR DESCRIPTION
Several minor tweaks including allowing spaces at the end of the ORCID (this is useful when users copy and paste an ORCID) and removing these extra spaces before saving to the database.

I am also using a slightly different regex that allows an `X` as the last "digit" since this is apparently OK.

Notice that we do the ORCID validation both in JavaScript and in Ruby and therefore the regex is in two places. This is OK and no big deal.

We also have the regex twice in JavaScript and at some *future PR* I would like to change that so that the JavaScript `isOrcid()` function is defined only once.

Fixes https://github.com/pulibrary/pdc_describe/issues/150
