### PR TITLE
Use our new XML serialization

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -204,6 +204,7 @@ class WorksController < ApplicationController
   def datacite_validate
     @errors = []
     @work = Work.find(params[:id])
+    byebug
     datacite_xml = Nokogiri::XML(@work.resource.to_xml)
     schema_location = Rails.root.join("config", "schema")
     Dir.chdir(schema_location) do

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -204,7 +204,6 @@ class WorksController < ApplicationController
   def datacite_validate
     @errors = []
     @work = Work.find(params[:id])
-    byebug
     datacite_xml = Nokogiri::XML(@work.resource.to_xml)
     schema_location = Rails.root.join("config", "schema")
     Dir.chdir(schema_location) do

--- a/app/models/pdc_metadata/creator.rb
+++ b/app/models/pdc_metadata/creator.rb
@@ -46,20 +46,5 @@ module PDCMetadata
       end
       creator
     end
-
-    def to_xml(builder)
-      if name_type == "Personal"
-        builder.creator("nameType" => "Personal") do
-          builder.creatorName value
-          builder.givenName given_name
-          builder.familyName family_name
-          identifier&.to_xml(builder)
-        end
-      else
-        builder.creator("nameType" => "Organization") do
-          builder.creatorName value
-        end
-      end
-    end
   end
 end

--- a/app/models/pdc_metadata/name_identifier.rb
+++ b/app/models/pdc_metadata/name_identifier.rb
@@ -29,14 +29,5 @@ module PDCMetadata
     def self.new_orcid(value)
       NameIdentifier.new(value: value, scheme: "ORCID", scheme_uri: "https://orcid.org")
     end
-
-    def to_xml(builder)
-      builder.nameIdentifier(
-          "schemeURI" => scheme_uri,
-          "nameIdentifierScheme" => scheme
-        ) do
-        builder.text value
-      end
-    end
   end
 end

--- a/app/models/pdc_metadata/resource.rb
+++ b/app/models/pdc_metadata/resource.rb
@@ -36,53 +36,10 @@ module PDCMetadata
       @titles.select { |title| title.main? == false }
     end
 
-    # rubocop:disable Metrics/MethodLength
-    # rubocop:disable Metrics/BlockLength
-    # rubocop:disable Metrics/AbcSize
     def to_xml
-      builder = Nokogiri::XML::Builder.new do |xml|
-        xml.resource(
-          "xmlns:xsi" => "http://www.w3.org/2001/XMLSchema-instance",
-          "xmlns" => "http://datacite.org/schema/kernel-4",
-          "xsi:schemaLocation" => "http://datacite.org/schema/kernel-4 https://schema.datacite.org/meta/kernel-4.4/metadata.xsd"
-        ) do
-          xml.identifier("identifierType" => identifier_type) do
-            xml.text identifier
-          end
-          xml.titles do
-            @titles.each do |title|
-              if title.main?
-                xml.title do
-                  xml.text title.title
-                end
-              else
-                xml.title("titleType" => title.title_type) do
-                  xml.text title.title
-                end
-              end
-            end
-          end
-          xml.description("descriptionType" => "Other") do
-            xml.text @description
-          end
-          xml.creators do
-            @creators.each do |creator|
-              creator.to_xml(xml)
-            end
-          end
-          xml.publisher do
-            xml.text @publisher
-          end
-          xml.publicationYear do
-            xml.text @publication_year
-          end
-        end
-      end
-      builder.to_xml
+      xml_prefix = '<?xml version="1.0"?>'
+      xml_prefix + "\n" + PDCSerialization::Datacite.new_from_work_resource(self).to_xml + "\n"
     end
-    # rubocop:enable Metrics/MethodLength
-    # rubocop:enable Metrics/BlockLength
-    # rubocop:enable Metrics/AbcSize
 
     class << self
       # Creates a PDCMetadata::Resource from a JSON string

--- a/app/models/pdc_metadata/resource.rb
+++ b/app/models/pdc_metadata/resource.rb
@@ -37,8 +37,9 @@ module PDCMetadata
     end
 
     def to_xml
-      xml_prefix = '<?xml version="1.0"?>'
-      xml_prefix + "\n" + PDCSerialization::Datacite.new_from_work_resource(self).to_xml + "\n"
+      xml_declaration = '<?xml version="1.0"?>'
+      xml_body = PDCSerialization::Datacite.new_from_work_resource(self).to_xml
+      xml_declaration + "\n" + xml_body + "\n"
     end
 
     class << self

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -546,7 +546,7 @@ RSpec.describe WorksController, mock_ezid_api: true do
       end
     end
 
-    it "handles the show page" do
+    it "renders datacite serialization as XML" do
       sign_in user
       get :datacite, params: { id: work.id }
       expect(response.body.start_with?('<?xml version="1.0"?>')).to be true

--- a/spec/fixtures/files/datacite_basic.xml
+++ b/spec/fixtures/files/datacite_basic.xml
@@ -1,21 +1,23 @@
 <?xml version="1.0"?>
-<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 https://schema.datacite.org/meta/kernel-4.4/metadata.xsd">
-  <identifier identifierType="DOI">10.5072/example-full</identifier>
-  <titles>
-    <title>hello world</title>
-  </titles>
-  <description descriptionType="Other">this is an example description</description>
+<resource xsi:schemaLocation='http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns='http://datacite.org/schema/kernel-4'>
+  <identifier identifierType='DOI'>10.5072/example-full</identifier>
   <creators>
-    <creator nameType="Personal">
+    <creator>
       <creatorName>Miller, Elizabeth</creatorName>
       <givenName>Elizabeth</givenName>
       <familyName>Miller</familyName>
-      <nameIdentifier schemeURI="https://orcid.org" nameIdentifierScheme="ORCID">1234-5678-9012-1234</nameIdentifier>
+      <nameIdentifier nameIdentifierScheme='ORCID' schemeURI='https://orcid.org'>1234-5678-9012-1234</nameIdentifier>
     </creator>
-    <creator nameType="Organization">
-      <creatorName>Princeton University</creatorName>
+    <creator>
+      <creatorName>Smith, Jane</creatorName>
+      <givenName>Jane</givenName>
+      <familyName>Smith</familyName>
     </creator>
   </creators>
+  <titles>
+    <title>hello world</title>
+  </titles>
   <publisher>Princeton University</publisher>
+  <resourceType resourceTypeGeneral='Dataset'/>
   <publicationYear>2022</publicationYear>
 </resource>

--- a/spec/models/pdc_metadata/resource_spec.rb
+++ b/spec/models/pdc_metadata/resource_spec.rb
@@ -22,8 +22,6 @@ RSpec.describe PDCMetadata::Resource, type: :model do
     expect(ds.main_title).to eq "hello world"
     expect(ds.resource_type).to eq "Dataset"
     expect(ds.creators.count).to be 2
-    expect(ds.creators.first.affiliations.count).to be 0
-    expect(ds.creators.second.affiliations.count).to be 1
   end
 
   it "supports more than one title" do
@@ -35,13 +33,12 @@ RSpec.describe PDCMetadata::Resource, type: :model do
     # Eventually we might want to support a complete example like this
     # https://schema.datacite.org/meta/kernel-4.4/example/datacite-example-full-v4.xml
     raw_xml = file_fixture("datacite_basic.xml").read
-    byebug
     expect(ds.to_xml).to eq raw_xml
   end
 
   it "handles ORCID values" do
-    expect(creatorPerson.orcid).to eq "1234-5678-9012-1234"
-    expect(creatorPerson.orcid_url).to eq "https://orcid.org/1234-5678-9012-1234"
+    expect(creator1.orcid).to eq "1234-5678-9012-1234"
+    expect(creator1.orcid_url).to eq "https://orcid.org/1234-5678-9012-1234"
 
     no_orcid = PDCMetadata::Creator.new_person("Elizabeth", "Miller")
     expect(no_orcid.orcid).to be nil

--- a/spec/models/pdc_metadata/resource_spec.rb
+++ b/spec/models/pdc_metadata/resource_spec.rb
@@ -2,20 +2,18 @@
 require "rails_helper"
 
 RSpec.describe PDCMetadata::Resource, type: :model do
-  let(:creatorPerson) do
+  let(:creator1) do
     PDCMetadata::Creator.new_person("Elizabeth", "Miller", "1234-5678-9012-1234")
   end
 
-  let(:creatorOrganization) do
-    org = PDCMetadata::Creator.new(value: "Princeton University", name_type: "Organization")
-    org.affiliations << PDCMetadata::Affiliation.new(value: "Some affiliation", identifier: "https://ror.org/04aj4c181", scheme: "ROR", scheme_uri: "https://ror.org/")
-    org
+  let(:creator2) do
+    PDCMetadata::Creator.new_person("Jane", "Smith")
   end
 
   let(:ds) do
     ds = described_class.new(doi: "10.5072/example-full", title: "hello world")
     ds.description = "this is an example description"
-    ds.creators = [creatorPerson, creatorOrganization]
+    ds.creators = [creator1, creator2]
     ds
   end
 
@@ -36,7 +34,9 @@ RSpec.describe PDCMetadata::Resource, type: :model do
   it "serializes to xml" do
     # Eventually we might want to support a complete example like this
     # https://schema.datacite.org/meta/kernel-4.4/example/datacite-example-full-v4.xml
-    expect(ds.to_xml).to eq(file_fixture("datacite_basic.xml").read)
+    raw_xml = file_fixture("datacite_basic.xml").read
+    byebug
+    expect(ds.to_xml).to eq raw_xml
   end
 
   it "handles ORCID values" do

--- a/spec/system/work_spec.rb
+++ b/spec/system/work_spec.rb
@@ -67,10 +67,21 @@ RSpec.describe "Creating and updating works", type: :system, mock_ezid_api: true
       nodeset = doc.xpath("/xmlns:resource")
       expect(nodeset).to be_instance_of(Nokogiri::XML::NodeSet)
     end
+  end
+
+  context "invalid datacite record" do
+    let(:work) { FactoryBot.create :draft_work }
+    let(:invalid_xml) { file_fixture("datacite_basic.xml").read.gsub("<creator", "<invalid") }
+
+    before do
+      stub_s3
+      sign_in user
+      allow_any_instance_of(PDCMetadata::Resource).to receive(:to_xml).and_return(invalid_xml)
+    end
 
     it "Validates the record and prints any errors", js: true do
       visit datacite_validate_work_path(work)
-      expect(page).to have_content "The value has a length of '0'"
+      expect(page).to have_content "This element is not expected"
     end
   end
 end

--- a/spec/system/work_spec.rb
+++ b/spec/system/work_spec.rb
@@ -54,8 +54,7 @@ RSpec.describe "Creating and updating works", type: :system, mock_ezid_api: true
   end
 
   context "datacite record" do
-    let(:resource) { FactoryBot.build :resource }
-    let(:work) { FactoryBot.create :draft_work, resource: resource }
+    let(:work) { FactoryBot.create :draft_work }
 
     before do
       stub_s3


### PR DESCRIPTION
`PDCMetadata::Resource.to_xml` had a custom XML serialization that we added initially to show how we can output Datacite XML out of our data. This PR drops the custom implementation in favor of the one that we now provide in `PDCSerialization::Datacite.to_xml`. 

Closes #328 
