### PR TITLE
Updating DOI code to utilize prefix environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ This is convenient when you need to step through the code as `byebug` does not a
 2. Terminal two: `bin/webpack-dev-server`
 3. Access pdc_describe at [http://localhost:3000/](http://localhost:3000/)
 
+## DataCite integration
+We use DataCite to mint DOIs and in production you must to define the `DATACITE_*` environment values indicated [here](https://github.com/pulibrary/princeton_ansible/blob/main/group_vars/pdc_describe/production.yml) for the system to run. During development if you do not set these values the system will use a hard-coded DOI.
+
 ## Deploying
 pulbot: `pulbot deploy pdc_describe to [staging|production]`
 

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -122,15 +122,13 @@ class Work < ApplicationRecord
   end
 
   def draft_doi
-    self.doi ||= "10.34770/tbd"
-    # TODO: Set up the doi to have  a variable prefix.  Test and production do not have the same one
-    # self.doi ||= begin
-    #                result = data_cite_connection.autogenerate_doi(prefix: "10.34770")
-    #                result.either(
-    #                   ->(response) { response.doi },
-    #                   ->(response) { raise("Something went wrong", response.status) }
-    #                 )
-    #              end
+    self.doi ||= begin
+                   result = data_cite_connection.autogenerate_doi(prefix: ENV["DATACITE_PREFIX"])
+                   result.either(
+                      ->(response) { response.doi },
+                      ->(response) { raise("Something went wrong", response.status) }
+                    )
+                 end
   end
 
   def approve(user)

--- a/app/services/s3_query_service.rb
+++ b/app/services/s3_query_service.rb
@@ -45,10 +45,9 @@ class S3QueryService
   # * https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/S3/Client.html#get_object_attributes-instance_method
   # @return [<S3File>] An Array of S3File objects
   def data_profile
-    return [] if @doi == "10.34770/tbd"
     objects = []
     resp = client.list_objects_v2({ bucket: bucket_name, max_keys: 1000, prefix: prefix })
-    resp.to_h[:contents].each do |object|
+    resp.to_h[:contents]&.each do |object|
       s3_file = S3File.new(filename: object[:key], last_modified: object[:last_modified], size: object[:size])
       objects << s3_file
     end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -37,11 +37,10 @@ RSpec.describe Work, type: :model, mock_ezid_api: true do
   end
 
   it "drafts a doi only once" do
-    expect(work.doi).to eq("10.34770/tbd")
+    expect(work.doi).to eq("10.34770/doc-1")
     work.draft_doi
     work.draft_doi # Doing this multiple times on purpose to make sure the api is only called once
-    # TODO: Set up the doi to have  a variable prefix.  Test and production do not have the same one
-    # expect(a_request(:post, ENV["DATACITE_URL"])).to have_been_made.once
+    expect(a_request(:post, ENV["DATACITE_URL"])).to have_been_made.once
   end
 
   it "prevents datasets with no users" do

--- a/spec/support/datacite_specs.rb
+++ b/spec/support/datacite_specs.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 def datacite_register_body(prefix: "10.80021")
+  ENV["DATACITE_PREFIX"] = prefix
   "{\"data\":{\"type\":\"dois\",\"attributes\":{\"prefix\":\"#{prefix}\"}}}"
 end
 


### PR DESCRIPTION
Updated the code to use a variable DOI prefix based on the environment. 

Updated error handling in DOI generation and when fetching S3 files associated with a DOI that has no files in S3 yet. Also added special condition to allow the system to work in development without having to have the DataCite credentials.