### PR TITLE
Only allow user to update non approved work

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -101,39 +101,17 @@ class WorksController < ApplicationController
     end
   end
 
-  # rubocop:disable Metrics/MethodLength
   def update
     @work = Work.find(params[:id])
-    @wizard_mode = wizard_mode?
-
-    collection_id_param = params[:collection_id]
-
-    updates = {
-      collection_id: collection_id_param,
-      resource: FormToResourceService.convert(params, @work, current_user)
-    }
-
-    if @work.approved?
-      upload_keys = work_params[:deleted_uploads] || []
-      deleted_uploads = WorkUploadsEditService.find_post_curation_uploads(work: @work, upload_keys: upload_keys)
-
-      return head(:forbidden) unless deleted_uploads.empty?
+    if current_user.blank? || !@work.editable_by?(current_user)
+      Rails.logger.warn("Unauthorized attempt to update work #{@work.id} by user #{current_user.uid}")
+      redirect_to root_path
+    elsif @work.approved? && @work.submitted_by?(current_user)
+      redirect_to root_path, notice: I18n.t("works.approved.uneditable")
     else
-      @work = WorkUploadsEditService.update_precurated_file_list(@work, work_params)
-    end
-
-    if @work.update(updates)
-      if @wizard_mode
-        redirect_to work_attachment_select_url(@work)
-      else
-        redirect_to work_url(@work), notice: "Work was successfully updated."
-      end
-    else
-      @uploads = @work.uploads
-      render :edit, status: :unprocessable_entity
+      update_work
     end
   end
-  # rubocop:enable Metrics/MethodLength
 
   # Prompt to select how to submit their files
   def attachment_select
@@ -305,6 +283,41 @@ class WorksController < ApplicationController
 
     def wizard_mode?
       params[:wizard] == "true"
+    end
+
+    def update_work
+      @wizard_mode = wizard_mode?
+
+      if @work.approved?
+        upload_keys = work_params[:deleted_uploads] || []
+        deleted_uploads = WorkUploadsEditService.find_post_curation_uploads(work: @work, upload_keys: upload_keys)
+
+        return head(:forbidden) unless deleted_uploads.empty?
+      else
+        @work = WorkUploadsEditService.update_precurated_file_list(@work, work_params)
+      end
+
+      process_updates
+    end
+
+    def update_params
+      {
+        collection_id: params[:collection_id],
+        resource: FormToResourceService.convert(params, @work, current_user)
+      }
+    end
+
+    def process_updates
+      if @work.update(update_params)
+        if @wizard_mode
+          redirect_to work_attachment_select_url(@work)
+        else
+          redirect_to work_url(@work), notice: "Work was successfully updated."
+        end
+      else
+        @uploads = @work.uploads
+        render :edit, status: :unprocessable_entity
+      end
     end
 end
 # rubocop:enable Metrics/ClassLength

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -1037,7 +1037,9 @@ RSpec.describe WorksController do
         sequence_2: "1",
         orcid_2: "1234-1234-1234-1234",
         creator_count: "1",
-        new_creator_count: "1"
+        new_creator_count: "1",
+        rights_identifier: "CC BY",
+        description: "a new description"
       }
     end
 
@@ -1122,6 +1124,52 @@ RSpec.describe WorksController do
           it "renders JSON-serialized error messages with a 422 response status code" do
             expect(response.code).to eq("422")
           end
+        end
+      end
+    end
+
+    context "the work is approved" do
+      let(:work) { FactoryBot.create :approved_work }
+      let(:new_params) { params.merge(doi: "new-doi").merge(ark: "new-ark").merge(collection_tags: "new-colletion-tag1, new-collection-tag2") }
+
+      context "the submitter" do
+        let(:user) { work.created_by_user }
+
+        it "redirects the home page on edit with informational message" do
+          sign_in user
+          patch :update, params: new_params
+          expect(response).to redirect_to(root_path)
+          expect(controller.flash[:notice]).to eq("This work has been approved.  Edits are no longer available.")
+        end
+      end
+      context "another user" do
+        let(:other_user) { FactoryBot.create(:user) }
+        it "redirects the home page on edit" do
+          sign_in other_user
+          patch :update, params: new_params
+          expect(response).to redirect_to(root_path)
+        end
+      end
+      context "a curator", mock_ezid_api: true do
+        let(:user) { FactoryBot.create(:research_data_moderator) }
+        it "renders the edit page on edit" do
+          stub_s3
+          sign_in user
+          patch :update, params: new_params
+          expect(work.reload.doi).to eq("new-doi")
+          expect(work.ark).to eq("new-ark")
+          expect(work.resource.collection_tags).to eq(["new-colletion-tag1", "new-collection-tag2"])
+        end
+      end
+      context "a super admin", mock_ezid_api: true do
+        let(:user) { FactoryBot.create(:super_admin_user) }
+        it "renders the edit page on edit" do
+          stub_s3
+          sign_in user
+          patch :update, params: new_params
+          expect(work.reload.doi).to eq("new-doi")
+          expect(work.ark).to eq("new-ark")
+          expect(work.resource.collection_tags).to eq(["new-colletion-tag1", "new-collection-tag2"])
         end
       end
     end


### PR DESCRIPTION
Also do not allow updates by users who do not have access to this work.  This was a bug I discovered while working on the ticket. 
Additionally refactor the update routine to make rubocop happy

fixes #255