### PR TITLE
Log changes

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -308,7 +308,13 @@ class WorksController < ApplicationController
     end
 
     def process_updates
+      resource_before = @work.resource
       if @work.update(update_params)
+
+        resource_compare = ResourceCompare.new(resource_before, update_params.resource)
+        changes = resource_compare.compare()
+        @work.log_changes(changes, current_user)
+
         if @wizard_mode
           redirect_to work_attachment_select_url(@work)
         else

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -101,6 +101,7 @@ class WorksController < ApplicationController
     end
   end
 
+<<<<<<< HEAD
   def update
     @work = Work.find(params[:id])
     if current_user.blank? || !@work.editable_by?(current_user)
@@ -108,10 +109,50 @@ class WorksController < ApplicationController
       redirect_to root_path
     elsif @work.approved? && @work.submitted_by?(current_user)
       redirect_to root_path, notice: I18n.t("works.approved.uneditable")
+=======
+  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/AbcSize
+  def update
+    @work = Work.find(params[:id])
+    @wizard_mode = wizard_mode?
+
+    collection_id_param = params[:collection_id]
+
+    resource_original = @work.resource
+    resource_updated = FormToResourceService.convert(params, @work, current_user)
+    updates = {
+      collection_id: collection_id_param,
+      resource: resource_updated
+    }
+
+    if @work.approved?
+      upload_keys = work_params[:deleted_uploads] || []
+      deleted_uploads = WorkUploadsEditService.find_post_curation_uploads(work: @work, upload_keys: upload_keys)
+
+      return head(:forbidden) unless deleted_uploads.empty?
+    else
+      @work = WorkUploadsEditService.update_precurated_file_list(@work, work_params)
+    end
+
+    if @work.update(updates)
+      compare = ResourceCompare.new(resource_original, resource_updated)
+      @work.log_changes(compare.differences, current_user)
+
+      if @wizard_mode
+        redirect_to work_attachment_select_url(@work)
+      else
+        redirect_to work_url(@work), notice: "Work was successfully updated."
+      end
+>>>>>>> Fine tuned some of the code.
     else
       update_work
     end
   end
+<<<<<<< HEAD
+=======
+  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/AbcSize
+>>>>>>> Fine tuned some of the code.
 
   # Prompt to select how to submit their files
   def attachment_select

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -135,8 +135,8 @@ class WorksController < ApplicationController
     end
 
     if @work.update(updates)
-      compare = ResourceCompare.new(resource_original, resource_updated)
-      @work.log_changes(compare.differences, current_user)
+      resource_compare = ResourceCompare.new(resource_original, resource_updated)
+      @work.log_changes(resource_compare, current_user)
 
       if @wizard_mode
         redirect_to work_attachment_select_url(@work)

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -311,7 +311,7 @@ class WorksController < ApplicationController
       resource_before = @work.resource
       if @work.update(update_params)
 
-        resource_compare = ResourceCompare.new(resource_before, update_params[:resource])
+        resource_compare = ResourceCompareService.new(resource_before, update_params[:resource])
         @work.log_changes(resource_compare, current_user)
 
         if @wizard_mode

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -101,7 +101,6 @@ class WorksController < ApplicationController
     end
   end
 
-<<<<<<< HEAD
   def update
     @work = Work.find(params[:id])
     if current_user.blank? || !@work.editable_by?(current_user)
@@ -109,50 +108,10 @@ class WorksController < ApplicationController
       redirect_to root_path
     elsif @work.approved? && @work.submitted_by?(current_user)
       redirect_to root_path, notice: I18n.t("works.approved.uneditable")
-=======
-  # rubocop:disable Metrics/MethodLength
-  # rubocop:disable Metrics/AbcSize
-  def update
-    @work = Work.find(params[:id])
-    @wizard_mode = wizard_mode?
-
-    collection_id_param = params[:collection_id]
-
-    resource_original = @work.resource
-    resource_updated = FormToResourceService.convert(params, @work, current_user)
-    updates = {
-      collection_id: collection_id_param,
-      resource: resource_updated
-    }
-
-    if @work.approved?
-      upload_keys = work_params[:deleted_uploads] || []
-      deleted_uploads = WorkUploadsEditService.find_post_curation_uploads(work: @work, upload_keys: upload_keys)
-
-      return head(:forbidden) unless deleted_uploads.empty?
-    else
-      @work = WorkUploadsEditService.update_precurated_file_list(@work, work_params)
-    end
-
-    if @work.update(updates)
-      resource_compare = ResourceCompare.new(resource_original, resource_updated)
-      @work.log_changes(resource_compare, current_user)
-
-      if @wizard_mode
-        redirect_to work_attachment_select_url(@work)
-      else
-        redirect_to work_url(@work), notice: "Work was successfully updated."
-      end
->>>>>>> Fine tuned some of the code.
     else
       update_work
     end
   end
-<<<<<<< HEAD
-=======
-  # rubocop:enable Metrics/MethodLength
-  # rubocop:enable Metrics/AbcSize
->>>>>>> Fine tuned some of the code.
 
   # Prompt to select how to submit their files
   def attachment_select
@@ -352,9 +311,8 @@ class WorksController < ApplicationController
       resource_before = @work.resource
       if @work.update(update_params)
 
-        resource_compare = ResourceCompare.new(resource_before, update_params.resource)
-        changes = resource_compare.compare()
-        @work.log_changes(changes, current_user)
+        resource_compare = ResourceCompare.new(resource_before, update_params[:resource])
+        @work.log_changes(resource_compare, current_user)
 
         if @wizard_mode
           redirect_to work_attachment_select_url(@work)

--- a/app/models/pdc_metadata/creator.rb
+++ b/app/models/pdc_metadata/creator.rb
@@ -47,6 +47,10 @@ module PDCMetadata
       identifier&.orcid
     end
 
+    def compare_value
+      "#{value} | #{sequence} | #{type}"
+    end
+
     def self.new_person(given_name, family_name, orcid_id = nil, sequence = 0)
       full_name = "#{family_name}, #{given_name}"
       creator = Creator.new(value: full_name, name_type: "Personal", given_name: given_name, family_name: family_name, sequence: sequence)

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -357,9 +357,9 @@ class Work < ApplicationRecord
     WorkActivity.add_system_activity(id, comment, current_user.id, activity_type: "COMMENT")
   end
 
-  def log_changes(changes, current_user)
-    return if changes == {}
-    WorkActivity.add_system_activity(id, changes.to_json, current_user.id, activity_type: "CHANGES")
+  def log_changes(resource_compare, current_user)
+    return if resource_compare.identical?
+    WorkActivity.add_system_activity(id, resource_compare.differences.to_json, current_user.id, activity_type: "CHANGES")
   end
 
   def activities

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -357,6 +357,11 @@ class Work < ApplicationRecord
     WorkActivity.add_system_activity(id, comment, current_user.id, activity_type: "COMMENT")
   end
 
+  def log_changes(changes, current_user)
+    return if changes == {}
+    WorkActivity.add_system_activity(id, changes.to_json, current_user.id, activity_type: "CHANGES")
+  end
+
   def activities
     WorkActivity.where(work_id: id).sort_by(&:updated_at).reverse
   end

--- a/app/models/work_activity.rb
+++ b/app/models/work_activity.rb
@@ -67,15 +67,10 @@ class WorkActivity < ApplicationRecord
       text = ""
       changes = JSON.parse(message)
       changes.keys.each do |field|
-        if changes[field].is_a?(Array)
-          # Multi-value change, process each individual entry
-          values = changes[field].map { |value| change_value_html(value) }
-          text += "<p><b>#{field}</b>:#{values.join}</p>"
-        else
-          # Single-value change
-          value = changes[field]
-          text += "<p><b>#{field}</b>: #{change_value_html(value)}</p>"
-        end
+        # changes[field] can be a hash (for single-value fields) or
+        # an array of hashes (for multi-value fields) - hence the call to Array.wrap()
+        values = Array.wrap(changes[field]).map { |value| change_value_html(value) }.join
+        text += "<p><b>#{field}</b>: #{values}</p>"
       end
       text
     end

--- a/app/models/work_activity.rb
+++ b/app/models/work_activity.rb
@@ -63,27 +63,22 @@ class WorkActivity < ApplicationRecord
     end
 
     # Returns the message formatted to display changes that were logged as an activity
-    # rubocop:disable Metrics/MethodLength
     def changes_html
       text = ""
       changes = JSON.parse(message)
       changes.keys.each do |field|
         if changes[field].is_a?(Array)
-          # Multi-value change logged, process each individual entry
-          text += "<p><b>#{field}</b>:"
-          changes[field].each do |value|
-            text += change_value_html(value)
-          end
-          text += "</p>"
+          # Multi-value change, process each individual entry
+          values = changes[field].map { |value| change_value_html(value) }
+          text += "<p><b>#{field}</b>:#{values.join}</p>"
         else
-          # Single-value change logged
+          # Single-value change
           value = changes[field]
           text += "<p><b>#{field}</b>: #{change_value_html(value)}</p>"
         end
       end
       text
     end
-    # rubocop:enable Metrics/MethodLength
 
     def change_value_html(value)
       if value["action"] == "added"
@@ -109,13 +104,14 @@ class WorkActivity < ApplicationRecord
 
     def change_set_html(from, to)
       if from.blank? && to.present?
+        # value was set
         "<span>#{to}</span><br/>"
       elsif from.present? && to.present?
-        "<span style=\"text-decoration: line-through;\">#{from}</span> <span>#{to}</span><br/>"
-      elsif from.present? && to.blank?
-        "<span style=\"text-decoration: line-through;\">#{from}</span>"
+        # value was changed
+        "<span>#{to}</span><br/>"
       else
-        "<span style=\"text-decoration: line-through;\">#{from}</span> <span>#{to}</span><br/>"
+        # value was cleared
+        "<span style=\"text-decoration: line-through;\">#{from.length <= 20 ? from : (from[0..15] + '...')}</span>"
       end
     end
 end

--- a/app/models/work_activity.rb
+++ b/app/models/work_activity.rb
@@ -67,9 +67,7 @@ class WorkActivity < ApplicationRecord
       text = ""
       changes = JSON.parse(message)
       changes.keys.each do |field|
-        # changes[field] can be a hash (for single-value fields) or
-        # an array of hashes (for multi-value fields) - hence the call to Array.wrap()
-        values = Array.wrap(changes[field]).map { |value| change_value_html(value) }.join
+        values = changes[field].map { |value| change_value_html(value) }.join
         text += "<p><b>#{field}</b>: #{values}</p>"
       end
       text

--- a/app/models/work_activity.rb
+++ b/app/models/work_activity.rb
@@ -109,7 +109,7 @@ class WorkActivity < ApplicationRecord
       elsif from.present? && to.present?
         # value was changed
         "<span>#{to}</span><br/>"
-      else
+      elsif from.present? && to.blank?
         # value was cleared
         "<span style=\"text-decoration: line-through;\">#{from.length <= 20 ? from : (from[0..15] + '...')}</span>"
       end

--- a/app/services/form_to_resource_service.rb
+++ b/app/services/form_to_resource_service.rb
@@ -15,8 +15,6 @@ class FormToResourceService
       resource.publication_year = params["publication_year"] if params["publication_year"].present?
       resource.rights = PDCMetadata::Rights.find(params["rights_identifier"])
       resource.keywords = (params["keywords"] || "").split(",").map(&:strip)
-      resource.resource_type = params["resource_type"]
-      resource.resource_type_general = params["resource_type_general"]
 
       # Process the titles
       resource = process_titles(params, resource)

--- a/app/services/form_to_resource_service.rb
+++ b/app/services/form_to_resource_service.rb
@@ -15,6 +15,8 @@ class FormToResourceService
       resource.publication_year = params["publication_year"] if params["publication_year"].present?
       resource.rights = PDCMetadata::Rights.find(params["rights_identifier"])
       resource.keywords = (params["keywords"] || "").split(",").map(&:strip)
+      resource.resource_type = params["resource_type"]
+      resource.resource_type_general = params["resource_type_general"]
 
       # Process the titles
       resource = process_titles(params, resource)

--- a/app/services/form_to_resource_service.rb
+++ b/app/services/form_to_resource_service.rb
@@ -14,7 +14,7 @@ class FormToResourceService
       resource.publisher = params["publisher"] if params["publisher"].present?
       resource.publication_year = params["publication_year"] if params["publication_year"].present?
       resource.rights = PDCMetadata::Rights.find(params["rights_identifier"])
-      resource.keywords = (params["keywords"] || "").split(",")
+      resource.keywords = (params["keywords"] || "").split(",").map(&:strip)
 
       # Process the titles
       resource = process_titles(params, resource)

--- a/app/services/resource_compare.rb
+++ b/app/services/resource_compare.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+class ResourceCompare
+  def initialize(before, after)
+    @before = before
+    @after = after
+    @result = {}
+  end
+
+  def compare()
+    compare_titles()
+    compare_creators()
+    # :contributors
+    compare_single_values()
+    @result
+  end
+
+  def compare_single_values()
+    field_names = [:description, :publisher, :publication_year, :resource_type, :resource_type_general,
+      :doi, :ark, :version_number, :collection_tags]
+
+    field_names.each do |field_name|
+      before_value = @before.send(field_name)
+      after_value = @after.send(field_name)
+      if before_value != after_value
+        @result[field_name] = {action: :changed, from: before_value, to: after_value}
+      end
+    end
+
+    before_value = @before.rights&.name
+    after_value = @after.rights&.name
+    if before_value != after_value
+      @result[:rights] = {action: :changed, from: before_value, to: after_value}
+    end
+
+    before_value = @before.keywords.join(',')
+    after_value = @after.keywords.join(',')
+    if before_value != after_value
+      @result[:keywords] = {action: :changed, from: before_value, to: after_value}
+    end
+  end
+
+  def compare_titles()
+    changes = []
+    keys_before = @before.titles.map(&:title_type)
+    keys_after = @after.titles.map(&:title_type)
+
+    removed = keys_before - keys_after
+    added = keys_after - keys_before
+    common = (keys_before + keys_after).uniq - removed - added
+
+    @before.titles.each do |before_title|
+      case
+      when before_title.title_type.in?(common)
+        after_title = @after.titles.find {|t| t.title_type == before_title.title_type }
+        if before_title.title != after_title.title
+          changes << {action: :changed, from: before_title.title, to: after_title.title}
+        end
+      when before_title.title_type.in?(removed)
+        changes << {action: :removed, value: before_title.title}
+      end
+    end
+
+    @after.titles.each do |after_title|
+      if after_title.title_type.in?(added)
+        changes << {action: :added, value: after_title.title}
+      end
+    end
+
+    @result[:titles] = changes if changes.count > 0
+  end
+
+  def compare_creators()
+    changes = []
+    keys_before = @before.creators.map(&:compare_value)
+    keys_after = @after.creators.map(&:compare_value)
+
+    removed = keys_before - keys_after
+    added = keys_after - keys_before
+    common = (keys_before + keys_after).uniq - removed - added
+
+    @before.creators.each do |before_creator|
+      case
+      when before_creator.compare_value.in?(common)
+        after_creator = @after.creators.find {|c| c.compare_value == before_creator.compare_value }
+        if before_creator.compare_value != after_creator.compare_value
+          changes << {action: :changed, from: before_creator.compare_value, to: after_creator.compare_value}
+        end
+      when before_creator.compare_value.in?(removed)
+        changes << {action: :removed, value: before_creator.compare_value}
+      end
+    end
+
+    @after.creators.each do |after_creator|
+      if after_creator.compare_value.in?(added)
+        changes << {action: :added, value: after_creator.compare_value}
+      end
+    end
+
+    @result[:creators] = changes if changes.count > 0
+  end
+end

--- a/app/services/resource_compare.rb
+++ b/app/services/resource_compare.rb
@@ -1,102 +1,162 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/PerceivedComplexity
+# rubocop:disable Metrics/CyclomaticComplexity
+# rubocop:disable Metrics/AbcSize
+# rubocop:disable Metrics/ClassLength
+# rubocop:disable Metrics/MethodLength
+# rubocop:disable Metrics/BlockLength
 class ResourceCompare
+  attr_reader :differences
+
   def initialize(before, after)
     @before = before
     @after = after
-    @result = {}
+    @differences = {}
+    compare_resources
   end
 
-  def compare()
-    compare_titles()
-    compare_creators()
-    # :contributors
-    compare_single_values()
-    @result
-  end
+  private
 
-  def compare_single_values()
-    field_names = [:description, :publisher, :publication_year, :resource_type, :resource_type_general,
-      :doi, :ark, :version_number, :collection_tags]
+    def compare_resources
+      compare_titles
+      compare_creators
+      compare_contributors
+      compare_simple_values
+      compare_rights
+      compare_keywords
+    end
 
-    field_names.each do |field_name|
-      before_value = @before.send(field_name)
-      after_value = @after.send(field_name)
+    ##
+    # Compares simple values between the two resources.
+    def compare_simple_values
+      field_names = [:description, :publisher, :publication_year, :resource_type, :resource_type_general,
+                     :doi, :ark, :version_number, :collection_tags]
+
+      field_names.each do |field_name|
+        before_value = @before.send(field_name)
+        after_value = @after.send(field_name)
+        if before_value != after_value
+          @differences[field_name] = { action: :changed, from: before_value, to: after_value }
+        end
+      end
+    end
+
+    def compare_rights
+      before_value = @before.rights&.name
+      after_value = @after.rights&.name
       if before_value != after_value
-        @result[field_name] = {action: :changed, from: before_value, to: after_value}
+        @differences[:rights] = { action: :changed, from: before_value, to: after_value }
       end
     end
 
-    before_value = @before.rights&.name
-    after_value = @after.rights&.name
-    if before_value != after_value
-      @result[:rights] = {action: :changed, from: before_value, to: after_value}
+    def compare_keywords
+      before_value = @before.keywords.join(",")
+      after_value = @after.keywords.join(",")
+      if before_value != after_value
+        @differences[:keywords] = { action: :changed, from: before_value, to: after_value }
+      end
     end
 
-    before_value = @before.keywords.join(',')
-    after_value = @after.keywords.join(',')
-    if before_value != after_value
-      @result[:keywords] = {action: :changed, from: before_value, to: after_value}
-    end
-  end
+    ##
+    # Compares the titles between the two resources. This is a bit tricky because we support many
+    # titles and the title itself is an object with two properties (title and title_type)
+    def compare_titles
+      changes = []
+      keys_before = @before.titles.map(&:title_type)
+      keys_after = @after.titles.map(&:title_type)
 
-  def compare_titles()
-    changes = []
-    keys_before = @before.titles.map(&:title_type)
-    keys_after = @after.titles.map(&:title_type)
+      removed = keys_before - keys_after
+      added = keys_after - keys_before
+      common = (keys_before + keys_after).uniq - removed - added
 
-    removed = keys_before - keys_after
-    added = keys_after - keys_before
-    common = (keys_before + keys_after).uniq - removed - added
-
-    @before.titles.each do |before_title|
-      case
-      when before_title.title_type.in?(common)
-        after_title = @after.titles.find {|t| t.title_type == before_title.title_type }
-        if before_title.title != after_title.title
-          changes << {action: :changed, from: before_title.title, to: after_title.title}
+      @before.titles.each do |before_title|
+        if before_title.title_type.in?(common)
+          after_title = @after.titles.find { |t| t.title_type == before_title.title_type }
+          if before_title.title != after_title.title
+            changes << { action: :changed, from: before_title.title, to: after_title.title }
+          end
+        elsif before_title.title_type.in?(removed)
+          changes << { action: :removed, value: before_title.title }
         end
-      when before_title.title_type.in?(removed)
-        changes << {action: :removed, value: before_title.title}
       end
-    end
 
-    @after.titles.each do |after_title|
-      if after_title.title_type.in?(added)
-        changes << {action: :added, value: after_title.title}
-      end
-    end
-
-    @result[:titles] = changes if changes.count > 0
-  end
-
-  def compare_creators()
-    changes = []
-    keys_before = @before.creators.map(&:compare_value)
-    keys_after = @after.creators.map(&:compare_value)
-
-    removed = keys_before - keys_after
-    added = keys_after - keys_before
-    common = (keys_before + keys_after).uniq - removed - added
-
-    @before.creators.each do |before_creator|
-      case
-      when before_creator.compare_value.in?(common)
-        after_creator = @after.creators.find {|c| c.compare_value == before_creator.compare_value }
-        if before_creator.compare_value != after_creator.compare_value
-          changes << {action: :changed, from: before_creator.compare_value, to: after_creator.compare_value}
+      @after.titles.each do |after_title|
+        if after_title.title_type.in?(added)
+          changes << { action: :added, value: after_title.title }
         end
-      when before_creator.compare_value.in?(removed)
-        changes << {action: :removed, value: before_creator.compare_value}
       end
+
+      @differences[:titles] = changes if changes.count > 0
     end
 
-    @after.creators.each do |after_creator|
-      if after_creator.compare_value.in?(added)
-        changes << {action: :added, value: after_creator.compare_value}
+    ##
+    # Compares the creators between the two resources. This is a bit tricky because we support many
+    # creators and the creator objects have many properties.
+    def compare_creators
+      changes = []
+      keys_before = @before.creators.map(&:compare_value)
+      keys_after = @after.creators.map(&:compare_value)
+
+      removed = keys_before - keys_after
+      added = keys_after - keys_before
+      common = (keys_before + keys_after).uniq - removed - added
+
+      @before.creators.each do |before_creator|
+        if before_creator.compare_value.in?(common)
+          after_creator = @after.creators.find { |c| c.compare_value == before_creator.compare_value }
+          if before_creator.compare_value != after_creator.compare_value
+            changes << { action: :changed, from: before_creator.compare_value, to: after_creator.compare_value }
+          end
+        elsif before_creator.compare_value.in?(removed)
+          changes << { action: :removed, value: before_creator.compare_value }
+        end
       end
+
+      @after.creators.each do |after_creator|
+        if after_creator.compare_value.in?(added)
+          changes << { action: :added, value: after_creator.compare_value }
+        end
+      end
+
+      @differences[:creators] = changes if changes.count > 0
     end
 
-    @result[:creators] = changes if changes.count > 0
-  end
+    ##
+    # Compares the contributors between the two resources. This is a bit tricky because we support many
+    # contributors and the contributor objects have many properties.
+    def compare_contributors
+      changes = []
+      keys_before = @before.contributors.map(&:compare_value)
+      keys_after = @after.contributors.map(&:compare_value)
+
+      removed = keys_before - keys_after
+      added = keys_after - keys_before
+      common = (keys_before + keys_after).uniq - removed - added
+
+      @before.contributors.each do |before_contributor|
+        if before_contributor.compare_value.in?(common)
+          after_contributor = @after.contributors.find { |c| c.compare_value == before_contributor.compare_value }
+          if before_contributor.compare_value != after_contributor.compare_value
+            changes << { action: :changed, from: before_contributor.compare_value, to: after_contributor.compare_value }
+          end
+        elsif before_contributor.compare_value.in?(removed)
+          changes << { action: :removed, value: before_contributor.compare_value }
+        end
+      end
+
+      @after.contributors.each do |after_contributor|
+        if after_contributor.compare_value.in?(added)
+          changes << { action: :added, value: after_contributor.compare_value }
+        end
+      end
+
+      @differences[:contributors] = changes if changes.count > 0
+    end
 end
+# rubocop:enable Metrics/PerceivedComplexity
+# rubocop:enable Metrics/CyclomaticComplexity
+# rubocop:enable Metrics/AbcSize
+# rubocop:enable Metrics/ClassLength
+# rubocop:enable Metrics/MethodLength
+# rubocop:enable Metrics/BlockLength

--- a/app/services/resource_compare_service.rb
+++ b/app/services/resource_compare_service.rb
@@ -6,9 +6,12 @@
 # If there are differences the `differences` hash has the following structure:
 #
 # ```
-#    :field_name = {action:, from:, to:, value: }     for single-value fields (e.g. description)
-#    :field_name = [{action:, from: to:, value: }]    for multi-value fields (e.g. keywords)
+#    :field_name = [{action:, from: to:, value: }]
 # ```
+#
+# The array for ``:field_name` lists all the changes that happened to the field.
+# For single-value fields is always a single element array, for multi-value fields
+# in can contain multiple elements.
 #
 # The `action` indicates whether a value changed, was added, or deleted.
 #
@@ -49,7 +52,7 @@ class ResourceCompareService
         before_value = @before.send(field_name)
         after_value = @after.send(field_name)
         if before_value != after_value
-          @differences[field_name] = { action: :changed, from: before_value, to: after_value }
+          @differences[field_name] = [{ action: :changed, from: before_value, to: after_value }]
         end
       end
     end
@@ -58,7 +61,7 @@ class ResourceCompareService
       before_value = @before.rights&.name
       after_value = @after.rights&.name
       if before_value != after_value
-        @differences[:rights] = { action: :changed, from: before_value, to: after_value }
+        @differences[:rights] = [{ action: :changed, from: before_value, to: after_value }]
       end
     end
 

--- a/app/services/resource_compare_service.rb
+++ b/app/services/resource_compare_service.rb
@@ -13,7 +13,7 @@
 # The `action` indicates whether a value changed, was added, or deleted.
 #
 # rubocop:disable Metrics/ClassLength
-class ResourceCompare
+class ResourceCompareService
   attr_reader :differences
 
   def initialize(before, after)
@@ -86,7 +86,7 @@ class ResourceCompare
       end
 
       after_values.each do |value|
-        changes << { action: :added, value: value } unless value.in?(added)
+        changes << { action: :added, value: value } if value.in?(added)
       end
 
       changes

--- a/app/views/works/_curator_controlled_form.html.erb
+++ b/app/views/works/_curator_controlled_form.html.erb
@@ -46,7 +46,7 @@
   <!-- Collection Tags field -->
   <div class="field">
     Collection Tags: <span class="text-muted field-hint">(enter tags that identify the collect in a comma separated list, e.g. Humanities, Life Sciences)</span><br>
-    <input type="text" id="collection_tags" name="collection_tags" class="input-text-long" value="<%= @work.resource.ark %>" />
+    <input type="text" id="collection_tags" name="collection_tags" class="input-text-long" value="<%= @work.resource.collection_tags.join(', ') %>" />
   </div>
 
 </div>

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -21,8 +21,12 @@
     padding-bottom: 10px;
   }
 
-  .activity-history-item-title {
+  .activity-history-comment-title {
     background-color: #ddf4ff;
+  }
+
+  .activity-history-log-title {
+    background-color: #f4edd2;
   }
 
   .comment-html > p {
@@ -168,7 +172,7 @@
     <h2>Activity History</h2>
     <% @work.activities.each do |activity| %>
       <div class="activity-history-item" >
-        <div class="activity-history-item-title">
+        <div class="<%= activity.activity_type == 'CHANGES' ? 'activity-history-log-title' : 'activity-history-comment-title' %>">
           <b><%= activity.created_by_user&.display_name_safe %></b>
           <span title="<%= activity.created_at.localtime %>"><%= distance_of_time_in_words_to_now(activity.created_at) %></span>
         </div>

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -22,11 +22,11 @@
   }
 
   .activity-history-comment-title {
-    background-color: #ddf4ff;
+    background-color:#bfe9fd;
   }
 
   .activity-history-log-title {
-    background-color: #f4edd2;
+    background-color:#f4d28f;
   }
 
   .comment-html > p {

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe WorksController do
         "family_name_1" => "Smith",
         "creator_count" => "1",
         "resource_type" => "Dataset",
-        "resource_type_general" => "dataset"
+        "resource_type_general" => "DATASET"
       }
       sign_in user
       post :update, params: params
@@ -132,7 +132,9 @@ RSpec.describe WorksController do
         "given_name_2" => "Ada",
         "family_name_2" => "Lovelace",
         "sequence_2" => "2",
-        "creator_count" => "2"
+        "creator_count" => "2",
+        "resource_type" => "Dataset",
+        "resource_type_general" => "DATASET"
       }
       sign_in user
       post :update, params: params
@@ -168,7 +170,9 @@ RSpec.describe WorksController do
         "given_name_2" => "Ada",
         "family_name_2" => "Lovelace",
         "sequence_2" => "1",
-        "creator_count" => "2"
+        "creator_count" => "2",
+        "resource_type" => "Dataset",
+        "resource_type_general" => "DATASET"
       }
 
       post :update, params: params_reordered

--- a/spec/services/resource_compare_service_spec.rb
+++ b/spec/services/resource_compare_service_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+describe ResourceCompareService do
+  it "detects identical objects" do
+    work1 = FactoryBot.create(:shakespeare_and_company_work)
+    work2 = FactoryBot.create(:shakespeare_and_company_work)
+    compare = described_class.new(work1.resource, work2.resource)
+    expect(compare.identical?).to be true
+  end
+
+  it "detects simple changes" do
+    work1 = FactoryBot.create(:shakespeare_and_company_work)
+    work2 = FactoryBot.create(:shakespeare_and_company_work)
+    work2 .resource.description = "hello"
+    compare = described_class.new(work1.resource, work2.resource)
+    expect(compare.identical?).to be false
+    expect(compare.differences[:description][:action]).to be :changed
+    expect(compare.differences[:description][:to]).to be "hello"
+  end
+
+  it "detects changes in multi-value properties" do
+    work1 = FactoryBot.create(:shakespeare_and_company_work)
+    work2 = FactoryBot.create(:shakespeare_and_company_work)
+    work2.resource.keywords = ["a", "b"]
+    compare = described_class.new(work1.resource, work2.resource)
+    differences = compare.differences[:keywords]
+    expect(differences.find { |diff| diff[:action] == :added && diff[:value] == "a" }).not_to be nil
+    expect(differences.find { |diff| diff[:action] == :added && diff[:value] == "b" }).not_to be nil
+    expect(differences.find { |diff| diff[:action] == :added && diff[:value] == "d" }).to be nil
+
+    work3 = FactoryBot.create(:shakespeare_and_company_work)
+    work3.resource.keywords = ["b", "c"]
+    compare = described_class.new(work2.resource, work3.resource)
+    differences = compare.differences[:keywords]
+    expect(differences.find { |diff| diff[:action] == :removed && diff[:value] == "a" }).not_to be nil
+    expect(differences.find { |diff| diff[:action] == :added && diff[:value] == "c" }).not_to be nil
+    expect(differences.find { |diff| diff[:value] == "b" }).to be nil
+  end
+
+  it "detects changes in creators" do
+    work1 = FactoryBot.create(:shakespeare_and_company_work)
+    work2 = FactoryBot.create(:shakespeare_and_company_work)
+    creator_other = PDCMetadata::Creator.new_person("Robert", "Smith", nil, 2)
+    work2.resource.creators = [work1.resource.creators.first, creator_other]
+
+    compare = described_class.new(work1.resource, work2.resource)
+    differences = compare.differences[:creators]
+    expect(differences.find { |diff| diff[:action] == :added && diff[:value] == "Smith, Robert | 2 | " }).not_to be nil
+
+    work3 = FactoryBot.create(:shakespeare_and_company_work)
+    work3.resource.creators = [creator_other]
+    compare = described_class.new(work2.resource, work3.resource)
+    differences = compare.differences[:creators]
+    expect(differences.find { |diff| diff[:action] == :removed && diff[:value] == "Kotin, Joshua | 1 | " }).not_to be nil
+  end
+end

--- a/spec/services/resource_compare_service_spec.rb
+++ b/spec/services/resource_compare_service_spec.rb
@@ -15,8 +15,8 @@ describe ResourceCompareService do
     work2 .resource.description = "hello"
     compare = described_class.new(work1.resource, work2.resource)
     expect(compare.identical?).to be false
-    expect(compare.differences[:description][:action]).to be :changed
-    expect(compare.differences[:description][:to]).to be "hello"
+    expect(compare.differences[:description].first[:action]).to be :changed
+    expect(compare.differences[:description].first[:to]).to be "hello"
   end
 
   it "detects changes in multi-value properties" do


### PR DESCRIPTION
Keeps tracks of changes to the metadata (provenance log) in works. 

![history](https://user-images.githubusercontent.com/568286/196548557-927bded7-96fb-4835-9de5-6863bdcb1aa3.png)

Handles the Provenance Log part of #198 for **metadata**. See issue #517 for file provenance log.

Closes #198

