### PR TITLE
Adding sending of XML to datacite

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem "friendly_id", "~> 5.4.0"
 
 gem "faraday"
 
-gem "datacite"
+gem "datacite", github: "sul-dlss/datacite-ruby", branch: "main"
 
 gem "kramdown"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,17 @@ GIT
       hashie (~> 3.4, >= 3.4.3)
       nokogiri
 
+GIT
+  remote: https://github.com/sul-dlss/datacite-ruby.git
+  revision: 3b08b70e81320975d1c78509e218d27b2d2a5e39
+  branch: main
+  specs:
+    datacite (0.3.0)
+      dry-monads (~> 1.3)
+      faraday (~> 2.0)
+      json_schema (~> 0.21.0)
+      zeitwerk (~> 2.4)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -152,11 +163,6 @@ GEM
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
-    datacite (0.3.0)
-      dry-monads (~> 1.3)
-      faraday (~> 2.0)
-      json_schema (~> 0.21.0)
-      zeitwerk (~> 2.4)
     datacite-mapping (0.4.1)
       typesafe_enum (~> 0.1, >= 0.1.7)
       xml-mapping_extensions (~> 0.4, >= 0.4.7)
@@ -170,7 +176,7 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
     docile (1.4.0)
-    dry-core (0.7.1)
+    dry-core (0.8.1)
       concurrent-ruby (~> 1.0)
     dry-monads (1.4.0)
       concurrent-ruby (~> 1.0)
@@ -458,7 +464,7 @@ DEPENDENCIES
   capybara (>= 3.26)
   coveralls_reborn (~> 0.24)
   database_cleaner-active_record
-  datacite
+  datacite!
   datacite-mapping
   devise
   ezid-client!


### PR DESCRIPTION
Updated the gem to allow for xml format, which is why we are pointing at main.

![Screen Shot 2022-08-02 at 11 14 15 AM](https://user-images.githubusercontent.com/1599081/182410394-d9a5b61c-941c-4bde-a813-4391c86e9738.png)

Draft PR on gem, which allowed for the above to be published via xml: https://github.com/sul-dlss/datacite-ruby/pull/18

Tested by creating a new item via `rspec spec/models/doi_spec.rb:68` and then running `rspec spec/models/doi_spec.rb:142` with the new id.  (Connected to the real server)
