### PR TITLE
Updating new notification count to be one sql query

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -313,11 +313,10 @@ class Work < ApplicationRecord
   end
 
   def new_notification_count_for_user(user_id)
-    count = 0
-    activities.each do |activity|
-      count += WorkActivityNotification.where(user_id: user_id, work_activity_id: activity.id, read_at: nil).count
-    end
-    count
+    WorkActivityNotification.joins(:work_activity)
+                            .where(user_id: user_id, read_at: nil)
+                            .where(work_activity: { work_id: id })
+                            .count
   end
 
   # Marks as read the notifications for the given user_id in this work.

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -13,6 +13,12 @@ RSpec.describe Work, type: :model, mock_ezid_api: true do
     datacite_resource.creators << PULDatacite::Creator.new_person("Harriet", "Tubman")
     described_class.create_dataset("test title", user.id, collection.id, datacite_resource)
   end
+  let(:work2) do
+    datacite_resource = PULDatacite::Resource.new
+    datacite_resource.description = "description of the second test dataset"
+    datacite_resource.creators << PULDatacite::Creator.new_person("Harriet", "Tubman")
+    described_class.create_dataset("second test title", user.id, collection.id, datacite_resource)
+  end
 
   let(:lib_user) do
     user = FactoryBot.create :user
@@ -271,6 +277,7 @@ RSpec.describe Work, type: :model, mock_ezid_api: true do
       expect(work.new_notification_count_for_user(curator_user.id)).to eq 0
 
       work.add_comment("taggging @#{curator_user.uid}", user)
+      work2.add_comment("taggging @#{curator_user.uid}", user)
       expect(work.new_notification_count_for_user(user.id)).to eq 0
       expect(work.new_notification_count_for_user(curator_user.id)).to eq 1
 


### PR DESCRIPTION
I believe this is easier to read, but I would be happy to hear otherwise.
It should be more performant with al the calculations occurring in one database call.