### PR TITLE
Fixes DOI value in old records

### DIFF
--- a/lib/tasks/works.rake
+++ b/lib/tasks/works.rake
@@ -12,7 +12,8 @@ namespace :works do
             puts "#{work.id} - #{work.errors.errors.map(&:type)}"
           end
         else
-          puts "#{work.id} - Can't be fixed"
+          work.doi = "10.80021/tbd"
+          puts "#{work.id} - Can't be fixed, try again? #{work.save}"
         end
       else
         puts "#{work.id} - OK"


### PR DESCRIPTION
Stubs a DOI value on records without one so they can be fixed with the rake task `transfer_doi_fix` that was added as part of PR https://github.com/pulibrary/pdc_describe/pull/316

DOI is always available in new records, but looks like at one point we had records without one.