### PR TITLE
Ensures that ARK and DOI resolution routing handles non-alphanumeric characters

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -98,12 +98,14 @@ class Work < ApplicationRecord
     end
 
     def find_by_doi(doi)
-      models = all.select { |work| work.resource.doi == doi }
+      models = all.select { |work| !work.doi.nil? && work.doi.include?(doi) }
+      raise ActiveRecord::RecordNotFound if models.empty?
       models.first
     end
 
     def find_by_ark(ark)
-      models = all.select { |work| work.resource.ark == ark }
+      models = all.select { |work| !work.ark.nil? && work.ark.include?(ark) }
+      raise ActiveRecord::RecordNotFound if models.empty?
       models.first
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,8 +32,8 @@ Rails.application.routes.draw do
   get "works/:id/datacite", to: "works#datacite", as: :datacite_work
   get "works/:id/datacite/validate", to: "works#datacite_validate", as: :datacite_validate_work
   resources :works
-  get "doi/:doi", to: "works#resolve_doi", as: :resolve_doi, format: false
-  get "ark/:ark", to: "works#resolve_ark", as: :resolve_ark
+  match "/doi/*doi", via: :get, to: "works#resolve_doi", as: :resolve_doi, format: false
+  match "/ark/*ark", via: :get, to: "works#resolve_ark", as: :resolve_ark, format: false
 
   delete "collections/:id/:uid", to: "collections#delete_user_from_collection", as: :delete_user_from_collection
   post "collections/:id/add-submitter/:uid", to: "collections#add_submitter", as: :add_submitter

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -730,6 +730,14 @@ RSpec.describe WorksController, mock_ezid_api: true do
         get :resolve_doi, params: { doi: work.doi }
         expect(response).to redirect_to(work_path(work))
       end
+
+      context "when passing only a segment of the DOI" do
+        it "redirects to the Work show view" do
+          stub_s3
+          get :resolve_doi, params: { doi: work.doi[-9..] }
+          expect(response).to redirect_to(work_path(work))
+        end
+      end
     end
 
     describe "#resolve_ark" do
@@ -745,6 +753,14 @@ RSpec.describe WorksController, mock_ezid_api: true do
         stub_s3
         get :resolve_ark, params: { ark: work.ark }
         expect(response).to redirect_to(work_path(work))
+      end
+
+      context "when passing only a segment of the ARK" do
+        it "redirects to the Work show view" do
+          stub_s3
+          get :resolve_ark, params: { ark: work.ark[-9..] }
+          expect(response).to redirect_to(work_path(work))
+        end
       end
     end
 

--- a/spec/routing/works_routing_spec.rb
+++ b/spec/routing/works_routing_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe WorksController, type: :routing do
     end
 
     context "when the Work has an ARK" do
-      let(:ark) { "dsp01zc77st047" }
+      let(:ark) { "ark:/88435/dsp01zc77st047" }
 
       it "routes to #resolve_ark" do
         expect(get: "/ark/#{ark}").to route_to("works#resolve_ark", ark: ark)
@@ -28,7 +28,7 @@ RSpec.describe WorksController, type: :routing do
     end
 
     context "when the Work has a DOI" do
-      let(:doi) { "34770" }
+      let(:doi) { "https://doi.org/10.34770/pe9w-x904" }
 
       it "routes to #resolve_doi" do
         expect(get: "/doi/#{doi}").to route_to("works#resolve_doi", doi: doi)


### PR DESCRIPTION
These errors were discovered after testing the latest deployment of PDC Describe.