### PR TITLE
Reduces the default retry_interval

### DIFF
--- a/config/initializers/ezid_client.rb
+++ b/config/initializers/ezid_client.rb
@@ -4,4 +4,5 @@ Ezid::Client.configure do |config|
   config.default_shoulder = "ark:/99999/fk4" || ENV["EZID_DEFAULT_SHOULDER"]
   config.user = "apitest" || ENV["EZID_USER"]
   config.password = "apitest" || ENV["EZID_PASSWORD"]
+  config.retry_interval = 1 || ENV["EZID_RETRY_INTERVAL"]
 end


### PR DESCRIPTION
The culprit on the slow validation of the ARK is that the gem that we are using does an automatic retry when there is an error with the id provided. By default the gem waits 15 seconds in between retries and it retries twice. This means that if the user provides an invalid ARK the validation takes between 33-35 seconds. Of those, 30 seconds are due to the retry logic.

This is the retry logic on the gem: https://github.com/duke-libraries/ezid-client/blob/dfcf7f49995560ed48df407560c4fe3fb6dbfa7b/lib/ezid/requests/request.rb#L49-L64

This PR changes the default retry value to `1` so that retries happen (almost) immediately and a user waits between 3-5 seconds rather than 33-35 seconds.

This is the code on the gem that shows how the retry value is initialized: https://github.com/duke-libraries/ezid-client/blob/dfcf7f49995560ed48df407560c4fe3fb6dbfa7b/lib/ezid/configuration.rb#L44-L52

Closes #432 