### PR TITLE
Adding tests to verify a super admin can access all works and collections

### DIFF
--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -30,7 +30,7 @@ FactoryBot.define do
     email { "#{uid}@princeton.edu" }
     provider { :cas }
     after(:create) do |user|
-      user.add_role(:super_admin)
+      User.new_super_admin(user.uid)
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe User, type: :model do
 
   let(:normal_user) { described_class.from_cas(access_token) }
   let(:pppl_user) { described_class.from_cas(access_token_pppl) }
-  let(:super_admin_user) { described_class.new_for_uid("fake1", roles: [:super_admin]) }
+  let(:super_admin_user) { described_class.new_super_admin("fake1") }
 
   let(:rd_collection) { Collection.where(code: "RD").first }
   let(:pppl_collection) { Collection.where(code: "PPPL").first }

--- a/spec/system/authz_super_admin_spec.rb
+++ b/spec/system/authz_super_admin_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+require "rails_helper"
+##
+# A submitter is a logged in user with no permissions other than being able to deposit.
+# One submitter should not be able to edit the work of another submitter.
+RSpec.describe "Authz for super admins", type: :system, js: true, mock_ezid_api: true do
+  describe "A Super Admin" do
+    let(:super_admin) { FactoryBot.create :super_admin_user }
+    let(:submitter2) { FactoryBot.create :princeton_submitter }
+    let(:title1) { "Title One" }
+    let(:title2) { "Title Two" }
+    let(:title3) { "Title Three" }
+
+    before do
+      stub_s3
+      stub_datacite(host: "api.datacite.org", body: datacite_register_body(prefix: "10.34770"))
+    end
+
+    it "should be able to edit someone else's work" do
+      sign_in submitter2
+      visit user_path(submitter2)
+      expect(page).to have_content submitter2.display_name
+      click_on "Submit New"
+      fill_in "title_main", with: title1
+
+      fill_in "given_name_1", with: FFaker::Name.first_name
+      fill_in "family_name_1", with: FFaker::Name.last_name
+      click_on "Create New"
+      fill_in "description", with: FFaker::Lorem.paragraph
+      find("#rights_identifier").find(:xpath, "option[2]").select_option
+      click_on "Additional Metadata"
+      expect(page).to have_content "Research Data"
+      click_on "Save Work"
+      page.find(:xpath, "//input[@value='file_other']").choose
+      click_on "Continue"
+      click_on "Continue"
+      click_on "Complete"
+
+      expect(page).to have_content "awaiting_approval"
+      work = Work.last
+
+      sign_out submitter2
+      sign_in super_admin
+
+      visit edit_work_path(work)
+      fill_in "title_main", with: title3
+      click_on "Save Work"
+      expect(page).to have_content(title3)
+    end
+
+    it "should be able to edit a collection to add curators and submitters" do
+      collection = FactoryBot.create(:collection) # any random collection
+      sign_in super_admin
+      visit collection_path(collection)
+      expect(page).to have_content "Add Submitter"
+      expect(page).to have_content "Add Curator"
+      visit edit_collection_path(collection)
+      fill_in "collection_title", with: title3
+      click_on "Update Collection"
+      expect(current_path).to eq collection_path(collection)
+      expect(page).to have_content title3
+    end
+
+    it "should be able to approve a work" do
+      work = FactoryBot.create :completed_work
+      sign_in super_admin
+      visit work_path(work)
+      expect(page).to have_button "Approve Dataset"
+    end
+  end
+end


### PR DESCRIPTION
Needed to adjust the roles a bit to allow the access to be right

fixes #306 

This change is utilizing the rolify add role without an object to allow access to any instance of that object.  `user.add_role :collection_admin` vs `user.add_role :collection_admin, collection`
