### PR TITLE
fix repeated "from"

### DIFF
--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -28,8 +28,8 @@ en:
       password_change:
         subject: "Password Changed"
     omniauth_callbacks:
-      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
-      success: "Successfully authenticated from %{kind} account."
+      failure: "Could not authenticate you %{kind} because \"%{reason}\"."
+      success: "Successfully authenticated %{kind} account."
     passwords:
       no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
       send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Users::OmniauthCallbacksController do
       allow(User).to receive(:from_cas) { FactoryBot.create(:user) }
       get :cas
       expect(response).to redirect_to(root_path)
-      expect(flash[:notice]).to eq("Successfully authenticated from from Princeton Central Authentication Service account.")
+      expect(flash[:notice]).to eq("Successfully authenticated from Princeton Central Authentication Service account.")
     end
   end
 


### PR DESCRIPTION
- Fix #542

I'm not sure how to produce a failed login, but the flash message for a successful login seems right now.