### PR TITLE
Submit new dataset step 0

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,7 +27,7 @@
 }
 
 .required-field {
-  color: red;
+  color: #d71616;
 }
 
 .text-not-editable {

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -13,11 +13,14 @@ class WorksController < ApplicationController
   end
 
   # Renders the "step 0" information page before creating a new dataset
-  def new_submission; end
+  def new; end
 
-  def new
+  # Creates the new dataset
+  def new_submission
+    byebug
     default_collection_id = current_user.default_collection.id
-    work = Work.create_dataset("New Dataset", current_user.id, default_collection_id)
+    datacite_resource = datacite_resource_from_form
+    work = Work.create_dataset(datacite_resource.main_title, current_user.id, default_collection_id, datacite_resource)
     redirect_to edit_work_path(work, wizard: true)
   end
 
@@ -67,7 +70,7 @@ class WorksController < ApplicationController
     updates = {
       title: title_param,
       collection_id: collection_id_param,
-      data_cite: datacite_resource_from_form,
+      data_cite: datacite_resource_from_form.to_json,
       deposit_uploads: updated_deposit_uploads
     }
 
@@ -236,7 +239,7 @@ class WorksController < ApplicationController
         resource.creators << creator unless creator.nil?
       end
 
-      resource.to_json
+      resource
     end
 
     def work_params

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -13,11 +13,12 @@ class WorksController < ApplicationController
   end
 
   # Renders the "step 0" information page before creating a new dataset
-  def new; end
+  def new
+    render "new_submission"
+  end
 
   # Creates the new dataset
   def new_submission
-    byebug
     default_collection_id = current_user.default_collection.id
     datacite_resource = datacite_resource_from_form
     work = Work.create_dataset(datacite_resource.main_title, current_user.id, default_collection_id, datacite_resource)
@@ -216,8 +217,8 @@ class WorksController < ApplicationController
       resource = PULDatacite::Resource.new
 
       resource.description = params["description"]
-      resource.publisher = params["publisher"]
-      resource.publication_year = params["publication_year"]
+      resource.publisher = params["publisher"] if params["publisher"].present?
+      resource.publication_year = params["publication_year"] if params["publication_year"].present?
 
       # Process the titles
       resource.titles << PULDatacite::Title.new(title: params["title_main"])

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -50,7 +50,7 @@
 
 <% if @my_dashboard %>
   <div class="text-left dashboard-options">
-    <%= link_to "Submit New", work_new_submission_path, class: "btn btn-primary", :role => "button", title: "Start the process to deposit a new dataset" %>
+    <%= link_to "Submit New", new_work_path, class: "btn btn-primary", :role => "button", title: "Start the process to deposit a new dataset" %>
   </div>
 <% else %>
   <% if @can_edit %>

--- a/app/views/works/_edit_javascript.html.erb
+++ b/app/views/works/_edit_javascript.html.erb
@@ -201,6 +201,7 @@
       return false;
     });
 
+    debugger;
     if ($(".creator-data").length ==0) {
       // Add an empty creator for the use to fill it out
       var num = incrementCounter("#creator_count");

--- a/app/views/works/_edit_javascript.html.erb
+++ b/app/views/works/_edit_javascript.html.erb
@@ -144,6 +144,18 @@
       return null;
     }
 
+    // Returns true if there is at least one creator with information
+    var hasCreators = function() {
+      var i;
+      var rows = $(".creators-table-row");
+      for(i = 0; i < rows.length; i++) {
+        if (!isEmptyRow(rows[i].id)) {
+          return true;
+        }
+      };
+      return false;
+    }
+
     // Sets the values of a creator given a rowId
     var setCreatorValues = function(rowId, orcid, givenName, familyName) {
       var suffix = rowId.replace("creator_row_", "");
@@ -181,6 +193,29 @@
       updateCreatorsSequence();
     });
 
+    // Client side validations before allowing user to create the dataset.
+    $("#btn-create-new").on("click", function(el) {
+      var title = $("#title_main").val() || "";
+      var status = true;
+
+      $("#title-required-message").addClass("hidden");
+      $("#creators-required-message").addClass("hidden");
+
+      if (!hasCreators()) {
+        $("#" + findEmptyCreator()).focus();
+        $("#creators-required-message").removeClass("hidden");
+        status = false;
+      }
+
+      if (title.trim() == "") {
+        $("#title_main").focus();
+        $("#title-required-message").removeClass("hidden");
+        status = false;
+      }
+
+      return status;
+    });
+
     // Delete button for creators.
     //
     // Notice the use of $(document).on("click", selector, ...) instead of the
@@ -201,7 +236,6 @@
       return false;
     });
 
-    debugger;
     if ($(".creator-data").length ==0) {
       // Add an empty creator for the use to fill it out
       var num = incrementCounter("#creator_count");

--- a/app/views/works/_form_hidden_fields.html.erb
+++ b/app/views/works/_form_hidden_fields.html.erb
@@ -4,9 +4,9 @@
   initially and how many are added on the fly. This helps to process the data when the form
   is submitted.
   -->
-  <input type="text" id="existing_title_count" name="existing_title_count" value="<%= @work.datacite_resource.titles.count %>" class="hidden" />
+  <input type="text" id="existing_title_count" name="existing_title_count" value="<%= @work&.datacite_resource&.titles&.count %>" class="hidden" />
   <input type="text" id="new_title_count" name="new_title_count" value="0" class="hidden" />
-  <input type="text" id="creator_count" name="creator_count" value="<%= @work.datacite_resource.creators.count %>" class="hidden" />
+  <input type="text" id="creator_count" name="creator_count" value="<%= @work&.datacite_resource&.creators&.count %>" class="hidden" />
 
   <% if @wizard_mode %>
     <input type="text" id="wizard" name="wizard" value="true" class="hidden" />

--- a/app/views/works/_form_hidden_fields.html.erb
+++ b/app/views/works/_form_hidden_fields.html.erb
@@ -4,9 +4,9 @@
   initially and how many are added on the fly. This helps to process the data when the form
   is submitted.
   -->
-  <input type="text" id="existing_title_count" name="existing_title_count" value="<%= @work&.datacite_resource&.titles&.count %>" class="hidden" />
+  <input type="text" id="existing_title_count" name="existing_title_count" value="<%= @work&.datacite_resource&.titles&.count || 0 %>" class="hidden" />
   <input type="text" id="new_title_count" name="new_title_count" value="0" class="hidden" />
-  <input type="text" id="creator_count" name="creator_count" value="<%= @work&.datacite_resource&.creators&.count %>" class="hidden" />
+  <input type="text" id="creator_count" name="creator_count" value="<%= @work&.datacite_resource&.creators&.count || 0%>" class="hidden" />
 
   <% if @wizard_mode %>
     <input type="text" id="wizard" name="wizard" value="true" class="hidden" />

--- a/app/views/works/_required_creators_table.html.erb
+++ b/app/views/works/_required_creators_table.html.erb
@@ -1,6 +1,9 @@
 <!-- Creators section -->
 <div class="section-title">
   <b>Creator(s)<span class="required-field" title="At least one creator must be indicated">*</span></b>
+  <span id="creators-required-message" class="hidden">
+    <i class="bi bi-exclamation-diamond-fill required-field"></i>&nbsp;Must provide at least one creator
+  </span>
 </div>
 
 <!--

--- a/app/views/works/_required_creators_table.html.erb
+++ b/app/views/works/_required_creators_table.html.erb
@@ -1,0 +1,41 @@
+<!-- Creators section -->
+<div class="section-title">
+  <b>Creator(s)<span class="required-field" title="At least one creator must be indicated">*</span></b>
+</div>
+
+<!--
+  Render the list of creators a hidden SPANs that are then added below
+  the HTML TABLE via JavaScript. This is so that we have a single way
+  of rendering creators already on the record *and* creators added
+  on the fly.
+-->
+<table id="creators-table">
+  <tbody id="creators-table-sortable">
+    <tr class="header-row">
+      <th>ORCID</th>
+      <th>Given name</th>
+      <th>Family name</th>
+      <th>&nbsp;</th> <!-- move icon-->
+      <th>&nbsp;</th> <!-- delete icon-->
+    </tr>
+  </tbody>
+</table>
+
+<% if @work %>
+  <% @work.datacite_resource.creators.each_with_index do |creator, i| %>
+  <span class="hidden creator-data"
+    data-num="<%= i + 1 %>"
+    data-orcid="<%= creator.orcid %>"
+    data-given-name="<%= creator.given_name %>"
+    data-family-name="<%= creator.family_name %>"
+    data-sequence="<%= creator.sequence %>"
+    ></span>
+  <% end %>
+<% end %>
+
+<!-- Let the user add new creators -->
+<div>
+  <%= link_to "Add Another Creator", "#", id: "btn-add-creator", class: "btn btn-secondary" %>
+  <%= link_to "Add me as a Creator", "#", id: "btn-add-me-creator", class: "btn btn-secondary" %>
+</div>
+

--- a/app/views/works/_required_form.html.erb
+++ b/app/views/works/_required_form.html.erb
@@ -13,33 +13,7 @@
   </div>
 <% end %>
 
-<!-- Render the main title (notice that we don't display a dropdown for this title) -->
-<div class="field">
-  Title:<span class="required-field">*</span><br>
-  <input type="text" id="title_main" name="title_main" class="input-text-long" value="<%= @work.datacite_resource.main_title %>" />
-  <span>
-    <a id="btn-add-title" class="add-title-button" href="#" title="Add an additional title for this dataset, like a subtitle or a translated title">
-      <i class="bi bi-plus-circle"></i>
-    </a>
-  </span>
-</div>
-
-<!-- Render other titles in the record -->
-<% @work.datacite_resource.other_titles.each_with_index do |title, i| %>
-  <div class="field">
-    <!-- todo: this should go into a helper -->
-    <select id="title_type_<%= i + 1 %>" name="title_type_<%= i + 1 %>">
-      <option value="AlternativeTitle" <%= title.title_type == "AlternativeTitle" ? "selected" : "" %>>Alternative Title</option>
-      <option value="Subtitle" <%= title.title_type == "Subtitle" ? "selected" : "" %> >Subtitle</option>
-      <option value="TranslatedTitle" <%= title.title_type == "TranslatedTitle" ? "selected" : "" %>>Translated Title</option>
-      <option value="Other" <%= title.title_type == "Other" ? "selected" : "" %>>Other Title</option>
-    </select>
-    <br>
-    <input type="text" id="title_<%= i + 1 %>" name="title_<%= i + 1 %>" value="<%= title.title %>" class="input-text-long" />
-  </div>
-<% end %>
-
-<div id="new-titles-anchor"></div>
+<%= render(partial: 'works/required_title', locals: {allow_many: true}) %>
 
 <!-- Description (one for now)-->
 <div class="field">
@@ -47,43 +21,6 @@
   <textarea type="text" id="description" name="description" class="input-text-long" rows="5" cols="120"><%= @work.datacite_resource.description %></textarea>
 </div>
 
-<!-- Creators section -->
-<div class="section-title">
-  <b>Creator(s)<span class="required-field" title="At least one creator must be indicated">*</span></b>
-</div>
-
-<!--
-  Render the list of creators a hidden SPANs that are then added below
-  the HTML TABLE via JavaScript. This is so that we have a single way
-  of rendering creators already on the record *and* creators added
-  on the fly.
--->
-<table id="creators-table">
-  <tbody id="creators-table-sortable">
-    <tr class="header-row">
-      <th>ORCID</th>
-      <th>Given name</th>
-      <th>Family name</th>
-      <th>&nbsp;</th> <!-- move icon-->
-      <th>&nbsp;</th> <!-- delete icon-->
-    </tr>
-  </tbody>
-</table>
-
-<% @work.datacite_resource.creators.each_with_index do |creator, i| %>
-<span class="hidden creator-data"
-  data-num="<%= i + 1 %>"
-  data-orcid="<%= creator.orcid %>"
-  data-given-name="<%= creator.given_name %>"
-  data-family-name="<%= creator.family_name %>"
-  data-sequence="<%= creator.sequence %>"
-  ></span>
-<% end %>
-
-<!-- Let the user add new creators -->
-<div>
-  <%= link_to "Add Another Creator", "#", id: "btn-add-creator", class: "btn btn-secondary" %>
-  <%= link_to "Add me as a Creator", "#", id: "btn-add-me-creator", class: "btn btn-secondary" %>
-</div>
+<%= render(partial: 'works/required_creators_table') %>
 
 <br />

--- a/app/views/works/_required_title.html.erb
+++ b/app/views/works/_required_title.html.erb
@@ -1,6 +1,10 @@
 <!-- Render the main title (notice that we don't display a dropdown for this title) -->
 <div class="field">
-  Title:<span class="required-field">*</span><br>
+  Title:<span class="required-field" title="Title for your submission must be indicated">*</span>
+  <span id="title-required-message" class="hidden">
+    <i class="bi bi-exclamation-diamond-fill required-field"></i>&nbsp;Must provide a title
+  </span>
+  <br>
   <input type="text" id="title_main" name="title_main" class="input-text-long" value="<%= @work&.datacite_resource&.main_title %>" />
   <% if allow_many %>
     <span>

--- a/app/views/works/_required_title.html.erb
+++ b/app/views/works/_required_title.html.erb
@@ -1,0 +1,31 @@
+<!-- Render the main title (notice that we don't display a dropdown for this title) -->
+<div class="field">
+  Title:<span class="required-field">*</span><br>
+  <input type="text" id="title_main" name="title_main" class="input-text-long" value="<%= @work&.datacite_resource&.main_title %>" />
+  <% if allow_many %>
+    <span>
+      <a id="btn-add-title" class="add-title-button" href="#" title="Add an additional title for this dataset, like a subtitle or a translated title">
+        <i class="bi bi-plus-circle"></i>
+      </a>
+    </span>
+  <% end %>
+</div>
+
+<!-- Render other titles in the record -->
+<% if @work %>
+  <% @work.datacite_resource.other_titles.each_with_index do |title, i| %>
+    <div class="field">
+      <!-- todo: this should go into a helper -->
+      <select id="title_type_<%= i + 1 %>" name="title_type_<%= i + 1 %>">
+        <option value="AlternativeTitle" <%= title.title_type == "AlternativeTitle" ? "selected" : "" %>>Alternative Title</option>
+        <option value="Subtitle" <%= title.title_type == "Subtitle" ? "selected" : "" %> >Subtitle</option>
+        <option value="TranslatedTitle" <%= title.title_type == "TranslatedTitle" ? "selected" : "" %>>Translated Title</option>
+        <option value="Other" <%= title.title_type == "Other" ? "selected" : "" %>>Other Title</option>
+      </select>
+      <br>
+      <input type="text" id="title_<%= i + 1 %>" name="title_<%= i + 1 %>" value="<%= title.title %>" class="input-text-long" />
+    </div>
+  <% end %>
+<% end %>
+
+<div id="new-titles-anchor"></div>

--- a/app/views/works/new_submission.html.erb
+++ b/app/views/works/new_submission.html.erb
@@ -33,19 +33,20 @@
 
   <p>By starting this new submission, a draft DOI will be reserved for your deposit.</p>
 
-  <p>If you have already started a submission for this deposit, then please go back
-  to the home page and complete the existing submission. If you would like to talk to a
-  specialist about your submission, we may be reached at
-  <a href="mailto:prds@princeton.edu">prds@princeton.edu</a>
+  <p>If you have already started a submission for this deposit, then please
+    <a href="<%= user_path(current_user) %>">go your dashboard</a> and complete
+    the existing submission. If you would like to talk to a specialist about
+    your submission, we may be reached at <a href="mailto:prds@princeton.edu">prds@princeton.edu</a>
   </p>
 
   <%= form_tag(action: "new_submission") do %>
     <%= render(partial: 'works/required_title', locals: {allow_many: false}) %>
     <%= render(partial: 'works/required_creators_table') %>
     <%= render 'form_hidden_fields' %>
-    <div>
+    <hr />
+    <div class="actions">
       <%= link_to "Go Back", root_path, class: "btn btn-secondary" %>
-      <%= submit_tag "Create New", class: "btn btn-primary wizard-next-button" %>
+      <%= submit_tag "Create New", class: "btn btn-primary wizard-next-button", id: "btn-create-new" %>
     </div>
   <% end %>
 </div>

--- a/app/views/works/new_submission.html.erb
+++ b/app/views/works/new_submission.html.erb
@@ -2,6 +2,29 @@
   p {
     font-size: larger;
   }
+
+  .input-text-long {
+    width: 700px;
+  }
+
+  .input-text-year {
+    width: 70px;
+  }
+
+  .section-title {
+    padding-top: 20px;
+  }
+
+  .doi-text {
+    font-size: large;
+    font-style: italic;
+  }
+
+  .add-title-button {
+    color: #0c68f0;
+    font-weight: bold;
+    font-size: 22px;
+  }
 </style>
 
 <div class="wizard-area">
@@ -16,9 +39,15 @@
   <a href="mailto:prds@princeton.edu">prds@princeton.edu</a>
   </p>
 
-  <div>
-    <%= link_to "Go Back", root_path, class: "btn btn-secondary" %>
-    <%= link_to "Create New", new_work_path, class: "btn btn-primary wizard-next-button" %>
-  </div>
+  <%= form_tag(action: "new_submission") do %>
+    <%= render(partial: 'works/required_title', locals: {allow_many: false}) %>
+    <%= render(partial: 'works/required_creators_table') %>
+    <%= render 'form_hidden_fields' %>
+    <div>
+      <%= link_to "Go Back", root_path, class: "btn btn-secondary" %>
+      <%= submit_tag "Create New", class: "btn btn-primary wizard-next-button" %>
+    </div>
+  <% end %>
 </div>
 
+<%= render 'edit_javascript' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
     get "sign_out", to: "devise/sessions#destroy", as: :destroy_user_session
   end
 
-  get "works/new-submission", to: "works#new_submission", as: :work_new_submission
+  post "works/new-submission", to: "works#new_submission", as: :work_new_submission
   get "works/:id/attachment-select", to: "works#attachment_select", as: :work_attachment_select
   post "works/:id/attachment-select", to: "works#attachment_selected", as: :work_attachment_selected
   patch "works/:id/file-upload", to: "works#file_uploaded", as: :work_file_uploaded

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -34,13 +34,13 @@ RSpec.describe WorksController, mock_ezid_api: true do
 
     it "renders the new submission wizard' step 0" do
       sign_in user
-      get :new_submission # this should be :new ???
+      get :new
       expect(response).to render_template("new_submission")
     end
 
     it "renders the edit page when creating a new dataset" do
       sign_in user
-      post :new
+      post :new_submission
       expect(response.status).to be 302
       expect(response.location.start_with?("http://test.host/works/")).to be true
     end

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe WorksController, mock_ezid_api: true do
 
     it "renders the new submission wizard' step 0" do
       sign_in user
-      get :new_submission
+      get :new_submission # this should be :new ???
       expect(response).to render_template("new_submission")
     end
 

--- a/spec/system/work_spec.rb
+++ b/spec/system/work_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Creating and updating works", type: :system, mock_ezid_api: true
     sign_in user
     visit new_work_path
     fill_in "title_main", with: ""
-    click_on "Save Work"
+    click_on "Create New"
     expect(page).to have_content "Must provide a title"
   end
 


### PR DESCRIPTION
Updated the Step 0 in the wizard to submit a new dataset to allow/force the user to indicate the *Title* and at least one *Creator* as requested on #199. This new workflow has the advantage that we will have at least two basic bits of information before we mint a DOI.

The following screenshots show the general workflow.

![step0](https://user-images.githubusercontent.com/568286/181829087-dbe37a05-0c3e-4b57-ab42-8186891990ea.png)


![step1](https://user-images.githubusercontent.com/568286/181829099-1e50be62-bdbd-4b6e-918f-0be70035fa65.png)

Closes #199 