### PR TITLE
Updating the edit form to only show upload edits before approval

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -88,7 +88,7 @@ class WorksController < ApplicationController
   def edit
     @work = Work.find(params[:id])
     if current_user && @work.editable_by?(current_user)
-      if @work.approved? && @work.submitted_by?(current_user)
+      if @work.approved? && !@work.administered_by?(current_user)
         redirect_to root_path, notice: I18n.t("works.approved.uneditable")
       else
         @uploads = @work.uploads

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -60,14 +60,15 @@ class Work < ApplicationRecord
   # @param [User]
   # @return [Boolean]
   def editable_by?(user)
-    return true if submitted_by?(user)
-    collection = Collection.find(collection_id)
-    return true if user.has_role?(:collection_admin, collection)
-    false
+    submitted_by?(user) || administered_by?(user)
   end
 
   def submitted_by?(user)
-    return true if created_by_user_id == user.id
+    created_by_user_id == user.id
+  end
+
+  def administered_by?(user)
+    user.has_role?(:collection_admin, collection)
   end
 
   class << self
@@ -242,6 +243,7 @@ class Work < ApplicationRecord
   end
 
   def uploads_attributes
+    return [] if approved? # once approved we no longer allow the updating of uploads via the application
     uploads.map do |upload|
       {
         id: upload.id,

--- a/app/views/works/_form.html.erb
+++ b/app/views/works/_form.html.erb
@@ -44,7 +44,14 @@
       <% if !@wizard_mode %>
         <hr />
         <div class="deposit-uploads">
-          <%= render(partial: 'works/uploads_form', locals: { form: form }) %>
+          <% if @work.approved? %>
+            <section class="uploads">
+              <h2 class="h2"><%= t('works.uploads.post_curation.heading') %></h2>
+              <%= render(partial: 'works/uploads/post_curation_s3_resources') %>
+            </section>
+         <% else %>
+            <%= render(partial: 'works/uploads_form', locals: { form: form }) %>
+          <% end %>
         </div>
       <% end %>
 

--- a/spec/system/view_data_in_s3_spec.rb
+++ b/spec/system/view_data_in_s3_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "View status of data in S3", mock_ezid_api: true do
 
       context "when user is a curator" do
         let(:user) { FactoryBot.create(:research_data_moderator) }
-        pending "shows data from S3" do
+        it "shows data from S3" do
           stub_s3(data: s3_data)
           visit work_path(work)
           expect(page).to have_content file1.filename
@@ -82,6 +82,20 @@ RSpec.describe "View status of data in S3", mock_ezid_api: true do
           click_on "Edit"
           expect(page).to have_content file1.filename
           expect(page).to have_content file2.filename
+        end
+
+        context "when user is a super super_admin_user" do
+          let(:user) { FactoryBot.create(:research_data_moderator) }
+          it "shows data from S3" do
+            stub_s3(data: s3_data)
+            visit work_path(work)
+            expect(page).to have_content file1.filename
+            expect(page).to have_content file2.filename
+
+            click_on "Edit"
+            expect(page).to have_content file1.filename
+            expect(page).to have_content file2.filename
+          end
         end
       end
     end


### PR DESCRIPTION
Only show the ability to edit the uploads before the Work is approved, since after it has been approved we drive everything off of S3 

Also changed test for edit of an approved work to administered by so that as an administrator I could edit my own work.

fixes #505