### PR TITLE
Render the ARK in the Datacite serialization

### DIFF
--- a/app/models/pdc_serialization/datacite.rb
+++ b/app/models/pdc_serialization/datacite.rb
@@ -71,7 +71,8 @@ module PDCSerialization
         titles: titles_from_work_resource(resource.titles),
         publisher: ::Datacite::Mapping::Publisher.new(value: resource.publisher),
         publication_year: resource.publication_year,
-        resource_type: datacite_resource_type(resource.resource_type)
+        resource_type: datacite_resource_type(resource.resource_type),
+        related_identifiers: related_identifiers_from_work_resource(resource)
       )
       Datacite.new(mapping)
     end
@@ -155,6 +156,18 @@ module PDCSerialization
               ::Datacite::Mapping::Title.new(value: title.title, type: ::Datacite::Mapping::TitleType::TRANSLATED_TITLE)
             end
           end.compact
+        end
+
+        def related_identifiers_from_work_resource(resource)
+          related_identifiers = []
+          if resource.ark.present?
+            related_identifiers << ::Datacite::Mapping::RelatedIdentifier.new(
+              relation_type: ::Datacite::Mapping::RelationType::IS_IDENTICAL_TO,
+              value: resource.ark,
+              identifier_type: ::Datacite::Mapping::RelatedIdentifierType::ARK
+            )
+          end
+          related_identifiers
         end
       end
   end

--- a/spec/fixtures/files/datacite_basic.xml
+++ b/spec/fixtures/files/datacite_basic.xml
@@ -20,4 +20,7 @@
   <publisher>Princeton University</publisher>
   <resourceType resourceTypeGeneral='Dataset'/>
   <publicationYear>2022</publicationYear>
+  <relatedIdentifiers>
+    <relatedIdentifier relationType='IsIdenticalTo' relatedIdentifierType='ARK'>ark:/88435/dsp01hx11xj13h</relatedIdentifier>
+  </relatedIdentifiers>
 </resource>

--- a/spec/models/pdc_metadata/resource_spec.rb
+++ b/spec/models/pdc_metadata/resource_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe PDCMetadata::Resource, type: :model do
     ds = described_class.new(doi: "10.5072/example-full", title: "hello world")
     ds.description = "this is an example description"
     ds.creators = [creator1, creator2]
+    ds.ark = "ark:/88435/dsp01hx11xj13h"
     ds
   end
 


### PR DESCRIPTION
Renders the ARK as an Alternate Identifier in the DataCite serialization. See https://support.datacite.org/docs/datacite-metadata-schema-v44-recommended-and-optional-properties#12-relatedidentifier

Closes #318 