### PR TITLE
Added ORCID format validation for the dataset creators

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -106,9 +106,17 @@ class Work < ApplicationRecord
 
     if work.data_cite.present?
       work.errors.add(:base, "Must provide a title") if work.title.blank?
-      work.errors.add(:base, "Must provide at least one Creator") if work.datacite_resource.creators.count == 0
       work.errors.add(:base, "Must indicate the Publisher") if work.datacite_resource.publisher.blank?
       work.errors.add(:base, "Must indicate the Publication Year") if work.datacite_resource.publication_year.blank?
+      if work.datacite_resource.creators.count == 0
+        work.errors.add(:base, "Must provide at least one Creator")
+      else
+        work.datacite_resource.creators.each do |creator|
+          if creator.orcid.present? && Orcid.invalid?(creator.orcid)
+            work.errors.add(:base, "ORCID for creator #{creator.value} is not in format 0000-0000-0000-0000")
+          end
+        end
+      end
     end
   end
 

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -21,6 +21,13 @@ RSpec.describe Work, type: :model, mock_ezid_api: true do
     stub_datacite(host: "api.datacite.org", body: datacite_register_body(prefix: "10.34770"))
   end
 
+  it "checks the format of the ORCID of the creators" do
+    # Add a new creator with an incomplete ORCID
+    work.datacite_resource.creators << PULDatacite::Creator.new_person("Williams", "Serena", "1234-12")
+    expect(work.save).to be false
+    expect(work.errors.find { |error| error.type.include?("ORCID") }).to be_present
+  end
+
   it "creates a skeleton dataset with a DOI and an ARK" do
     expect(work.created_by_user.id).to eq user.id
     expect(work.collection.id).to eq collection.id


### PR DESCRIPTION
Added the ORCID format validation for each of the creators of a dataset. 

It is OK for a creator to not have an ORCID, but if the creator has an ORCID it must be in the correct format e.f. 0000-0000-0000-0000-0000.

Closes #151 