### PR TITLE
Renaming PULDatacite to PDCMetadata

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -213,12 +213,12 @@ class WorksController < ApplicationController
 
     def new_creator(given_name, family_name, orcid, sequence)
       return if family_name.blank? && given_name.blank? && orcid.blank?
-      PULDatacite::Creator.new_person(given_name, family_name, orcid, sequence)
+      PDCMetadata::Creator.new_person(given_name, family_name, orcid, sequence)
     end
 
     # rubocop:disable Metrics/CyclomaticComplexity:
     def resource_from_form
-      resource = PULDatacite::Resource.new
+      resource = PDCMetadata::Resource.new
       resource.doi = params["doi"] if params["doi"].present?
       resource.ark = params["ark"] if params["ark"].present?
       resource.description = params["description"]
@@ -226,16 +226,16 @@ class WorksController < ApplicationController
       resource.publication_year = params["publication_year"] if params["publication_year"].present?
 
       # Process the titles
-      resource.titles << PULDatacite::Title.new(title: params["title_main"])
+      resource.titles << PDCMetadata::Title.new(title: params["title_main"])
       for i in 1..params["existing_title_count"].to_i do
         if params["title_#{i}"].present?
-          resource.titles << PULDatacite::Title.new(title: params["title_#{i}"], title_type: params["title_type_#{i}"])
+          resource.titles << PDCMetadata::Title.new(title: params["title_#{i}"], title_type: params["title_type_#{i}"])
         end
       end
 
       for i in 1..params["new_title_count"].to_i do
         if params["new_title_#{i}"].present?
-          resource.titles << PULDatacite::Title.new(title: params["new_title_#{i}"], title_type: params["new_title_type_#{i}"])
+          resource.titles << PDCMetadata::Title.new(title: params["new_title_#{i}"], title_type: params["new_title_type_#{i}"])
         end
       end
 

--- a/app/models/pdc_metadata/resource.rb
+++ b/app/models/pdc_metadata/resource.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-module PULDatacite
+module PDCMetadata
   # Represents a PUL Datacite resource
   # https://support.datacite.org/docs/datacite-metadata-schema-v44-properties-overview
   #
@@ -10,7 +10,7 @@ module PULDatacite
 
     def initialize(doi: nil, title: nil, resource_type: nil, creators: [], description: nil)
       @titles = []
-      @titles << PULDatacite::Title.new(title: title) unless title.nil?
+      @titles << PDCMetadata::Title.new(title: title) unless title.nil?
       @description = description
       @creators = creators
       @resource_type = resource_type || "Dataset"
@@ -103,11 +103,11 @@ module PULDatacite
     # rubocop:enable Metrics/BlockLength
     # rubocop:enable Metrics/AbcSize
 
-    # Creates a PULDatacite::Resource from a JSON string
+    # Creates a PDCMetadata::Resource from a JSON string
     # rubocop:disable Metrics/MethodLength
     # rubocop:disable Metrics/AbcSize
     def self.new_from_json(json_string)
-      resource = PULDatacite::Resource.new
+      resource = PDCMetadata::Resource.new
       hash = json_string.blank? ? {} : JSON.parse(json_string)
 
       resource.doi = hash["doi"]
@@ -115,7 +115,7 @@ module PULDatacite
       resource.description = hash["description"]
 
       hash["titles"]&.each do |title|
-        resource.titles << PULDatacite::Title.new(title: title["title"], title_type: title["title_type"])
+        resource.titles << PDCMetadata::Title.new(title: title["title"], title_type: title["title_type"])
       end
 
       hash["creators"]&.each do |creator|
@@ -123,7 +123,7 @@ module PULDatacite
         family_name = creator["family_name"]
         orcid = creator.dig("name_identifier", "scheme") == "ORCID" ? creator.dig("name_identifier", "value") : nil
         sequence = (creator["sequence"] || "").to_i
-        resource.creators << PULDatacite::Creator.new_person(given_name, family_name, orcid, sequence)
+        resource.creators << PDCMetadata::Creator.new_person(given_name, family_name, orcid, sequence)
       end
       resource.creators.sort_by!(&:sequence)
 

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -48,8 +48,8 @@ class Work < ApplicationRecord
 
   class << self
     def create_skeleton(title, user_id, collection_id, work_type, profile)
-      resource = PULDatacite::Resource.new(title: title,
-                                           creators: [PULDatacite::Creator.new_person("", "skeleton", "", 0)],
+      resource = PDCMetadata::Resource.new(title: title,
+                                           creators: [PDCMetadata::Creator.new_person("", "skeleton", "", 0)],
                                            description: title)
       work = Work.new(
         created_by_user_id: user_id,
@@ -190,7 +190,7 @@ class Work < ApplicationRecord
   end
 
   def resource
-    @resource ||= PULDatacite::Resource.new_from_json(metadata)
+    @resource ||= PDCMetadata::Resource.new_from_json(metadata)
   end
 
   def ark_url

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -17,4 +17,5 @@
 # end
 ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym "PUL"
+  inflect.acronym "PDC"
 end

--- a/spec/factories/resource.rb
+++ b/spec/factories/resource.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :resource, class: "PULDatacite::Resource" do
+  factory :resource, class: "PDCMetadata::Resource" do
     transient do
       title { FFaker::Book.title }
     end
@@ -12,7 +12,7 @@ FactoryBot.define do
     publisher { "Princeton University" }
     publication_year { "2020" }
     description { FFaker::Book.description }
-    creators { [PULDatacite::Creator.new_person(FFaker::Name.first_name, FFaker::Name.last_name)] }
-    titles { [PULDatacite::Title.new(title: title)] }
+    creators { [PDCMetadata::Creator.new_person(FFaker::Name.first_name, FFaker::Name.last_name)] }
+    titles { [PDCMetadata::Title.new(title: title)] }
   end
 end

--- a/spec/models/pdc_metadata/resource_spec.rb
+++ b/spec/models/pdc_metadata/resource_spec.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 require "rails_helper"
 
-RSpec.describe PULDatacite::Resource, type: :model do
+RSpec.describe PDCMetadata::Resource, type: :model do
   let(:creatorPerson) do
-    PULDatacite::Creator.new_person("Elizabeth", "Miller", "1234-5678-9012-1234")
+    PDCMetadata::Creator.new_person("Elizabeth", "Miller", "1234-5678-9012-1234")
   end
 
   let(:creatorOrganization) do
-    org = PULDatacite::Creator.new(value: "Princeton University", name_type: "Organization")
-    org.affiliations << PULDatacite::Affiliation.new(value: "Some affiliation", identifier: "https://ror.org/04aj4c181", scheme: "ROR", scheme_uri: "https://ror.org/")
+    org = PDCMetadata::Creator.new(value: "Princeton University", name_type: "Organization")
+    org.affiliations << PDCMetadata::Affiliation.new(value: "Some affiliation", identifier: "https://ror.org/04aj4c181", scheme: "ROR", scheme_uri: "https://ror.org/")
     org
   end
 
@@ -29,7 +29,7 @@ RSpec.describe PULDatacite::Resource, type: :model do
   end
 
   it "supports more than one title" do
-    ds.titles << PULDatacite::Title.new(title: "hola mundo", title_type: "TranslatedTitle")
+    ds.titles << PDCMetadata::Title.new(title: "hola mundo", title_type: "TranslatedTitle")
     expect(ds.titles.count).to be 2
   end
 
@@ -43,7 +43,7 @@ RSpec.describe PULDatacite::Resource, type: :model do
     expect(creatorPerson.orcid).to eq "1234-5678-9012-1234"
     expect(creatorPerson.orcid_url).to eq "https://orcid.org/1234-5678-9012-1234"
 
-    no_orcid = PULDatacite::Creator.new_person("Elizabeth", "Miller")
+    no_orcid = PDCMetadata::Creator.new_person("Elizabeth", "Miller")
     expect(no_orcid.orcid).to be nil
   end
 end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Work, type: :model, mock_ezid_api: true do
 
   it "checks the format of the ORCID of the creators" do
     # Add a new creator with an incomplete ORCID
-    work.resource.creators << PULDatacite::Creator.new_person("Williams", "Serena", "1234-12")
+    work.resource.creators << PDCMetadata::Creator.new_person("Williams", "Serena", "1234-12")
     expect(work.save).to be false
     expect(work.errors.find { |error| error.type.include?("ORCID") }).to be_present
   end
@@ -53,7 +53,7 @@ RSpec.describe Work, type: :model, mock_ezid_api: true do
   end
 
   it "prevents datasets with no users" do
-    work = Work.new(collection: collection, metadata: PULDatacite::Resource.new.to_json)
+    work = Work.new(collection: collection, metadata: PDCMetadata::Resource.new.to_json)
     expect { work.draft! }.to raise_error AASM::InvalidTransition
   end
 

--- a/spec/system/accessibility_spec.rb
+++ b/spec/system/accessibility_spec.rb
@@ -57,8 +57,8 @@ describe "application accessibility", type: :system, js: true do
     it "complies with WCAG 2.0 AA and Section 508" do
       stub_datacite(host: "api.datacite.org", body: datacite_register_body(prefix: "10.34770"))
       stub_s3
-      resource = PULDatacite::Resource.new(title: "Test dataset")
-      resource.creators << PULDatacite::Creator.new_person("Harriet", "Tubman", "1234-5678-9012-3456")
+      resource = PDCMetadata::Resource.new(title: "Test dataset")
+      resource.creators << PDCMetadata::Creator.new_person("Harriet", "Tubman", "1234-5678-9012-3456")
       ark = "ark:/99999/dsp01qb98mj541"
       work = FactoryBot.create(:draft_work, created_by_user_id: user.id, collection_id: user.default_collection_id, ark: ark, resource: resource)
       visit work_path(work)

--- a/spec/system/work_spec.rb
+++ b/spec/system/work_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Creating and updating works", type: :system, mock_ezid_api: true
 
   it "Renders ORCID links for creators", js: true do
     stub_s3
-    resource = FactoryBot.build(:resource, creators: [PULDatacite::Creator.new_person("Harriet", "Tubman", "1234-5678-9012-3456")])
+    resource = FactoryBot.build(:resource, creators: [PDCMetadata::Creator.new_person("Harriet", "Tubman", "1234-5678-9012-3456")])
     work = FactoryBot.create(:draft_work, metadata: resource.to_json)
 
     sign_in user


### PR DESCRIPTION
This is just renaming the class and moving it to a directory.  To complete #275 more needs to be done, but I wanted to make the PRs easier to review
This was a basic search and replace of PULDatacite to PDCMetdata.