### PR TITLE
ARK tooltip on data entry

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -77,3 +77,7 @@
   display:block;
   border-radius: 5px;
 }
+
+.field-hint {
+  font-size: smaller;
+}

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,9 +1,3 @@
-<style>
-  .orcid-hint {
-    font-size: smaller;
-  }
-</style>
-
 <%= form_with(model: user) do |form| %>
   <% if user.errors.any? %>
     <div id="error_explanation">
@@ -37,7 +31,7 @@
 
   <div class="field">
     ORCID iD
-    <span id="orcid-bad" class="hidden text-muted orcid-hint"> - use format 0000-0000-0000-0000</span>
+    <span id="orcid-bad" class="hidden text-muted field-hint"> - use format 0000-0000-0000-0000</span>
     <span id="orcid-ok" class="hidden"><img alt="ORCID logo" src="https://info.orcid.org/wp-content/uploads/2019/11/orcid_16x16.png" width="16" height="16" /></span>
     <br />
     <%= form.text_field :orcid, placeholder: "0000-0000-0000-0000" %>

--- a/app/views/works/_additional_form.html.erb
+++ b/app/views/works/_additional_form.html.erb
@@ -21,7 +21,7 @@
 
   <!-- ARK field (mostly for legacy DSpace works) -->
   <div class="field">
-    ARK: <br>
+    ARK <span class="text-muted field-hint">(enter the core ARK identifier, e.g. ark:/88435/xyz123)</span><br>
     <input type="text" id="ark" name="ark" class="input-text-long" value="<%= @work.resource.ark %>" />
   </div>
 </div>

--- a/app/views/works/_edit_javascript.html.erb
+++ b/app/views/works/_edit_javascript.html.erb
@@ -272,6 +272,16 @@
       }
     });
 
+    // Drop the "http..."" portion of the URL if the user enters the full URL of a DataSpace ARK
+    // http://arks.princeton.edu/ark:/88435/dsp01hx11xj13h => ark:/88435/dsp01hx11xj13h
+    $("#ark").on("input", function(el) {
+      var prefix = "http://arks.princeton.edu/";
+      var ark = el.currentTarget.value.trim();
+      if (ark.startsWith(prefix)) {
+        el.currentTarget.value = ark.replace(prefix, "")
+      }
+    });
+
     // Allows the creators to be reordered via drag and drop.
     // The `cancel` property "prevents sorting if you start on elements matching the selector"
     // https://api.jqueryui.com/sortable/#method-cancel

--- a/spec/system/work_spec.rb
+++ b/spec/system/work_spec.rb
@@ -46,6 +46,18 @@ RSpec.describe "Creating and updating works", type: :system, mock_ezid_api: true
     expect(page.html.include?("By initiating this new submission, we have reserved a draft DOI for your use")).to be true
   end
 
+  it "Handles ARK URLs in the ARK field", js: true do
+    resource = FactoryBot.build(:resource, creators: [PDCMetadata::Creator.new_person("Harriet", "Tubman", "1234-5678-9012-3456")])
+    work = FactoryBot.create(:draft_work, resource: resource)
+    sign_in user
+    visit edit_work_path(work)
+    click_on "Additional Metadata"
+    fill_in "ark", with: "http://arks.princeton.edu/ark:/88435/dsp01hx11xj13h"
+    click_on "Save Work"
+    work = Work.find(work.id) # force to reload the work
+    expect(work.ark).to eq "ark:/88435/dsp01hx11xj13h"
+  end
+
   context "datacite record" do
     let(:work) { FactoryBot.create :draft_work }
 


### PR DESCRIPTION
Added a hint to the data entry to indicate the expected format of the ARK (if entered). 

I also added a convenience method to drop the "http://arks.princeton.edu/" part of an ARK if a user enters it. This should help when we migrate data from DataSpace in which the full ARK URL (e.g. "http://arks.princeton.edu/ark:/88435/dsp01hx11xj13h") is available to the user at the top but we only care about the core ARK identifier (e.g. "ark:/88435/dsp01hx11xj13h")

Closes #327 

![ark-hint](https://user-images.githubusercontent.com/568286/187717855-ce353f2d-c941-45db-b2c8-65dfa700f3ae.png)
