### PR TITLE
Allow a user to be added to their default collection

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -49,6 +49,8 @@ class Collection < ApplicationRecord
 
   def add_submitter(current_user, additional_user)
     if current_user.has_role?(:super_admin) || current_user.has_role?(:collection_admin, self)
+      return if (self == additional_user.default_collection) && additional_user.just_created
+
       if additional_user.has_role? :submitter, self
         errors.add(:submitter, "User has already been added")
       else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,8 @@ class User < ApplicationRecord
   devise :rememberable, :omniauthable
   after_create :assign_default_role
 
+  attr_accessor :just_created
+
   validate do |user|
     user.orcid&.strip!
     if user.orcid.present? && Orcid.invalid?(user.orcid)
@@ -203,6 +205,7 @@ class User < ApplicationRecord
   end
 
   def assign_default_role
+    @just_created = true
     add_role(:submitter, default_collection) unless has_role?(:submitter, default_collection)
   end
 end

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -88,6 +88,7 @@ RSpec.describe CollectionsController do
     it "adds a submitter" do
       sign_in admin_user
       # Detects that the user already has submitter rights to the default collection
+      User.new_for_uid("submit2")
       post :add_submitter, params: { id: collection.id, uid: "submit2" }
       expect(response.status).to eq 400
 

--- a/spec/system/authz_admin_spec.rb
+++ b/spec/system/authz_admin_spec.rb
@@ -32,14 +32,14 @@ RSpec.describe "Authz for curators", type: :system, js: true, mock_ezid_api: tru
         expect(work.reload.title).to eq "New Title"
       end
 
-      pending it "can add submitters to the collection" do
+      it "can add submitters to the collection" do
         login_as research_data_moderator
         expect(research_data_moderator.can_admin?(Collection.research_data)).to eq true
         expect(new_submitter.can_submit?(Collection.research_data)).to eq false
         visit collection_path(Collection.research_data)
         fill_in "submitter-uid-to-add", with: new_submitter.uid
         click_on "Add Submitter"
-        # This does not work. Bug ticketed here: https://github.com/pulibrary/pdc_describe/issues/372
+        expect(page).to have_content new_submitter.uid
         expect(new_submitter.can_submit?(Collection.research_data)).to eq true
       end
 

--- a/spec/system/collection_edit_spec.rb
+++ b/spec/system/collection_edit_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Editing collections" do
   let(:collection) { FactoryBot.create :collection }
   let(:collection_other) { Collection.second }
 
-  let(:collection_admin_user) { FactoryBot.create :user, collections_to_admin: [collection] }
+  let(:collection_admin_user) { FactoryBot.create :user, collections_to_admin: [collection, Collection.research_data] }
 
   it "allows super admin to edit collections", js: true do
     sign_in super_admin_user
@@ -36,8 +36,20 @@ RSpec.describe "Editing collections" do
     visit collection_path(collection)
     fill_in "submitter-uid-to-add", with: "submiter123"
     click_on "Add Submitter"
-    visit collection_path(collection)
     expect(page).to have_content "submiter123"
+    expect(page).not_to have_content "User has already been added"
+  end
+
+  it "allows a collection admin to add a submitter to their defailt collection without error only when the user is first created", js: true do
+    sign_in collection_admin_user
+    visit collection_path(Collection.research_data)
+    fill_in "submitter-uid-to-add", with: "submiter123"
+    click_on "Add Submitter"
+    expect(page).to have_content "submiter123"
+    expect(page).not_to have_content "User has already been added"
+    fill_in "submitter-uid-to-add", with: "submiter123"
+    click_on "Add Submitter"
+    expect(page).to have_content "User has already been added"
   end
 
   it "allows a curator to add another curator to the collection", js: true do


### PR DESCRIPTION
When a user is first added to the system and they are being added as a submitter to thier default collection and error is not needed.
Only error to say the user has already been added if someone tries to add them again

fixes #372