### PR TITLE
Allow resource type to change on assignment

### DIFF
--- a/app/models/pdc_metadata/resource.rb
+++ b/app/models/pdc_metadata/resource.rb
@@ -90,6 +90,8 @@ module PDCMetadata
           resource.ark = hash["ark"]
           resource.version_number = hash["version_number"]
           resource.collection_tags = collection_tags(hash["collection_tags"])
+          resource.resource_type = hash["resource_type"]
+          resource.resource_type_general = hash["resource_type_general"]&.to_sym
           resource
         end
 

--- a/app/services/form_to_resource_service.rb
+++ b/app/services/form_to_resource_service.rb
@@ -37,6 +37,8 @@ class FormToResourceService
           resource.ark = params["ark"] if params["ark"].present?
           resource.version_number = params["version_number"] if params["version_number"].present?
           resource.collection_tags = params["collection_tags"].split(",").map(&:strip) if params["collection_tags"]
+          resource.resource_type = params["resource_type"] if params["resource_type"]
+          resource.resource_type_general = params["resource_type_general"] if params["resource_type_general"]
         end
         resource
       end

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -1085,6 +1085,9 @@ RSpec.describe WorksController do
             new_params = params.merge(doi: "new-doi")
                                .merge(ark: "new-ark")
                                .merge(collection_tags: "new-colletion-tag1, new-collection-tag2")
+                               .merge(resource_type: "digitized video")
+                               .merge(resource_type_general: Datacite::Mapping::ResourceTypeGeneral::AUDIOVISUAL.key)
+
             patch :update, params: new_params
           end
 
@@ -1092,6 +1095,8 @@ RSpec.describe WorksController do
             expect(work.reload.doi).to eq("new-doi")
             expect(work.ark).to eq("new-ark")
             expect(work.resource.collection_tags).to eq(["new-colletion-tag1", "new-collection-tag2"])
+            expect(work.resource_type).to eq("digitized video")
+            expect(work.resource_type_general.to_sym).to eq(::Datacite::Mapping::ResourceTypeGeneral::AUDIOVISUAL.key)
           end
         end
 

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -803,4 +803,25 @@ RSpec.describe Work, type: :model do
       expect(persisted).to eq(user.uid)
     end
   end
+
+  describe "resource=" do
+    let(:resource_json) do
+      '{"titles":[{"title":"Planet of the Blue Rain","title_type":null},' \
+        '{"title":"the subtitle","title_type":"Subtitle"}],' \
+        '"description":"a new description",' \
+        '"collection_tags":["new-colletion-tag1","new-collection-tag2"],' \
+        '"creators":[{"value":"Morrison, Toni","name_type":"Personal","given_name":"Toni","family_name":"Morrison",' \
+        '"identifier":null,"affiliations":[],"sequence":1}],' \
+        '"resource_type":"digitized video",' \
+        '"resource_type_general":"AUDIOVISUAL",' \
+        '"publisher":"Princeton University","publication_year":2022,"ark":"new-ark","doi":"new-doi",' \
+        '"rights":{"identifier":"CC BY","uri":"https://creativecommons.org/licenses/by/4.0/",' \
+        '"name":"Creative Commons Attribution 4.0 International"},' \
+        '"version_number":"1","keywords":[],"contributors":[]}'
+    end
+    it "can change the entire resource" do
+      work.resource = PDCMetadata::Resource.new_from_json(resource_json)
+      expect(work.resource.to_json).to eq(resource_json)
+    end
+  end
 end

--- a/spec/system/curator_controlled_metadata_spec.rb
+++ b/spec/system/curator_controlled_metadata_spec.rb
@@ -43,9 +43,11 @@ RSpec.describe "Curator Controlled metadata tab", type: :system do
       expect(page).to have_css("#ark.input-text-long")
       fill_in "ark", with: "http://arks.princeton.edu/ark:/88435/dsp01hx11xj13h"
       fill_in "collection_tags", with: "ABC, 123"
+      find("#resource_type_general").find(:xpath, "option[1]").select_option
       click_on "Save Work"
       expect(draft_work.reload.ark).to eq "ark:/88435/dsp01hx11xj13h"
       expect(draft_work.resource.collection_tags).to eq(["ABC", "123"])
+      expect(draft_work.resource.resource_type_general).to eq(:AUDIOVISUAL)
     end
   end
 
@@ -56,9 +58,11 @@ RSpec.describe "Curator Controlled metadata tab", type: :system do
       expect(page).to have_css("#ark.input-text-long")
       fill_in "ark", with: "http://arks.princeton.edu/ark:/88435/dsp01hx11xj13h"
       fill_in "collection_tags", with: "ABC, 123"
+      find("#resource_type_general").find(:xpath, "option[1]").select_option
       click_on "Save Work"
       expect(draft_work.reload.ark).to eq "ark:/88435/dsp01hx11xj13h"
       expect(draft_work.resource.collection_tags).to eq(["ABC", "123"])
+      expect(draft_work.resource.resource_type_general).to eq(:AUDIOVISUAL)
     end
   end
 end


### PR DESCRIPTION
Allow the resource type to change when the entire resource is assigned. fixes #502

The resource type and resource type general were not connected back through to the model at any point in the edit cycle.