### PR TITLE
Removing Edit button from show of approved work

### DIFF
--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -40,7 +40,9 @@
 </style>
 
 <div>
-  <%= link_to("Edit", edit_work_path(@work, wizard: @work.draft? ? true : nil), class: "btn btn-primary") %>
+  <% if @work.draft?  || @work.awaiting_approval? || current_user.has_role?(:collection_admin, @work.collection) %>
+    <%= link_to("Edit", edit_work_path(@work, wizard: @work.draft? ? true : nil), class: "btn btn-primary") %>
+  <% end %>
   <% if @work.awaiting_approval? && current_user.has_role?(:collection_admin, @work.collection) %>
     <%= button_to("Approve Dataset", approve_work_path(@work), class: "btn btn-secondary", method: :post) %>
   <% elsif @work.approved? %>


### PR DESCRIPTION
Only curators and super admins should have edit capabilities on approved works. There is a pending test, because there is a bug on the edit screen for approved works (#505).

refs #255 