### PR TITLE
Allow files to be displayed after edit

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -83,6 +83,8 @@ class WorksController < ApplicationController
                                      end
 
                                      updated_uploads
+                                   else
+                                     @work.pre_curation_uploads.map(&:blob)
                                    end
 
     collection_id_param = params[:collection_id]
@@ -100,6 +102,7 @@ class WorksController < ApplicationController
         redirect_to work_url(@work), notice: "Work was successfully updated."
       end
     else
+      @uploads = @work.uploads
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -47,46 +47,11 @@ class WorksController < ApplicationController
     end
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity
   def update
     @work = Work.find(params[:id])
     @wizard_mode = params[:wizard] == "true"
 
-    updated_pre_curation_uploads = if work_params.key?(:pre_curation_uploads)
-                                     work_params[:pre_curation_uploads]
-                                   elsif work_params.key?(:replaced_uploads)
-                                     persisted_pre_curation_uploads = @work.pre_curation_uploads
-                                     replaced_uploads_params = work_params[:replaced_uploads]
-
-                                     updated_uploads = []
-                                     persisted_pre_curation_uploads.each_with_index do |existing, i|
-                                       key = i.to_s
-
-                                       if replaced_uploads_params.key?(key)
-                                         replaced = replaced_uploads_params[key]
-                                         updated_uploads << replaced
-                                       else
-                                         updated_uploads << existing.blob
-                                       end
-                                     end
-
-                                     updated_uploads
-                                   elsif work_params.key?(:deleted_uploads)
-                                     persisted_pre_curation_uploads = @work.pre_curation_uploads
-                                     deleted_uploads_params = work_params[:deleted_uploads]
-                                     updated_uploads = []
-
-                                     persisted_pre_curation_uploads.each_with_index do |existing, _i|
-                                       unless deleted_uploads_params.key?(existing.key) && deleted_uploads_params[existing.key] == "1"
-                                         updated_uploads << existing.blob
-                                       end
-                                     end
-
-                                     updated_uploads
-                                   else
-                                     @work.pre_curation_uploads.map(&:blob)
-                                   end
-
+    updated_pre_curation_uploads = WorkUploadsEditService.precurated_file_list(@work, work_params)
     collection_id_param = params[:collection_id]
 
     updates = {
@@ -106,7 +71,6 @@ class WorksController < ApplicationController
       render :edit, status: :unprocessable_entity
     end
   end
-  # rubocop:enable Metrics/CyclomaticComplexity
 
   # Prompt to select how to submit their files
   def attachment_select

--- a/app/services/work_uploads_edit_service.rb
+++ b/app/services/work_uploads_edit_service.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+class WorkUploadsEditService
+  class << self
+    def precurated_file_list(work, work_params)
+      if work_params.key?(:pre_curation_uploads)
+        work_params[:pre_curation_uploads]
+      elsif work_params.key?(:replaced_uploads)
+        replace_uploads(work.pre_curation_uploads, work_params[:replaced_uploads])
+      elsif work_params.key?(:deleted_uploads)
+        remaining_uploads(work.pre_curation_uploads, work_params[:deleted_uploads])
+      else
+        work.pre_curation_uploads.map(&:blob)
+      end
+    end
+
+      private
+
+        def replace_uploads(persisted_pre_curation_uploads, replaced_uploads_params)
+          updated_uploads = []
+          persisted_pre_curation_uploads.each_with_index do |existing, i|
+            key = i.to_s
+
+            if replaced_uploads_params.key?(key)
+              replaced = replaced_uploads_params[key]
+              updated_uploads << replaced
+            else
+              updated_uploads << existing.blob
+            end
+          end
+
+          updated_uploads
+        end
+
+        def remaining_uploads(persisted_pre_curation_uploads, deleted_uploads_params)
+          updated_uploads = []
+
+          persisted_pre_curation_uploads.each do |existing|
+            next if deleted_uploads_params.key?(existing.key) && deleted_uploads_params[existing.key] == "1"
+
+            updated_uploads << existing.blob
+          end
+
+          updated_uploads
+        end
+  end
+end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -12,7 +12,6 @@ Rails.application.configure do
   # Compile and load CSS when running tests if we're running in browser
   if ENV["RUN_IN_BROWSER"]
     config.assets.compile = true
-    config.asset_host = "http://localhost:3000"
   end
 
   config.cache_classes = false

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe WorksController, mock_ezid_api: true do
       end
     end
 
-    it "handles the update page" do
+    it "handles the reordering the creators on the update page" do
       params = {
         "title_main" => "test dataset updated",
         "description" => "a new description",

--- a/spec/factories/work.rb
+++ b/spec/factories/work.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :work do
     factory :draft_work do
       transient do
-        doi { "https://doi.org/10.34770/123-abc" }
+        doi { "10.34770/123-abc" }
       end
       collection { Collection.research_data }
       state { "draft" }

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -433,9 +433,9 @@ RSpec.describe Work, type: :model, mock_ezid_api: true do
     end
 
     it "publishes the doi" do
-      stub_request(:put, "https://api.datacite.org/dois/https://doi.org/10.34770/123-abc")
+      stub_request(:put, "https://api.datacite.org/dois/10.34770/123-abc")
       expect { approved_work }.to change { WorkActivity.where(activity_type: "DATACITE_ERROR").count }.by(0)
-      expect(a_request(:put, "https://api.datacite.org/dois/https://doi.org/10.34770/123-abc")).to have_been_made
+      expect(a_request(:put, "https://api.datacite.org/dois/10.34770/123-abc")).to have_been_made
     end
 
     it "notes a issue when an error occurs" do
@@ -656,7 +656,7 @@ RSpec.describe Work, type: :model, mock_ezid_api: true do
       upload_attributes = uploads_attributes.first
 
       expect(upload_attributes).to include(id: work.pre_curation_uploads.first.id)
-      expect(upload_attributes).to include(key: "https://doi.org/10.34770/123-abc/#{work.id}/us_covid_2019.csv")
+      expect(upload_attributes).to include(key: "10.34770/123-abc/#{work.id}/us_covid_2019.csv")
       expect(upload_attributes).to include(filename: "us_covid_2019.csv")
       expect(upload_attributes).to include(:created_at)
       expect(upload_attributes[:created_at]).to be_a(ActiveSupport::TimeWithZone)

--- a/spec/services/work_upload_edit_service_spec.rb
+++ b/spec/services/work_upload_edit_service_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe WorkUploadsEditService do
+  let(:work) { FactoryBot.create :draft_work }
+  let(:uploaded_file) do
+    fixture_file_upload("us_covid_2019.csv", "text/csv")
+  end
+  let(:uploaded_file2) do
+    fixture_file_upload("us_covid_2020.csv", "text/csv")
+  end
+  let(:uploaded_file3) do
+    fixture_file_upload("orcid.csv", "text/csv")
+  end
+
+  let(:bucket_url) do
+    "https://example-bucket.s3.amazonaws.com/"
+  end
+
+  before do
+    stub_request(:put, /#{bucket_url}/).to_return(status: 200)
+    work.pre_curation_uploads.attach(uploaded_file)
+  end
+
+  context "When no uploads changes are in the params" do
+    let(:params) { { "work_id" => "" }.with_indifferent_access }
+
+    it "returns all existing files" do
+      list = described_class.precurated_file_list(work, params)
+      expect(list.map(&:filename)).to eq([uploaded_file.original_filename])
+    end
+  end
+
+  context "When upload additions are in the params" do
+    # this is not possible at the moment, but should be
+  end
+
+  context "When upload removals are in the params" do
+    let(:params) { { "work_id" => "", "deleted_uploads" => { "10.34770/123-abc/#{work.id}/#{uploaded_file.original_filename}" => "1" } }.with_indifferent_access }
+
+    before do
+      work.pre_curation_uploads.attach(uploaded_file2)
+    end
+
+    it "returns all existing files except the deleted one" do
+      list = described_class.precurated_file_list(work, params)
+      expect(list.map(&:filename)).to eq([uploaded_file2.original_filename])
+    end
+  end
+
+  context "When upload replacements are in the params" do
+    before do
+      work.pre_curation_uploads.attach(uploaded_file2)
+    end
+    let(:params) { { "work_id" => "", "replaced_uploads" => { "0" => uploaded_file3 } }.with_indifferent_access }
+
+    it "replaces the correct file" do
+      list = described_class.precurated_file_list(work, params)
+      expect(list.first).to eq(uploaded_file3)
+      expect(list.last.filename).to eq(uploaded_file2.original_filename)
+    end
+  end
+
+  context "When replacing all uploads is the params" do
+    let(:params) { { "work_id" => "", "pre_curation_uploads" => [uploaded_file2, uploaded_file3] }.with_indifferent_access }
+
+    it "replaces all the files" do
+      list = described_class.precurated_file_list(work, params)
+      expect(list).to eq([uploaded_file2, uploaded_file3])
+    end
+  end
+end

--- a/spec/system/work_spec.rb
+++ b/spec/system/work_spec.rb
@@ -133,6 +133,26 @@ RSpec.describe "Creating and updating works", type: :system, mock_ezid_api: true
       visit edit_work_path(work)
     end
 
+    it "shows the uploads before and after errors", js: true do
+      # Make the screen larger so the save button is alway on screen.   This avoids random `Element is not clickable` errors
+      page.driver.browser.manage.window.resize_to(2000, 2000)
+      expect(page).to have_content "us_covid_2019.csv"
+      fill_in "title_main", with: ""
+      click_on "Save Work"
+      expect(page).to have_content "Must provide a title"
+      expect(page).to have_content "us_covid_2019.csv"
+    end
+
+    it "shows the uploads before and after a valid metadata save", js: true do
+      # Make the screen larger so the save button is alway on screen.  This avoids random `Element is not clickable` errors
+      page.driver.browser.manage.window.resize_to(2000, 2000)
+      expect(page).to have_content "us_covid_2019.csv"
+      fill_in "title_main", with: "updated title"
+      click_on "Save Work"
+      expect(page).to have_content "updated title"
+      expect(page).to have_content "us_covid_2019.csv"
+    end
+
     it "allows users to modify the order of the uploads", js: true do
       expect(page).to have_content "Filename"
       expect(page).to have_content "Created At"


### PR DESCRIPTION
Also makes sure the files still exists both before and after an edit. 
Also makes sure the files still display both before and after an update error.

fixes #376 and fixes #400