### PR TITLE
Reference asdf in install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,18 @@ Cataloging application for PDC content and more
 
 ### Setup
 1. Check out code
-2. `bundle install`
-3. `yarn install`
+1. Install tool dependencies
+  1. [Lando](https://docs.lando.dev/getting-started/installation.html)
+  1. [asdf](https://asdf-vm.com/guide/getting-started.html#_2-download-asdf)
+1. Install asdf dependencies
+  1. `asdf plugin add ruby`
+  1. `asdf plugin add node`
+  1. `asdf plugin add yarn`
+  1. `asdf install`
+  1. ... but because asdf is not a dependency manager, if there are errors, you may need to install other dependencies. For example: `brew install gpg`
+1. Install language-specific dependencies
+  1. `bundle install`
+  1. `yarn install`
 
 ### Starting / stopping services
 We use lando to run services required for both test and development environments.

--- a/README.md
+++ b/README.md
@@ -15,17 +15,17 @@ Cataloging application for PDC content and more
 ### Setup
 1. Check out code and `cd`
 1. Install tool dependencies
-  1. [Lando](https://docs.lando.dev/getting-started/installation.html)
-  1. [asdf](https://asdf-vm.com/guide/getting-started.html#_2-download-asdf)
+    1. [Lando](https://docs.lando.dev/getting-started/installation.html)
+    1. [asdf](https://asdf-vm.com/guide/getting-started.html#_2-download-asdf)
 1. Install asdf dependencies
-  1. `asdf plugin add ruby`
-  1. `asdf plugin add node`
-  1. `asdf plugin add yarn`
-  1. `asdf install`
-  1. ... but because asdf is not a dependency manager, if there are errors, you may need to install other dependencies. For example: `brew install gpg`
+    1. `asdf plugin add ruby`
+    1. `asdf plugin add node`
+    1. `asdf plugin add yarn`
+    1. `asdf install`
+    1. ... but because asdf is not a dependency manager, if there are errors, you may need to install other dependencies. For example: `brew install gpg`
 1. Install language-specific dependencies
-  1. `bundle install`
-  1. `yarn install`
+    1. `bundle install`
+    1. `yarn install`
 
 ### Starting / stopping services
 We use lando to run services required for both test and development environments.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Cataloging application for PDC content and more
 ## Local development
 
 ### Setup
-1. Check out code
+1. Check out code and `cd`
 1. Install tool dependencies
   1. [Lando](https://docs.lando.dev/getting-started/installation.html)
   1. [asdf](https://asdf-vm.com/guide/getting-started.html#_2-download-asdf)


### PR DESCRIPTION
- Fix #526

Maybe the 3.v. step shouldn't be needed? Not sure if there's a better way for it to work out of the box.

I also wonder if down the road it would be worth pulling CI and dev environment from the same place... but probably not worth worrying about until we hit a problem.