### PR TITLE
Removing the title field from the work object

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -21,7 +21,7 @@ class WorksController < ApplicationController
   def new_submission
     default_collection_id = current_user.default_collection.id
     resource = resource_from_form
-    work = Work.create_dataset(resource.main_title, current_user.id, default_collection_id, resource)
+    work = Work.create_dataset(current_user.id, default_collection_id, resource)
     redirect_to edit_work_path(work, wizard: true)
   end
 
@@ -67,11 +67,9 @@ class WorksController < ApplicationController
                                 updated_uploads
                               end
 
-    title_param = params[:title_main]
     collection_id_param = params[:collection_id]
 
     updates = {
-      title: title_param,
       collection_id: collection_id_param,
       metadata: resource_from_form.to_json,
       deposit_uploads: updated_deposit_uploads

--- a/app/models/pul_datacite.rb
+++ b/app/models/pul_datacite.rb
@@ -5,13 +5,13 @@ module PULDatacite
   class Resource
     attr_accessor :identifier, :identifier_type, :creators, :titles, :publisher, :publication_year, :resource_type, :description
 
-    def initialize(identifier: nil, identifier_type: nil, title: nil, resource_type: nil)
+    def initialize(identifier: nil, identifier_type: nil, title: nil, resource_type: nil, creators: [], description: nil)
       @identifier = identifier
       @identifier_type = identifier_type
       @titles = []
       @titles << PULDatacite::Title.new(title: title) unless title.nil?
-      @description = nil
-      @creators = []
+      @description = description
+      @creators = creators
       @resource_type = resource_type || "Dataset"
       @publisher = "Princeton University"
       @publication_year = Time.zone.today.year
@@ -97,6 +97,9 @@ module PULDatacite
     def self.new_from_json(json_string)
       resource = PULDatacite::Resource.new
       hash = json_string.blank? ? {} : JSON.parse(json_string)
+
+      resource.identifier = hash["identifier"]
+      resource.identifier_type = hash["identifier_type"]
 
       resource.description = hash["description"]
 

--- a/db/migrate/20220816121418_work_remove_title.rb
+++ b/db/migrate/20220816121418_work_remove_title.rb
@@ -1,0 +1,5 @@
+class WorkRemoveTitle < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :works, :title
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_15_180808) do
+ActiveRecord::Schema.define(version: 2022_08_16_121418) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -117,7 +117,6 @@ ActiveRecord::Schema.define(version: 2022_08_15_180808) do
   end
 
   create_table "works", force: :cascade do |t|
-    t.string "title"
     t.string "work_type"
     t.string "state"
     t.integer "collection_id"

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -11,12 +11,8 @@ RSpec.describe WorksController, mock_ezid_api: true do
   let(:user) { FactoryBot.create(:user) }
   let(:curator) { FactoryBot.create(:user) }
   let(:collection) { Collection.first }
-  let(:work) do
-    resource = PULDatacite::Resource.new
-    resource.creators << PULDatacite::Creator.new_person("Harriet", "Tubman")
-    resource.description = "description of the test dataset"
-    Work.create_dataset("test dataset", user.id, collection.id, resource)
-  end
+  let(:resource) { FactoryBot.build :resource }
+  let(:work) { Work.create_dataset(user.id, collection.id, resource) }
 
   context "valid user login" do
     it "handles the index page" do

--- a/spec/factories/resource.rb
+++ b/spec/factories/resource.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :resource, class: "PULDatacite::Resource" do
+    transient do
+      title { "test title" }
+    end
+    description { "description of the test dataset" }
+    creators { [PULDatacite::Creator.new_person("Harriet", "Tubman")] }
+    titles { [PULDatacite::Title.new(title: title)] }
+  end
+end

--- a/spec/factories/work.rb
+++ b/spec/factories/work.rb
@@ -3,7 +3,6 @@
 FactoryBot.define do
   factory :work do
     factory :shakespeare_and_company_work do
-      title { "Shakespeare and Company Project Dataset: Lending Library Members, Books, Events" }
       collection { Collection.research_data }
       doi { "https://doi.org/10.34770/pe9w-x904" }
       ark { "ark:/88435/dsp01zc77st047" }
@@ -11,7 +10,7 @@ FactoryBot.define do
         {
           "identifier": doi,
           "identifier_type": "DOI",
-          "titles": [{ "title": "Shakespeare and Company Project Dataset: Lending Library Members, Books, Events", "title_type": "Main" }],
+          "titles": [{ "title": "Shakespeare and Company Project Dataset: Lending Library Members, Books, Events" }],
           "description": "All data is related to the Shakespeare and Company bookshop and lending library opened and operated by Sylvia Beach in Paris, 1919–1962.",
           "creators": [
             { "value": "Kotin, Joshua", "name_type": "Personal", "given_name": "Joshua", "family_name": "Kotin", "affiliations": [], "sequence": "1" }

--- a/spec/system/accessibility_spec.rb
+++ b/spec/system/accessibility_spec.rb
@@ -60,7 +60,7 @@ describe "application accessibility", type: :system, js: true do
       resource = PULDatacite::Resource.new(title: "Test dataset")
       resource.creators << PULDatacite::Creator.new_person("Harriet", "Tubman", "1234-5678-9012-3456")
       ark = "ark:/99999/dsp01qb98mj541"
-      work = Work.create_dataset("Test dataset", user.id, user.default_collection_id, resource, ark)
+      work = Work.create_dataset(user.id, user.default_collection_id, resource, ark)
       visit work_path(work)
       expect(page).to be_axe_clean
         .according_to(:wcag2a, :wcag2aa, :wcag21a, :wcag21aa, :section508)

--- a/spec/system/work_spec.rb
+++ b/spec/system/work_spec.rb
@@ -37,9 +37,8 @@ RSpec.describe "Creating and updating works", type: :system, mock_ezid_api: true
 
   it "Renders ORCID links for creators", js: true do
     stub_s3
-    resource = PULDatacite::Resource.new(title: "Test dataset")
-    resource.creators << PULDatacite::Creator.new_person("Harriet", "Tubman", "1234-5678-9012-3456")
-    work = Work.create_dataset("Test dataset", user.id, user.default_collection_id, resource)
+    resource = FactoryBot.build(:resource, creators: [PULDatacite::Creator.new_person("Harriet", "Tubman", "1234-5678-9012-3456")])
+    work = Work.create_dataset(user.id, user.default_collection_id, resource)
 
     sign_in user
     visit work_path(work)
@@ -47,9 +46,7 @@ RSpec.describe "Creating and updating works", type: :system, mock_ezid_api: true
   end
 
   it "Renders in wizard mode when requested", js: true do
-    resource = PULDatacite::Resource.new(title: "Test dataset")
-    resource.creators << PULDatacite::Creator.new_person("Harriet", "Tubman", "1234-5678-9012-3456")
-    work = Work.create_dataset("Test dataset", user.id, user.default_collection_id, resource)
+    work = Work.create_dataset(user.id, user.default_collection_id, FactoryBot.build(:resource))
 
     sign_in user
     visit edit_work_path(work, wizard: true)
@@ -57,13 +54,8 @@ RSpec.describe "Creating and updating works", type: :system, mock_ezid_api: true
   end
 
   context "datacite record" do
-    let(:creator) { PULDatacite::Creator.new_person("Harriet", "Tubman", "1234-5678-9012-3456") }
-    let(:resource) do
-      resource = PULDatacite::Resource.new(title: "Test dataset")
-      resource.creators << creator
-      resource
-    end
-    let(:work) { Work.create_dataset("Test dataset", user.id, user.default_collection_id, resource) }
+    let(:resource) { FactoryBot.build :resource }
+    let(:work) { Work.create_dataset(user.id, user.default_collection_id, resource) }
 
     before do
       stub_s3

--- a/spec/views/works/file_upload.html.erb_spec.rb
+++ b/spec/views/works/file_upload.html.erb_spec.rb
@@ -11,11 +11,9 @@ describe "works/file_upload.html.erb", mock_ezid_api: true do
     stub_datacite(host: "api.datacite.org", body: datacite_register_body(prefix: "10.34770"))
   end
 
+  let(:resource) { FactoryBot.build :resource }
   let(:work) do
-    resource = PULDatacite::Resource.new
-    resource.creators << PULDatacite::Creator.new_person("Harriet", "Tubman")
-    resource.description = "description of the test dataset"
-    Work.create_dataset("test dataset", user.id, collection.id, resource)
+    Work.create_dataset(user.id, collection.id, resource)
   end
 
   it "supports multiple file uploads" do


### PR DESCRIPTION
It already lives in the json metadata.  Having it in two places is causing confusion.
fixes #274