### PR TITLE
Displays description in show page and DataCite XML

### DIFF
--- a/app/models/pul_datacite.rb
+++ b/app/models/pul_datacite.rb
@@ -51,6 +51,9 @@ module PULDatacite
               end
             end
           end
+          xml.description("descriptionType" => "Other") do
+            xml.text @description
+          end
           xml.creators do
             @creators.each do |creator|
               if creator.name_type == "Personal"

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -11,6 +11,9 @@
 </p>
 
 <div>
+  <p>Description:<br/>
+    <%= @work.datacite_resource.description %>
+  </p>
   <p>Publisher: <%= @work.datacite_resource.publisher %></p>
   <p>Publication Year: <%= @work.datacite_resource.publication_year %></p>
   <p>DOI: <%= link_to(@work.doi, @work.doi) %></p>

--- a/spec/fixtures/files/datacite_basic.xml
+++ b/spec/fixtures/files/datacite_basic.xml
@@ -4,6 +4,7 @@
   <titles>
     <title>hello world</title>
   </titles>
+  <description descriptionType="Other">this is an example description</description>
   <creators>
     <creator nameType="Personal">
       <creatorName>Miller, Elizabeth</creatorName>

--- a/spec/models/pul_datacite_spec.rb
+++ b/spec/models/pul_datacite_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe PULDatacite::Resource, type: :model do
 
   let(:ds) do
     ds = described_class.new(identifier: "10.5072/example-full", identifier_type: "DOI", title: "hello world")
+    ds.description = "this is an example description"
     ds.creators = [creatorPerson, creatorOrganization]
     ds
   end


### PR DESCRIPTION
In a previous PR I added the description to the Edit form. This PR displays it on the Show page and adds it to the DataCite XML rendering as well.