### PR TITLE
Drop the work.doi and work.ark database columns

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -160,6 +160,14 @@ class Work < ApplicationRecord
     resource.main_title
   end
 
+  def doi
+    resource.doi
+  end
+
+  def ark
+    resource.ark
+  end
+
   def curator
     return nil if curator_user_id.nil?
     User.find(curator_user_id)

--- a/db/migrate/20220823094818_work_remove_doi_ark.rb
+++ b/db/migrate/20220823094818_work_remove_doi_ark.rb
@@ -1,0 +1,6 @@
+class WorkRemoveDoiArk < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :works, :doi
+    remove_column :works, :ark
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_18_110918) do
+ActiveRecord::Schema.define(version: 2022_08_23_094818) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -125,8 +125,6 @@ ActiveRecord::Schema.define(version: 2022_08_18_110918) do
     t.datetime "updated_at", precision: 6, null: false
     t.json "metadata"
     t.string "profile"
-    t.string "ark"
-    t.string "doi"
     t.text "location_notes"
     t.text "submission_notes"
     t.string "files_location"

--- a/spec/factories/work.rb
+++ b/spec/factories/work.rb
@@ -3,9 +3,8 @@
 FactoryBot.define do
   factory :work do
     factory :draft_work do
-      doi { "https://doi.org/10.34770/123-abc" }
       transient do
-        resource { FactoryBot.build :resource, doi: doi }
+        resource { FactoryBot.build :resource, doi: "https://doi.org/10.34770/123-abc" }
       end
       collection { Collection.research_data }
       state { "draft" }

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -6,8 +6,7 @@ RSpec.describe Work, type: :model, mock_ezid_api: true do
   let(:collection) { Collection.research_data }
   let(:user_other) { FactoryBot.create :user }
   let(:superadmin_user) { User.from_cas(OmniAuth::AuthHash.new(provider: "cas", uid: "fake1", extra: { mail: "fake@princeton.edu" })) }
-  let(:doi) { "https://doi.org/10.34770/0q6b-cj27" }
-  let(:work) { FactoryBot.create(:draft_work, doi: doi) }
+  let(:work) { FactoryBot.create(:draft_work) }
   let(:work2) { FactoryBot.create(:draft_work) }
 
   let(:lib_user) do
@@ -122,7 +121,7 @@ RSpec.describe Work, type: :model, mock_ezid_api: true do
     end
 
     it "updates the ARK metadata" do
-      work.ark = ezid
+      work.resource.ark = ezid
       work.save
       work.complete_submission!(user)
       stub_datacite_doi
@@ -131,7 +130,7 @@ RSpec.describe Work, type: :model, mock_ezid_api: true do
     end
 
     it "does not update the ARK metadata" do
-      work.ark = nil
+      work.resource.ark = nil
       work.save
       work.complete_submission!(user)
       stub_datacite_doi
@@ -169,7 +168,7 @@ RSpec.describe Work, type: :model, mock_ezid_api: true do
 
       it "does not mint a new ARK" do
         expect(work.persisted?).not_to be false
-        work.ark = ezid
+        work.resource.ark = ezid
         work.save
 
         expect(work.persisted?).to be true
@@ -186,7 +185,7 @@ RSpec.describe Work, type: :model, mock_ezid_api: true do
       it "raises an error" do
         expect(work.persisted?).not_to be false
         bad_ezid = "ark:/bad-99999/fk4tq65d6k"
-        work.ark = bad_ezid
+        work.resource.ark = bad_ezid
         expect { work.save! }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Invalid ARK provided for the Work: #{bad_ezid}")
       end
     end

--- a/spec/system/accessibility_spec.rb
+++ b/spec/system/accessibility_spec.rb
@@ -59,8 +59,8 @@ describe "application accessibility", type: :system, js: true do
       stub_s3
       resource = PDCMetadata::Resource.new(title: "Test dataset")
       resource.creators << PDCMetadata::Creator.new_person("Harriet", "Tubman", "1234-5678-9012-3456")
-      ark = "ark:/99999/dsp01qb98mj541"
-      work = FactoryBot.create(:draft_work, created_by_user_id: user.id, collection_id: user.default_collection_id, ark: ark, resource: resource)
+      resource.ark = "ark:/99999/dsp01qb98mj541"
+      work = FactoryBot.create(:draft_work, created_by_user_id: user.id, collection_id: user.default_collection_id, resource: resource)
       visit work_path(work)
       expect(page).to be_axe_clean
         .according_to(:wcag2a, :wcag2aa, :wcag21a, :wcag21aa, :section508)


### PR DESCRIPTION
Drop the work.doi and work.ark database columns since now we store the data as part of the JSON `resource` field. Aliased their getters in the work model (but not the assignments) and updated the tests