### PR TITLE
Display of error messages when saving

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -103,3 +103,9 @@
 .dataset-table {
   margin-left: 10px;
 }
+
+.error_box {
+  background-color: #ffebeb;
+  border-radius: 12px;
+  padding-left: 10px;
+}

--- a/app/views/works/_form.html.erb
+++ b/app/views/works/_form.html.erb
@@ -1,3 +1,5 @@
+<%= render 'form_errors' %>
+
 <!--
   Information about Bootstrap tabs
   https://getbootstrap.com/docs/5.0/components/navs-tabs/
@@ -19,7 +21,6 @@
 
         <!-- tab: required fields -->
         <div class="tab-pane fade show active" id="v-pills-required" role="tabpanel" aria-labelledby="v-pills-required-tab">
-          <%= render 'form_errors' %>
           <%= form.hidden_field :work_id %>
           <%= render 'required_form' %>
         </div>

--- a/app/views/works/_form_errors.html.erb
+++ b/app/views/works/_form_errors.html.erb
@@ -1,6 +1,7 @@
 <% if @work.errors.any? %>
-<div id="error_explanation">
-  <h2><i class="bi bi-exclamation-triangle-fill" style="color: red"></i><%= pluralize(@work.errors.count, "error") %> prohibited this dataset from being saved:</h2>
+<div id="error_explanation" class="error_box">
+  <h2><i class="bi bi-exclamation-triangle-fill" style="color: red"></i>
+    <%= pluralize(@work.errors.count, "error") %> prohibited this dataset from being saved:</h2>
   <ul>
     <% @work.errors.each do |error| %>
       <li><%= error.full_message %></li>


### PR DESCRIPTION
Moved the error messages to be displayed outside the tabs (see screenshot below) so that users can see them regardless of which tab they are on. This only addresses part of #426, but it moves us in the right direction. I'll submit a separate PR to address the remaining work to close #426 since that might require more thought.

![Screen Shot 2022-09-23 at 2 59 26 PM](https://user-images.githubusercontent.com/568286/192038387-41c05f33-61b0-41e8-b294-510a15e798c1.png)

