### PR TITLE
Do not allow edit by submitter after approved

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -88,9 +88,13 @@ class WorksController < ApplicationController
   def edit
     @work = Work.find(params[:id])
     if current_user && @work.editable_by?(current_user)
-      @uploads = @work.uploads
-      @wizard_mode = wizard_mode?
-      render "edit"
+      if @work.approved? && @work.submitted_by?(current_user)
+        redirect_to root_path, notice: I18n.t("works.approved.uneditable")
+      else
+        @uploads = @work.uploads
+        @wizard_mode = wizard_mode?
+        render "edit"
+      end
     else
       Rails.logger.warn("Unauthorized attempt to edit work #{@work.id} by user #{current_user.uid}")
       redirect_to root_path

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -60,10 +60,14 @@ class Work < ApplicationRecord
   # @param [User]
   # @return [Boolean]
   def editable_by?(user)
-    return true if created_by_user_id == user.id
+    return true if submitted_by?(user)
     collection = Collection.find(collection_id)
     return true if user.has_role?(:collection_admin, collection)
     false
+  end
+
+  def submitted_by?(user)
+    return true if created_by_user_id == user.id
   end
 
   class << self

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,3 +58,5 @@ en:
         replace_upload: "Replace Upload"
         empty: "No files in S3"
         delete_upload: "Delete Upload"
+    approved:
+      uneditable: "This work has been approved.  Edits are no longer available."

--- a/spec/factories/work.rb
+++ b/spec/factories/work.rb
@@ -23,6 +23,17 @@ FactoryBot.define do
       resource { FactoryBot.build :resource, doi: doi, ark: ark }
     end
 
+    factory :approved_work do
+      transient do
+        doi { "10.34770/123-abc" }
+        ark { nil }
+      end
+      collection { Collection.research_data }
+      state { "approved" }
+      created_by_user_id { FactoryBot.create(:user).id }
+      resource { FactoryBot.build :resource, doi: doi, ark: ark }
+    end
+
     factory :shakespeare_and_company_work do
       collection { Collection.research_data }
       resource do


### PR DESCRIPTION
Stop the user from editing the work at the controller level after the work has been approved

refs #255

This is a first step.  We would still need to remove the edit button from the page, and protect the update action.  I think those can be done as separate PRs to keep them smaller.