### PR TITLE
Adding Tests for minting the correct ids

### DIFF
--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe WorksController, mock_ezid_api: true do
+RSpec.describe WorksController do
   before do
     Collection.create_defaults
     user

--- a/spec/models/doi_spec.rb
+++ b/spec/models/doi_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "rails_helper"
 
-RSpec.describe "DOI", type: :model, mock_ezid_api: true do
+RSpec.describe "DOI", type: :model do
   let(:client) do
     Datacite::Client.new(username: Rails.configuration.datacite.user,
                          password: Rails.configuration.datacite.password,

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "rails_helper"
 
-RSpec.describe Work, type: :model, mock_ezid_api: true do
+RSpec.describe Work, type: :model do
   let(:user) { FactoryBot.create :user }
   let(:collection) { Collection.research_data }
   let(:user_other) { FactoryBot.create :user }

--- a/spec/services/s3_query_service_spec.rb
+++ b/spec/services/s3_query_service_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "rails_helper"
 
-RSpec.describe S3QueryService, mock_ezid_api: true, mock_s3_query_service: false do
+RSpec.describe S3QueryService, mock_s3_query_service: false do
   let(:work) { FactoryBot.create :draft_work, doi: doi }
   let(:subject) { described_class.new(work) }
   let(:s3_key1) { "10-34770/pe9w-x904/SCoData_combined_v1_2020-07_README.txt" }

--- a/spec/system/authz_admin_spec.rb
+++ b/spec/system/authz_admin_spec.rb
@@ -2,7 +2,7 @@
 require "rails_helper"
 ##
 # A collection admin is a user who has admin rights on a given collection
-RSpec.describe "Authz for curators", type: :system, js: true, mock_ezid_api: true do
+RSpec.describe "Authz for curators", type: :system, js: true do
   describe "A curator" do
     let(:research_data_moderator) { FactoryBot.create :research_data_moderator }
     let(:work) { FactoryBot.create(:shakespeare_and_company_work) }

--- a/spec/system/authz_submitter_spec.rb
+++ b/spec/system/authz_submitter_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 ##
 # A submitter is a logged in user with no permissions other than being able to deposit.
 # One submitter should not be able to edit the work of another submitter.
-RSpec.describe "Authz for submitters", type: :system, js: true, mock_ezid_api: true do
+RSpec.describe "Authz for submitters", type: :system, js: true do
   describe "A submitter" do
     let(:submitter1) { FactoryBot.create :princeton_submitter }
     let(:submitter2) { FactoryBot.create :princeton_submitter }

--- a/spec/system/authz_super_admin_spec.rb
+++ b/spec/system/authz_super_admin_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 ##
 # A submitter is a logged in user with no permissions other than being able to deposit.
 # One submitter should not be able to edit the work of another submitter.
-RSpec.describe "Authz for super admins", type: :system, js: true, mock_ezid_api: true do
+RSpec.describe "Authz for super admins", type: :system, js: true do
   describe "A Super Admin" do
     let(:super_admin) { FactoryBot.create :super_admin_user }
     let(:submitter2) { FactoryBot.create :princeton_submitter }

--- a/spec/system/authz_unauthenticated_spec.rb
+++ b/spec/system/authz_unauthenticated_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 ##
 # A non-authenticated user cannot get to any edit screens, they always get redirected back
 # to the root of the application
-RSpec.describe "Authz for non-authenticated users", type: :system, js: true, mock_ezid_api: true do
+RSpec.describe "Authz for non-authenticated users", type: :system, js: true do
   describe "A non-authenticated user" do
     context "works" do
       let(:work) { FactoryBot.create(:shakespeare_and_company_work) }

--- a/spec/system/external_ids_spec.rb
+++ b/spec/system/external_ids_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe "External Identifiers", type: :system, mock_ezid_api: true, js: true do
+  let(:user) { FactoryBot.create(:princeton_submitter) }
+
+  before do
+    stub_datacite(host: "api.datacite.org", body: datacite_register_body(prefix: "10.34770"))
+    # Make the screen larger so the save button is alway on screen.  This avoids random `Element is not clickable` errors
+    page.driver.browser.manage.window.resize_to(2000, 2000)
+  end
+
+  it "Mints a DOI, but does not mint an ark at any point in the wizard proccess" do
+    sign_in user
+    visit user_path(user)
+    click_on "Submit New"
+    fill_in "title_main", with: "test title"
+
+    fill_in "given_name_1", with: "Sally"
+    fill_in "family_name_1", with: "Smith"
+    click_on "Create New"
+    fill_in "description", with: "test description"
+    find("#rights_identifier").find(:xpath, "option[2]").select_option
+    click_on "Save Work"
+    click_on "Continue"
+    click_on "Continue"
+    click_on "Complete"
+
+    expect(page).to have_content "awaiting_approval"
+    expect(Ezid::Identifier).not_to have_received(:mint)
+    expect(a_request(:post, "https://api.datacite.org/dois")).to have_been_made
+  end
+
+  it "Mints a DOI, but does not mint an ark at any point in the non wizard proccess" do
+    sign_in user
+    visit user_path(user)
+    click_on(user.uid)
+    click_on "Create Dataset"
+    fill_in "title_main", with: "test title"
+    fill_in "description", with: "test description"
+    fill_in "given_name_1", with: "Sally"
+    fill_in "family_name_1", with: "Smith"
+    find("#rights_identifier").find(:xpath, "option[2]").select_option
+    click_on "Create"
+    click_on "Complete"
+
+    expect(page).to have_content "awaiting_approval"
+    expect(Ezid::Identifier).not_to have_received(:mint)
+    expect(a_request(:post, "https://api.datacite.org/dois")).to have_been_made
+  end
+end

--- a/spec/system/form_submission_spec.rb
+++ b/spec/system/form_submission_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "rails_helper"
 
-RSpec.describe "Form submission for a legacy dataset", type: :system, mock_ezid_api: true do
+RSpec.describe "Form submission for a legacy dataset", type: :system do
   let(:user) { FactoryBot.create(:princeton_submitter) }
   let(:title) { "Sowing the Seeds for More Usable Web Archives: A Usability Study of Archive-It" }
   let(:contributors) do

--- a/spec/system/rss_spec.rb
+++ b/spec/system/rss_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "rails_helper"
 
-RSpec.describe "RSS feed of approved works, for harvesting and indexing", type: :system, mock_ezid_api: true do
+RSpec.describe "RSS feed of approved works, for harvesting and indexing", type: :system do
   let(:work1) { FactoryBot.create(:draft_work) }
   let(:work2) { FactoryBot.create(:draft_work) }
   let(:work3) { FactoryBot.create(:draft_work) }

--- a/spec/system/work_spec.rb
+++ b/spec/system/work_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "rails_helper"
 
-RSpec.describe "Creating and updating works", type: :system, mock_ezid_api: true do
+RSpec.describe "Creating and updating works", type: :system do
   let(:user) { FactoryBot.create(:princeton_submitter) }
 
   before do
@@ -48,7 +48,7 @@ RSpec.describe "Creating and updating works", type: :system, mock_ezid_api: true
     expect(page.html.include?("By initiating this new submission, we have reserved a draft DOI for your use")).to be true
   end
 
-  it "Handles ARK URLs in the ARK field", js: true do
+  it "Handles ARK URLs in the ARK field", js: true, mock_ezid_api: true do
     resource = FactoryBot.build(:resource, creators: [PDCMetadata::Creator.new_person("Harriet", "Tubman", "1234-5678-9012-3456")])
     work = FactoryBot.create(:draft_work, resource: resource)
     user = work.created_by_user

--- a/spec/views/works/file_upload.html.erb_spec.rb
+++ b/spec/views/works/file_upload.html.erb_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "rails_helper"
 
-describe "works/file_upload.html.erb", mock_ezid_api: true do
+describe "works/file_upload.html.erb" do
   let(:collection) { Collection.first }
   let(:user) { FactoryBot.create(:user) }
 


### PR DESCRIPTION
DOIs are minted and ARKs are NOT.

Removing mocking for ezid in locations where it was not needed.  The code that needed the mocking was removed in the commit aa9c96ee97e2c3d8e205e1bd556a9d86c35fcef2

refs #17