### PR TITLE
Allow user to toggle display of change history

### DIFF
--- a/app/views/works/_edit_javascript.html.erb
+++ b/app/views/works/_edit_javascript.html.erb
@@ -385,7 +385,7 @@
       }
     }
 
-    // Load any existing related objects into the edit form. 
+    // Load any existing related objects into the edit form.
     // If there are any related objects they should appear in hidden <span> tags.
     if ($(".related-object-data").length == 0) {
       // Add an empty related object for the user to fill it out

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -178,8 +178,12 @@
 <div id="activity-history">
   <% if @work.work_activity.count > 0 %>
     <h2>Activity History</h2>
+    <div class="form-check form-switch">
+      <input id="show-change-history" class="form-check-input" type="checkbox" role="switch" id="flexSwitchCheckDefault" checked>
+      <label class="form-check-label" for="flexSwitchCheckDefault">Show change history</label>
+    </div>
     <% @work.activities.each do |activity| %>
-      <div class="activity-history-item" >
+      <div class="activity-history-item <%= activity.activity_type == 'CHANGES' ? 'activity-history-log-item' : 'activity-history-comment-item' %>">
         <div class="<%= activity.activity_type == 'CHANGES' ? 'activity-history-log-title' : 'activity-history-comment-title' %>">
           <b><%= activity.created_by_user&.display_name_safe %></b>
           <span title="<%= activity.created_at.localtime %>"><%= distance_of_time_in_words_to_now(activity.created_at) %></span>
@@ -237,6 +241,11 @@
       hidden: '#hidden_inputbox',
       source: userList,
       trigger: "@"
+    });
+
+    // Toggle display of change history
+    $("#show-change-history").on("click", function(el) {
+      $(".activity-history-log-item").toggleClass("hidden");
     });
   });
 </script>

--- a/spec/system/work_edit_spec.rb
+++ b/spec/system/work_edit_spec.rb
@@ -97,4 +97,19 @@ RSpec.describe "Creating and updating works", type: :system, js: true, mock_s3_q
       expect(page.find("#relation_type_1").value).to have_content "isCitedBy"
     end
   end
+
+  context "change log" do
+    let(:work) { FactoryBot.create(:distinct_cytoskeletal_proteins_work) }
+    let(:user) { work.created_by_user }
+
+    it "toggles the display of changes" do
+      sign_in user
+      visit edit_work_path(work)
+      fill_in "title_main", with: "UPDATED" + work.resource.titles.first.title
+      click_on "Save Work"
+      expect(page.find(".activity-history-log-title", visible: true).tag_name).to eq "div"
+      uncheck "show-change-history"
+      expect(page.find(".activity-history-log-title", visible: false).tag_name).to eq "div"
+    end
+  end
 end


### PR DESCRIPTION
Tiny enhancement to the change log display

# Default display (comments + change history)
![show](https://user-images.githubusercontent.com/568286/196779174-7df30171-2355-497a-ba5b-1a693a2bd798.png)

# Without change history
![show-me-not](https://user-images.githubusercontent.com/568286/196779185-2112102e-31ad-4da7-8a6c-d3083ffc209b.png)
