### PR TITLE
Ensures that `window.rails` is not already defined before initializing `Rails.start()` for rails-ujs

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -11,7 +11,9 @@ import "channels"
 import "./vendor/jquery-ui-triggeredAutocomplete"
 import WorkForm from "./works/form"
 
-Rails.start()
+if (typeof(window._rails_loaded) == "undefined" || window._rails_loaded == null || !window._rails_loaded) {
+  Rails.start()
+}
 Turbolinks.start()
 ActiveStorage.start()
 


### PR DESCRIPTION
I found that this error, also, needed to be resolved for the `staging` environment.