### PR TITLE
Force the work.resource to be reloaded when work.reload is called

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -142,6 +142,24 @@ class Work < ApplicationRecord
     end
   end
 
+  # Overload ActiveRecord.reload method
+  # https://apidock.com/rails/ActiveRecord/Base/reload
+  #
+  # NOTE: Usually `after_save` is a better place to put this kind of code:
+  #
+  #   after_save do |work|
+  #     work.resource = nil
+  #   end
+  #
+  # but that does not work in this case because the block points to a different
+  # memory object for `work` than the we want we want to reload.
+  def reload(options = nil)
+    super
+    # Force `resource` to be reloaded
+    @resource = nil
+    self
+  end
+
   def save_pre_curation_uploads
     new_attachments = pre_curation_uploads.reject(&:persisted?)
     save_new_attachments(new_attachments: new_attachments)

--- a/spec/system/work_spec.rb
+++ b/spec/system/work_spec.rb
@@ -54,8 +54,7 @@ RSpec.describe "Creating and updating works", type: :system, mock_ezid_api: true
     click_on "Additional Metadata"
     fill_in "ark", with: "http://arks.princeton.edu/ark:/88435/dsp01hx11xj13h"
     click_on "Save Work"
-    work = Work.find(work.id) # force to reload the work
-    expect(work.ark).to eq "ark:/88435/dsp01hx11xj13h"
+    expect(work.reload.ark).to eq "ark:/88435/dsp01hx11xj13h"
   end
 
   it "Handles Rights field", js: true do
@@ -65,8 +64,7 @@ RSpec.describe "Creating and updating works", type: :system, mock_ezid_api: true
     visit edit_work_path(work)
     find("#rights_identifier").find(:xpath, "option[2]").select_option
     click_on "Save Work"
-    work = Work.find(work.id) # force to reload the work
-    expect(work.resource.rights.identifier).to eq "CC BY"
+    expect(work.reload.resource.rights.identifier).to eq "CC BY"
   end
 
   context "datacite record" do


### PR DESCRIPTION
This is one way to address the issue with `work.reload` not reloading the `work.resource`.

I am not too happy with having to overload ActiveRecord's `reload` method but this was the only way I could get it to work. Left a big comment about it on the code. 

Fixes #365 