### PR TITLE
Improvements for the transfer of pre-curation uploads to the post-curation S3 Bucket for Works

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,6 +40,7 @@ Metrics/ClassLength:
 Metrics/MethodLength:
   Exclude:
     - "app/models/work.rb"
+    - "spec/support/work_s3_requests_specs.rb"
 
 Metrics/ParameterLists:
   Enabled: false

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -516,6 +516,7 @@ RSpec.describe WorksController do
           allow(S3QueryService).to receive(:new).and_return(s3_query_service_double)
           allow(s3_query_service_double).to receive(:bucket_name).and_return("example-bucket")
           allow(s3_client).to receive(:delete_object)
+          allow(s3_client).to receive(:head_object)
           allow(s3_query_service_double).to receive(:client).and_return(s3_client)
           allow(s3_query_service_double).to receive(:data_profile).and_return({ objects: s3_data, ok: true })
 

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -510,20 +510,23 @@ RSpec.describe WorksController do
         end
         let(:s3_client) { instance_double(Aws::S3::Client) }
         let(:s3_object) { double }
+        let(:uploaded_file) { fixture_file_upload("us_covid_2019.csv", "text/csv") }
 
         before do
           # Account for files in S3 added outside of ActiveStorage
           allow(S3QueryService).to receive(:new).and_return(s3_query_service_double)
           allow(s3_query_service_double).to receive(:bucket_name).and_return("example-bucket")
           allow(s3_client).to receive(:delete_object)
-          allow(s3_client).to receive(:head_object)
+          allow(s3_client).to receive(:put_object)
+          allow(s3_client).to receive(:head_object).with(bucket: "example-bucket", key: "#{work.s3_object_key}/us_covid_2019.csv").and_return(true)
+          allow(s3_client).to receive(:head_object).with(bucket: "example-bucket", key: work.s3_object_key.to_s)
           allow(s3_query_service_double).to receive(:client).and_return(s3_client)
           allow(s3_query_service_double).to receive(:data_profile).and_return({ objects: s3_data, ok: true })
 
           stub_request(:put, "https://api.datacite.org/dois/#{work.doi}").to_return(status: 200, body: "", headers: {})
+          work.pre_curation_uploads.attach(uploaded_file)
           work.approve!(user)
 
-          work.attach_s3_resources
           sign_in user
         end
 

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe Work, type: :model do
 
     before do
       allow(s3_client).to receive(:put_object)
-      allow(s3_client).to receive(:head_object).with(bucket: "example-bucket", key: "10.34770/123-abc")
+      allow(s3_client).to receive(:head_object).with(bucket: "example-bucket", key: "10.34770/123-abc/#{work.id}").and_raise(Aws::S3::Errors::NotFound.new(true, "test error"))
       allow(s3_client).to receive(:head_object).with(bucket: "example-bucket", key: "10.34770/123-abc/#{work.id}/us_covid_2019.csv").and_return(true)
       allow(s3_client).to receive(:head_object).with(bucket: "example-bucket", key: "10.34770/123-abc/#{work.id}/us_covid_2019_2.csv").and_return(true)
       allow(s3_client).to receive(:delete_object).and_return(nil)

--- a/spec/support/s3_query_service_specs.rb
+++ b/spec/support/s3_query_service_specs.rb
@@ -1,8 +1,14 @@
 # frozen_string_literal: true
 
 def stub_s3(data: [])
-  fake_s3_query = double(S3QueryService, data_profile: { objects: data, ok: true })
+  @s3_client = instance_double(Aws::S3::Client)
+  allow(@s3_client).to receive(:head_object)
+  allow(@s3_client).to receive(:delete_object)
+
+  fake_s3_query = double(S3QueryService, data_profile: { objects: data, ok: true }, client: @s3_client)
+  allow(fake_s3_query).to receive(:bucket_name).and_return("example-bucket")
   allow(S3QueryService).to receive(:new).and_return(fake_s3_query)
+
   fake_s3_query
 end
 

--- a/spec/support/work_s3_requests_specs.rb
+++ b/spec/support/work_s3_requests_specs.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+RSpec.configure do |_config|
+  def build_s3_list_objects_response(work:, file_name:)
+    @s3_list_objects_response = <<-XML
+<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Name>example-bucket</Name>
+  <Prefix/>
+  <KeyCount>1</KeyCount>
+  <MaxKeys>1000</MaxKeys>
+  <IsTruncated>false</IsTruncated>
+  <Contents>
+    <Key>#{work.s3_object_key}/#{file_name}</Key>
+    <LastModified>2009-10-12T17:50:30.000Z</LastModified>
+    <ETag>"fba9dede5f27731c9771645a39863328"</ETag>
+    <Size>434234</Size>
+    <StorageClass>STANDARD</StorageClass>
+  </Contents>
+</ListBucketResult>
+XML
+  end
+
+  def stub_work_s3_requests(work:, file_name:)
+    @works = [work]
+    @works.each do |w|
+      # Stub the request for the S3 directory object to determine if it exists
+      stub_request(:head, "https://example-bucket.s3.amazonaws.com/#{w.s3_object_key}").to_return(status: 404)
+      # Stub the request for deleting the pre-curation S3 directory object
+      stub_request(:delete, "https://example-bucket.s3.amazonaws.com/#{w.s3_object_key}").to_return(status: 200)
+      # Stub the request for retrieving the S3 file attachment object
+      stub_request(:get, "https://example-bucket.s3.amazonaws.com/#{w.s3_object_key}/#{file_name}").to_return(status: 200)
+      # Stub the request for uploading the S3 file attachment object
+      stub_request(:put, "https://example-bucket.s3.amazonaws.com/#{w.s3_object_key}/#{file_name}").to_return(status: 200)
+      # Stub the request for querying the contents of the S3 directory object
+      s3_list_objects_response = build_s3_list_objects_response(work: w, file_name: file_name)
+      stub_request(:get, "https://example-bucket.s3.amazonaws.com/?list-type=2&max-keys=1000&prefix=#{w.s3_object_key}/").to_return(
+        status: 200,
+        body: s3_list_objects_response
+      )
+      # Stub the request for retrieving the S3 file attachment object
+      stub_request(:get, "https://example-bucket.s3.amazonaws.com/#{w.s3_object_key}/#{file_name}").to_return(
+        status: 200,
+        body: {
+          accept_ranges: "bytes",
+          content_length: 3191,
+          content_type: "image/jpeg",
+          etag: "\"6805f2cfc46c0f04559748bb039d69ae\"",
+          last_modified: Time.parse("Thu, 15 Dec 2016 01:19:41 GMT"),
+          metadata: {
+          },
+          tag_count: 2,
+          version_id: "null"
+        }.to_json
+      )
+
+      stub_request(:head, "https://example-bucket.s3.amazonaws.com/#{w.s3_object_key}/#{file_name}").to_return(status: 200)
+      stub_request(:delete, "https://example-bucket.s3.amazonaws.com/#{w.s3_object_key}/#{file_name}").to_return(status: 200)
+    end
+  end
+end

--- a/spec/system/rss_spec.rb
+++ b/spec/system/rss_spec.rb
@@ -6,22 +6,96 @@ RSpec.describe "RSS feed of approved works, for harvesting and indexing", type: 
   let(:work2) { FactoryBot.create(:draft_work) }
   let(:work3) { FactoryBot.create(:draft_work) }
   let(:admin) { FactoryBot.create(:super_admin_user) }
+  let(:file_name) { "us_covid_2019.csv" }
+  let(:uploaded_file) { fixture_file_upload(file_name, "text/csv") }
+  let(:list_objects_response) do
+    <<-XML
+<?xml version="1.0" encoding="UTF-8"?>
+      <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+          <Name>example-bucket</Name>
+    <Prefix/>
+    <KeyCount>1</KeyCount>
+    <MaxKeys>1000</MaxKeys>
+    <IsTruncated>false</IsTruncated>
+    <Contents>
+        <Key>#{file_name}</Key>
+        <LastModified>2009-10-12T17:50:30.000Z</LastModified>
+        <ETag>"fba9dede5f27731c9771645a39863328"</ETag>
+        <Size>434234</Size>
+        <StorageClass>STANDARD</StorageClass>
+    </Contents>
+</ListBucketResult>
+XML
+  end
 
   before do
     stub_datacite(host: "api.datacite.org", body: datacite_register_body(prefix: "10.34770"))
 
-    stub_request(:head, "https://example-bucket.s3.amazonaws.com/#{work1.doi}").to_return(status: 404)
-    stub_request(:head, "https://example-bucket.s3.amazonaws.com/#{work2.doi}").to_return(status: 404)
-    stub_request(:delete, "https://example-bucket.s3.amazonaws.com/#{work1.doi}").to_return(status: 200)
-    stub_request(:delete, "https://example-bucket.s3.amazonaws.com/#{work2.doi}").to_return(status: 200)
+    stub_request(:head, "https://example-bucket.s3.amazonaws.com/#{work1.s3_object_key}").to_return(status: 404)
+    stub_request(:head, "https://example-bucket.s3.amazonaws.com/#{work2.s3_object_key}").to_return(status: 404)
+
+    stub_request(:head, "https://example-bucket.s3.amazonaws.com/#{work1.s3_object_key}").to_return(status: 404)
+    stub_request(:head, "https://example-bucket.s3.amazonaws.com/#{work2.s3_object_key}").to_return(status: 404)
+
+    stub_request(:delete, "https://example-bucket.s3.amazonaws.com/#{work1.s3_object_key}").to_return(status: 200)
+    stub_request(:delete, "https://example-bucket.s3.amazonaws.com/#{work2.s3_object_key}").to_return(status: 200)
+
+    stub_request(:put, "https://example-bucket.s3.amazonaws.com/#{work1.s3_object_key}/us_covid_2019.csv").to_return(status: 200)
+    stub_request(:put, "https://example-bucket.s3.amazonaws.com/#{work2.s3_object_key}/us_covid_2019.csv").to_return(status: 200)
+
+    stub_request(:get, "https://example-bucket.s3.amazonaws.com/?list-type=2&max-keys=1000&prefix=#{work1.s3_object_key}/").to_return(
+      status: 200,
+      body: list_objects_response
+    )
+    stub_request(:get, "https://example-bucket.s3.amazonaws.com/?list-type=2&max-keys=1000&prefix=#{work2.s3_object_key}/").to_return(
+      status: 200,
+      body: list_objects_response
+    )
+
+    stub_request(:get, "https://example-bucket.s3.amazonaws.com/#{work1.s3_object_key}/us_covid_2019.csv").to_return(
+      status: 200,
+      body: {
+        accept_ranges: "bytes",
+        content_length: 3191,
+        content_type: "image/jpeg",
+        etag: "\"6805f2cfc46c0f04559748bb039d69ae\"",
+        last_modified: Time.parse("Thu, 15 Dec 2016 01:19:41 GMT"),
+        metadata: {
+        },
+        tag_count: 2,
+        version_id: "null"
+      }.to_json
+    )
+    stub_request(:get, "https://example-bucket.s3.amazonaws.com/#{work2.s3_object_key}/us_covid_2019.csv").to_return(
+      status: 200,
+      body: {
+        accept_ranges: "bytes",
+        content_length: 3191,
+        content_type: "image/jpeg",
+        etag: "\"6805f2cfc46c0f04559748bb039d69ae\"",
+        last_modified: Time.parse("Thu, 15 Dec 2016 01:19:41 GMT"),
+        metadata: {
+        },
+        tag_count: 2,
+        version_id: "null"
+      }.to_json
+    )
+
+    stub_request(:head, "https://example-bucket.s3.amazonaws.com/#{work1.s3_object_key}/us_covid_2019.csv").to_return(status: 200)
+    stub_request(:head, "https://example-bucket.s3.amazonaws.com/#{work2.s3_object_key}/us_covid_2019.csv").to_return(status: 200)
+
+    stub_request(:delete, "https://example-bucket.s3.amazonaws.com/#{work1.s3_object_key}/us_covid_2019.csv").to_return(status: 200)
+    stub_request(:delete, "https://example-bucket.s3.amazonaws.com/#{work2.s3_object_key}/us_covid_2019.csv").to_return(status: 200)
 
     allow(work1).to receive(:publish_doi).and_return(true)
     allow(work2).to receive(:publish_doi).and_return(true)
 
     # Works 1 & 2 are approved, so they should show up in the RSS feed
+    work1.pre_curation_uploads.attach(uploaded_file)
     work1.complete_submission!(admin)
     work1.approve!(admin)
 
+    work2.pre_curation_uploads.attach(uploaded_file)
     work2.complete_submission!(admin)
     work2.approve!(admin)
 

--- a/spec/system/rss_spec.rb
+++ b/spec/system/rss_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe "RSS feed of approved works, for harvesting and indexing", type: 
 
   before do
     stub_datacite(host: "api.datacite.org", body: datacite_register_body(prefix: "10.34770"))
+
+    stub_request(:head, "https://example-bucket.s3.amazonaws.com/#{work1.doi}").to_return(status: 404)
+    stub_request(:head, "https://example-bucket.s3.amazonaws.com/#{work2.doi}").to_return(status: 404)
+    stub_request(:delete, "https://example-bucket.s3.amazonaws.com/#{work1.doi}").to_return(status: 200)
+    stub_request(:delete, "https://example-bucket.s3.amazonaws.com/#{work2.doi}").to_return(status: 200)
+
     allow(work1).to receive(:publish_doi).and_return(true)
     allow(work2).to receive(:publish_doi).and_return(true)
 

--- a/spec/system/view_data_in_s3_spec.rb
+++ b/spec/system/view_data_in_s3_spec.rb
@@ -63,11 +63,11 @@ RSpec.describe "View status of data in S3", mock_ezid_api: true do
     context "when item is approved" do
       let(:work) { FactoryBot.create(:approved_work) }
       it "shows data from S3" do
-        stub_s3(data: s3_data)
-        visit work_path(work)
-        expect(page).to have_content file1.filename
-        expect(page).to have_content file2.filename
+        stub_work_s3_requests(work: work, file_name: file1.filename)
 
+        visit work_path(work)
+
+        expect(page).to have_content file1.filename
         expect(page).not_to have_button("Edit")
       end
 


### PR DESCRIPTION
Advances #256 by addressing the following:
- Files no longer exist in the pre-curation bucket
- Files should exist in the post-curation bucket in a directory that is the dataset DOI
- The directory in the pre-curation bucket should be removed
- An error is raised if the post-curation bucket already has a directory for the DOI
- Make sure it exists in the new location, before deleting it in the old location