### PR TITLE
Should not directly between withdrawn and awaiting approval

### DIFF
--- a/docs/work_states.md
+++ b/docs/work_states.md
@@ -52,7 +52,7 @@ stateDiagram-v2
     await --> await
     await --> approve
     await --> withdrawn
-    withdrawn --> await
+    withdrawn --> draft
     approve --> withdrawn
     draft --> withdrawn
     withdrawn --> tombstone


### PR DESCRIPTION
It is not safe to go directly between withdrawn and awaiting approval.  It is possible for a withdrawn item to have come from a draft state, so we should go back to draft.