### PR TITLE
Collections clean up

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -35,27 +35,20 @@ class Collection < ApplicationRecord
     Rails.logger.info "Creating default Collections"
     Collection.create(title: "Research Data", code: "RD")
     Collection.create(title: "Princeton Plasma Physics Laboratory", code: "PPPL")
-    Collection.create(title: "Electronic Theses and Dissertations", code: "ETD")
-    Collection.create(title: "Library Resources", code: "LIB")
   end
 
   # Returns the default collection.
   # Used when we don't have anything else to determine a more specific collection for a user.
   def self.default
     create_defaults
-    Collection.where(code: "RD").first
+    research_data
   end
 
   # Returns the default collection for a given department number.
+  # Reference: https://docs.google.com/spreadsheets/d/1_Elxs3Ex-2wCbbKUzD4ii3k16zx36sYf/edit#gid=1484576831
   def self.default_for_department(department_number)
-    create_defaults
-    # Reference: https://docs.google.com/spreadsheets/d/1_Elxs3Ex-2wCbbKUzD4ii3k16zx36sYf/edit#gid=1484576831
-    if department_number.nil?
-      default
-    elsif department_number >= "31000" && department_number <= "31026"
-      Collection.where(code: "PPPL").first
-    elsif department_number >= "41000" && department_number <= "41032"
-      Collection.where(code: "LIB").first
+    if department_number.present? && department_number >= "31000" && department_number <= "31026"
+      plasma_laboratory
     else
       default
     end
@@ -64,11 +57,6 @@ class Collection < ApplicationRecord
   def self.research_data
     create_defaults
     Collection.where(code: "RD").first
-  end
-
-  def self.library_resources
-    create_defaults
-    Collection.where(code: "LIB").first
   end
 
   def self.plasma_laboratory

--- a/config/collection_defaults.yml
+++ b/config/collection_defaults.yml
@@ -12,21 +12,13 @@ shared:
     submit:
       - tbd-002
       - tbd-003
-  etd:
-    admin:
-      - tbd-007
-    submit:
-  lib:
-    admin:
-    submit:
-      - tbd-008
 test:
   rd:
     admin:
       - user1
     submit:
       - user2
-  lib:
+  pppl:
     admin:
     submit:
       - user3

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -12,8 +12,6 @@ RSpec.describe Collection, type: :model do
 
     expect(Collection.where(code: "PPPL").count).to be 1
     expect(Collection.where(code: "RD").count).to be 1
-    expect(Collection.where(code: "ETD").count).to be 1
-    expect(Collection.where(code: "LIB").count).to be 1
 
     described_class.create_defaults
     expect(described_class.count).to be default_count

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -140,14 +140,12 @@ RSpec.describe User, type: :model do
       described_class.create_default_users
       fake1 = described_class.find_by(uid: "fake1")
       expect(fake1).to be_super_admin
-      user1 = described_class.find_by(uid: "user1")
-      user2 = described_class.find_by(uid: "user2")
-      rd = Collection.where(code: "RD").first
-      lib = Collection.where(code: "LIB").first
-      expect(user1.can_admin?(rd.id)).to be true
-      expect(user1.can_admin?(lib.id)).to be false
-      expect(user2.can_submit?(rd.id)).to be true
-      expect(user2.can_admin?(rd.id)).to be false
+      admin_user = described_class.find_by(uid: "user1")
+      submitter_user = described_class.find_by(uid: "user2")
+      rd = Collection.research_data
+      expect(admin_user.can_admin?(rd.id)).to be true
+      expect(submitter_user.can_submit?(rd.id)).to be true
+      expect(submitter_user.can_admin?(rd.id)).to be false
     end
   end
 

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe Work, type: :model, mock_ezid_api: true do
   let(:work) { FactoryBot.create(:draft_work) }
   let(:work2) { FactoryBot.create(:draft_work) }
 
-  let(:lib_user) do
+  let(:rd_user) do
     user = FactoryBot.create :user
-    UserCollection.add_submitter(user.id, Collection.library_resources.id)
+    UserCollection.add_submitter(user.id, Collection.research_data.id)
     user
   end
 
@@ -24,7 +24,6 @@ RSpec.describe Work, type: :model, mock_ezid_api: true do
   let(:curator_user) do
     user = FactoryBot.create :user
     UserCollection.add_admin(user.id, Collection.research_data.id)
-    UserCollection.add_admin(user.id, Collection.library_resources.id)
     user
   end
 
@@ -209,16 +208,16 @@ RSpec.describe Work, type: :model, mock_ezid_api: true do
       FactoryBot.create(:draft_work, created_by_user_id: user.id)
       FactoryBot.create(:draft_work, created_by_user_id: user.id)
       FactoryBot.create(:draft_work, created_by_user_id: pppl_user.id, collection_id: Collection.plasma_laboratory.id)
-      # Create the dataset for `lib_user`` and @mention `user`
-      ds = FactoryBot.create(:draft_work, created_by_user_id: lib_user.id)
-      WorkActivity.add_system_activity(ds.id, "Tagging @#{user.uid} in this dataset", lib_user.id)
+      # Create the dataset for `rd_user` and @mention `user`
+      ds = FactoryBot.create(:draft_work, created_by_user_id: rd_user.id)
+      WorkActivity.add_system_activity(ds.id, "Tagging @#{user.uid} in this dataset", rd_user.id)
     end
 
     it "for a typical user retrieves only the datasets created by the user or where the user is tagged" do
       user_datasets = described_class.unfinished_works(user)
       expect(user_datasets.count).to be 3
       expect(user_datasets.count { |ds| ds.created_by_user_id == user.id }).to be 2
-      expect(user_datasets.count { |ds| ds.created_by_user_id == lib_user.id }).to be 1
+      expect(user_datasets.count { |ds| ds.created_by_user_id == rd_user.id }).to be 1
     end
 
     it "for a curator retrieves dataset created in collections they can curate" do

--- a/spec/services/s3_query_service_spec.rb
+++ b/spec/services/s3_query_service_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe S3QueryService, mock_ezid_api: true do
   context "with persisted Works" do
     let(:user) do
       persisted = FactoryBot.create(:user)
-      UserCollection.add_admin(persisted.id, Collection.library_resources.id)
+      UserCollection.add_admin(persisted.id, Collection.research_data.id)
       persisted
     end
     let(:collection) { Collection.library_resources }


### PR DESCRIPTION
Remove code references to non-existing collections. Added rake task to clean up database records as well.

```
# show records that need to be cleaned up
bundle exec rake users:collection_cleanup

# cleans up the records
bundle exec rake users:collection_cleanup[true]
```

Closes #335