### PR TITLE
Include works where the user is mentioned 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,7 @@ AllCops:
     - "vendor/**/*"
     - "node_modules/**/*"
     - "bin/*"
+    - "storage/**/*"
 
 Layout/IndentationConsistency:
   EnforcedStyle: indented_internal_methods

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -46,7 +46,7 @@ class Work < ApplicationRecord
       works = []
       if user.admin_collections.count == 0
         # Just the user's own works by state
-        works = Work.where(created_by_user_id: user, state: state)
+        works += Work.where(created_by_user_id: user, state: state)
       else
         # The works that match the given state, in all the collections the user can admin
         # (regardless of who created those works)


### PR DESCRIPTION
Update the dashboard to include works where the user is mentioned (even if they don't own the dataset). 

This is to handle cases where a user tags a user, say `@userA`, on a dataset that they typically does not have access to (e.g. it's the PPPL collection). With this changes the dataset will still show under `@userA's` dashboard and with the proper badge indicating that there are unread notifications.

Closes #223 

Below is an example on how this looks in practice. Notice that the dashboard for Bess has a dataset with a badge with one pending notification because Bess was mentioned in a comment for this dataset.

![dashboard](https://user-images.githubusercontent.com/568286/181277518-69f58b2d-e08d-46ce-af01-14f1ed03db23.png)

![mention](https://user-images.githubusercontent.com/568286/181277550-f46c7565-7dd1-4a45-ae0d-8b1164291e4d.png)
