### PR TITLE
Updating assm callback to after_event instead of after_transition

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -27,7 +27,7 @@ class Work < ApplicationRecord
       transitions from: [:withdrawn, :awaiting_approval], to: :awaiting_approval
     end
 
-    after_all_transitions :track_state_change
+    after_all_events :track_state_change
   end
 
   class << self

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -423,6 +423,7 @@ RSpec.describe WorksController, mock_ezid_api: true do
       post :approve, params: { id: work.id }
       expect(response.status).to be 302
       expect(response.location).to eq "http://test.host/works/#{work.id}"
+      expect(work.reload).to be_approved
     end
 
     it "handles withdraw" do
@@ -430,13 +431,16 @@ RSpec.describe WorksController, mock_ezid_api: true do
       post :withdraw, params: { id: work.id }
       expect(response.status).to be 302
       expect(response.location).to eq "http://test.host/works/#{work.id}"
+      expect(work.reload).to be_withdrawn
     end
 
     it "handles resubmit" do
       sign_in user
+      work.withdraw!(user)
       post :resubmit, params: { id: work.id }
       expect(response.status).to be 302
       expect(response.location).to eq "http://test.host/works/#{work.id}"
+      expect(work.reload).to be_awaiting_approval
     end
 
     it "handles the show page" do


### PR DESCRIPTION
After the event the work is is the correct state, but after transition the model has not yet been updated
fixes #295