### PR TITLE
Explicitly deleting files as they change

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -115,14 +115,10 @@ class WorksController < ApplicationController
 
       return head(:forbidden) unless deleted_uploads.empty?
     else
-      updated_pre_curation_uploads = WorkUploadsEditService.precurated_file_list(@work, work_params)
-      updates[:pre_curation_uploads] = updated_pre_curation_uploads
+      @work = WorkUploadsEditService.update_precurated_file_list(@work, work_params)
     end
 
     if @work.update(updates)
-      # pause to allow s3 time to remove the file completely
-      sleep(0.1) if work_params.key?(:deleted_uploads)
-
       if @wizard_mode
         redirect_to work_attachment_select_url(@work)
       else

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -62,6 +62,8 @@ Rails.application.configure do
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 
+  # config.active_job.queue_adapter     = :inline
+
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 

--- a/spec/system/work_edit_spec.rb
+++ b/spec/system/work_edit_spec.rb
@@ -66,6 +66,7 @@ RSpec.describe "Creating and updating works", type: :system, js: true, mock_s3_q
     end
 
     it "allows users to delete one of the uploads" do
+      allow(ActiveStorage::PurgeJob).to receive(:new).and_call_original
       # Make the screen larger so the save button is alway on screen.  This avoids random `Element is not clickable` errors
       page.driver.browser.manage.window.resize_to(2000, 2000)
       expect(page).to have_content "Filename"
@@ -79,6 +80,7 @@ RSpec.describe "Creating and updating works", type: :system, js: true, mock_s3_q
       expect(page).to have_content("us_covid_2020.csv")
       expect(page).not_to have_content("us_covid_2019.csv")
       expect(a_request(:delete, delete_url)).to have_been_made
+      expect(ActiveStorage::PurgeJob).not_to have_received(:new)
     end
   end
 end


### PR DESCRIPTION
We no longer rely on ActiveStorage to do the Right thing, by setting the attribute pre_curation_uploads. 
Instead we explicitly call purge on items that are deleted.  ActiveStorage will utilize a purge_later which introduces a timing issue when deleting items and then reloading from S3 for the show page, immediately after the deletes.

fixes #394