### PR TITLE
Allow access to default collection

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -203,7 +203,7 @@ class User < ApplicationRecord
   end
 
   def assign_default_role
-    add_role(:submitter, default_collection) if roles.blank?
+    add_role(:submitter, default_collection) unless has_role?(:submitter, default_collection)
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -52,14 +52,14 @@ namespace :users do
       user.default_collection_id = Collection.research_data.id
       if fixit
         user.save!
-        user.setup_user_default_collections
+        user.assign_default_role
       end
     end
 
     puts "-- Work records"
     Work.all.each do |work|
-      next if work.collection.code == "RD" || work.collection.code == "PPPL"
-      puts "fixing work #{work.id}, #{work.collection_id}, #{work.collection.code}"
+      next if work.collection&.code == "RD" || work.collection&.code == "PPPL"
+      puts "fixing work #{work.id}, #{work.collection_id}, #{work.collection&.code}"
       work.collection_id = Collection.research_data.id
       work.save! if fixit
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -173,6 +173,13 @@ RSpec.describe User, type: :model do
       expect(pppl_user.can_submit?(rd_collection)).to be false
       expect(pppl_user.submitter_collections.count).to eq 1
     end
+
+    it "gives access to the default collection" do
+      user = FactoryBot.build :user
+      user.add_role(:collection_admin, pppl_collection)
+      user.save!
+      expect(user.can_submit?(rd_collection)).to be_truthy
+    end
   end
 
   describe "default collection is set on ititalize" do


### PR DESCRIPTION
Even if another role has already been assigned.  Each user should get access to thier default collection

Also removes reference to setup_user_default_collections as it no longer exists.  Utilizing assign_default_role instead