### PR TITLE
Ensures that clients cannot delete post-curation S3 Objects

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -112,7 +112,7 @@ class WorksController < ApplicationController
       upload_keys = work_params[:deleted_uploads]
       deleted_uploads = WorkUploadsEditService.find_post_curation_uploads(work: @work, upload_keys: upload_keys)
 
-      @work.delete_post_curation_uploads(uploads: deleted_uploads)
+      return head(:forbidden) unless deleted_uploads.empty?
     else
       updated_pre_curation_uploads = WorkUploadsEditService.precurated_file_list(@work, work_params)
       updates[:pre_curation_uploads] = updated_pre_curation_uploads

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -425,12 +425,6 @@ class Work < ApplicationRecord
     post_curation_s3_query_service.bucket_name
   end
 
-  def delete_post_curation_uploads(uploads:)
-    uploads.each do |upload|
-      s3_client.delete_object(bucket: bucket_name, key: upload.key)
-    end
-  end
-
   def add_post_curation_s3_object(blob:)
     s3_client.put_object({
                            bucket: post_curation_bucket_name,

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -458,6 +458,7 @@ RSpec.describe WorksController do
           allow(s3_client).to receive(:delete_object)
           allow(s3_query_service_double).to receive(:client).and_return(s3_client)
           allow(s3_query_service_double).to receive(:data_profile).and_return({ objects: s3_data, ok: true })
+
           stub_request(:put, "https://api.datacite.org/dois/#{work.doi}").to_return(status: 200, body: "", headers: {})
           work.approve!(user)
 
@@ -465,19 +466,13 @@ RSpec.describe WorksController do
           sign_in user
         end
 
-        # @todo Remove this
-        xit "deletes the S3 Objects associated with the Work" do
+        it "returns with a 403 response code" do
           expect(work.post_curation_uploads.length).to eq(2)
 
           sign_in user
           post :update, params: params
 
-          expect(s3_client).to have_received(:delete_object).with(
-            { bucket: "example-bucket", key: "SCoData_combined_v1_2020-07_README.txt" }
-          )
-          expect(s3_client).to have_received(:delete_object).with(
-            { bucket: "example-bucket", key: "SCoData_combined_v1_2020-07_datapackage.json" }
-          )
+          expect(response).to have_http_status(:forbidden)
         end
       end
     end


### PR DESCRIPTION
It was confirmed that users should not be able to delete S3 Objects once they have been curated (please see: https://pulibrary.slack.com/archives/C02PHG9MGU8/p1663955197008019?thread_ts=1663952066.026279&cid=C02PHG9MGU8)