### PR TITLE
Log file changes

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -287,14 +287,14 @@ class WorksController < ApplicationController
 
     def update_work
       @wizard_mode = wizard_mode?
-
+      upload_service = WorkUploadsEditService.new(@work, current_user)
       if @work.approved?
         upload_keys = work_params[:deleted_uploads] || []
-        deleted_uploads = WorkUploadsEditService.find_post_curation_uploads(work: @work, upload_keys: upload_keys)
+        deleted_uploads = upload_service.find_post_curation_uploads(upload_keys: upload_keys)
 
         return head(:forbidden) unless deleted_uploads.empty?
       else
-        @work = WorkUploadsEditService.update_precurated_file_list(@work, work_params)
+        @work = upload_service.update_precurated_file_list(work_params)
       end
 
       process_updates

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -362,6 +362,11 @@ class Work < ApplicationRecord
     WorkActivity.add_system_activity(id, resource_compare.differences.to_json, current_user.id, activity_type: "CHANGES")
   end
 
+  def log_file_changes(changes, current_user)
+    return if changes.count == 0
+    WorkActivity.add_system_activity(id, changes.to_json, current_user.id, activity_type: "FILE-CHANGES")
+  end
+
   def activities
     WorkActivity.where(work_id: id).sort_by(&:updated_at).reverse
   end

--- a/app/models/work_activity.rb
+++ b/app/models/work_activity.rb
@@ -41,7 +41,7 @@ class WorkActivity < ApplicationRecord
 
   def message_html
     if activity_type == "CHANGES"
-      changes_html
+      metadata_changes_html
     elsif activity_type == "FILE-CHANGES"
       file_changes_html
     else
@@ -74,7 +74,7 @@ class WorkActivity < ApplicationRecord
     end
 
     # Returns the message formatted to display _metadata_ changes that were logged as an activity
-    def changes_html
+    def metadata_changes_html
       text = ""
       changes = JSON.parse(message)
       changes.keys.each do |field|

--- a/app/models/work_activity.rb
+++ b/app/models/work_activity.rb
@@ -42,6 +42,8 @@ class WorkActivity < ApplicationRecord
   def message_html
     if activity_type == "CHANGES"
       changes_html
+    elsif activity_type == "FILE-CHANGES"
+      file_changes_html
     else
       comment_html
     end
@@ -62,7 +64,16 @@ class WorkActivity < ApplicationRecord
       Kramdown::Document.new(text).to_html
     end
 
-    # Returns the message formatted to display changes that were logged as an activity
+    # Returns the message formatted to display _file_ changes that were logged as an activity
+    def file_changes_html
+      changes = JSON.parse(message)
+      changes_html = changes.map do |change|
+        "<i>#{change['action']}</i> <span>#{change['filename']}<span><br/>"
+      end
+      "<p><b>Files</b>: #{changes_html.join}</p>"
+    end
+
+    # Returns the message formatted to display _metadata_ changes that were logged as an activity
     def changes_html
       text = ""
       changes = JSON.parse(message)

--- a/app/services/work_uploads_edit_service.rb
+++ b/app/services/work_uploads_edit_service.rb
@@ -1,50 +1,76 @@
 # frozen_string_literal: true
 class WorkUploadsEditService
-  class << self
-    def update_precurated_file_list(work, work_params)
-      if work_params.key?(:deleted_uploads) || work_params.key?(:pre_curation_uploads) || work_params.key?(:replaced_uploads)
-        if work_params.key?(:deleted_uploads)
-          delete_pre_curation_uploads(work.pre_curation_uploads, work_params[:deleted_uploads])
-        elsif work_params.key?(:pre_curation_uploads)
-          work.pre_curation_uploads.each(&:purge)
-          work.reload # reload the work to pick up the changes in the attachments
-          Array(work_params[:pre_curation_uploads]).each { |new_upload| work.pre_curation_uploads.attach(new_upload) }
-        elsif work_params.key?(:replaced_uploads)
-          replace_uploads(work, work_params[:replaced_uploads])
+  def initialize(work, current_user)
+    @work = work
+    @current_user = current_user
+    @changes = []
+  end
+
+  def work
+    @work
+  end
+
+  def update_precurated_file_list(work_params)
+    if work_params.key?(:deleted_uploads) || work_params.key?(:pre_curation_uploads) || work_params.key?(:replaced_uploads)
+      if work_params.key?(:deleted_uploads)
+        # delete the files indicated in the parameters
+        delete_pre_curation_uploads(work_params[:deleted_uploads])
+      elsif work_params.key?(:pre_curation_uploads)
+        # delete all existing uploads and then and then add the ones indicated in the parameters
+        work.pre_curation_uploads.each do |existing_upload|
+          track_change(:deleted, existing_upload.filename.to_s)
+          existing_upload.purge
         end
         work.reload # reload the work to pick up the changes in the attachments
+        Array(work_params[:pre_curation_uploads]).each do |new_upload|
+          track_change(:added, new_upload.original_filename)
+          work.pre_curation_uploads.attach(new_upload)
+        end
+      elsif work_params.key?(:replaced_uploads)
+        # replace the files indicated in the parameters
+        replace_uploads(work_params[:replaced_uploads])
+      end
 
-      else # no changes in the parameters, just return the original work
-        work
+      work.log_file_changes(@changes, @current_user)
+      work.reload # reload the work to pick up the changes in the attachments
+    else # no changes in the parameters, just return the original work
+      work
+    end
+  end
+
+  def find_post_curation_uploads(upload_keys: [])
+    return [] unless work.approved? && !upload_keys.empty?
+    work.post_curation_uploads.select { |upload| upload_keys.include?(upload.key) }
+  end
+
+  private
+
+    def replace_uploads(replaced_uploads_params)
+      new_uploads = []
+      work.pre_curation_uploads.each_with_index do |existing, i|
+        key = i.to_s
+        next unless replaced_uploads_params.key?(key)
+        new_uploads << replaced_uploads_params[key]
+        track_change(:deleted, existing.filename.to_s)
+        existing.purge
+      end
+      work.reload
+      new_uploads.each do |new_upload|
+        track_change(:added, new_upload.original_filename)
+        work.pre_curation_uploads.attach(new_upload)
       end
     end
 
-    def find_post_curation_uploads(work:, upload_keys: [])
-      return [] unless work.approved? && !upload_keys.empty?
-
-      work.post_curation_uploads.select { |upload| upload_keys.include?(upload.key) }
+    def delete_pre_curation_uploads(deleted_uploads_params)
+      work.pre_curation_uploads.each do |existing|
+        if deleted_uploads_params.key?(existing.key) && deleted_uploads_params[existing.key] == "1"
+          track_change(:deleted, existing.filename.to_s)
+          existing.purge
+        end
+      end
     end
 
-      private
-
-        def replace_uploads(work, replaced_uploads_params)
-          new_uploads = []
-          work.pre_curation_uploads.each_with_index do |existing, i|
-            key = i.to_s
-            next unless replaced_uploads_params.key?(key)
-            new_uploads << replaced_uploads_params[key]
-            existing.purge
-          end
-          work.reload
-          new_uploads.each { |new_upload| work.pre_curation_uploads.attach(new_upload) }
-        end
-
-        def delete_pre_curation_uploads(persisted_pre_curation_uploads, deleted_uploads_params)
-          persisted_pre_curation_uploads.each do |existing|
-            if deleted_uploads_params.key?(existing.key) && deleted_uploads_params[existing.key] == "1"
-              existing.purge
-            end
-          end
-        end
-  end
+    def track_change(action, filename)
+      @changes << { action: action, filename: filename }
+    end
 end

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -183,7 +183,7 @@
       <label class="form-check-label" for="flexSwitchCheckDefault">Show change history</label>
     </div>
     <% @work.activities.each do |activity| %>
-      <div class="activity-history-item <%= activity.activity_type == 'CHANGES' ? 'activity-history-log-item' : 'activity-history-comment-item' %>">
+      <div class="activity-history-item <%= activity.activity_type.in?(['CHANGES','FILE-CHANGES']) ? 'activity-history-log-item' : 'activity-history-comment-item' %>">
         <div class="<%= activity.activity_type.in?(['CHANGES','FILE-CHANGES']) ? 'activity-history-log-title' : 'activity-history-comment-title' %>">
           <b><%= activity.created_by_user&.display_name_safe %></b>
           <span title="<%= activity.created_at.localtime %>"><%= distance_of_time_in_words_to_now(activity.created_at) %></span>

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -184,7 +184,7 @@
     </div>
     <% @work.activities.each do |activity| %>
       <div class="activity-history-item <%= activity.activity_type == 'CHANGES' ? 'activity-history-log-item' : 'activity-history-comment-item' %>">
-        <div class="<%= activity.activity_type == 'CHANGES' ? 'activity-history-log-title' : 'activity-history-comment-title' %>">
+        <div class="<%= activity.activity_type.in?(['CHANGES','FILE-CHANGES']) ? 'activity-history-log-title' : 'activity-history-comment-title' %>">
           <b><%= activity.created_by_user&.display_name_safe %></b>
           <span title="<%= activity.created_at.localtime %>"><%= distance_of_time_in_words_to_now(activity.created_at) %></span>
         </div>

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,6 +1,9 @@
 local: &local
-  service: 'Disk'
-  root: <%= Rails.root.join("storage") %>
+  service: 'S3'
+  access_key_id: <%= ENV['AWS_S3_KEY_ID'] || 'not-used-access_key_id' %>
+  secret_access_key: <%= ENV['AWS_S3_SECRET_KEY'] || 'not-used-secret_access_key' %>
+  region: <%= S3QueryService.pre_curation_config.fetch(:region) %>
+  bucket: <%= S3QueryService.pre_curation_config.fetch(:bucket) %>
 
 development: &development
   <<: *local

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,9 +1,6 @@
 local: &local
-  service: 'S3'
-  access_key_id: <%= ENV['AWS_S3_KEY_ID'] || 'not-used-access_key_id' %>
-  secret_access_key: <%= ENV['AWS_S3_SECRET_KEY'] || 'not-used-secret_access_key' %>
-  region: <%= S3QueryService.pre_curation_config.fetch(:region) %>
-  bucket: <%= S3QueryService.pre_curation_config.fetch(:bucket) %>
+  service: 'Disk'
+  root: <%= Rails.root.join("storage") %>
 
 development: &development
   <<: *local

--- a/spec/services/work_upload_edit_service_spec.rb
+++ b/spec/services/work_upload_edit_service_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe WorkUploadsEditService do
       expect(a_request(:delete, attachment_url)).to have_been_made.once
       # it logs the delete
       activity_log = JSON.parse(work.work_activity.first.message)
-      expect(activity_log.find {|log| log["action"] == "deleted" && log["filename"]== "us_covid_2019.csv"}).not_to be nil
+      expect(activity_log.find { |log| log["action"] == "deleted" && log["filename"] == "us_covid_2019.csv" }).not_to be nil
     end
   end
 
@@ -84,8 +84,8 @@ RSpec.describe WorkUploadsEditService do
 
       # it logs the activity
       activity_log = JSON.parse(work.work_activity.first.message)
-      expect(activity_log.find {|log| log["action"] == "deleted" && log["filename"]== "us_covid_2020.csv"}).not_to be nil
-      expect(activity_log.find {|log| log["action"] == "added" && log["filename"]== "datacite_basic.xml"}).not_to be nil
+      expect(activity_log.find { |log| log["action"] == "deleted" && log["filename"] == "us_covid_2020.csv" }).not_to be nil
+      expect(activity_log.find { |log| log["action"] == "added" && log["filename"] == "datacite_basic.xml" }).not_to be nil
     end
   end
 
@@ -101,9 +101,9 @@ RSpec.describe WorkUploadsEditService do
 
       # it logs the activity
       activity_log = JSON.parse(work.work_activity.first.message)
-      expect(activity_log.find {|log| log["action"] == "deleted" && log["filename"]== "us_covid_2019.csv"}).not_to be nil
-      expect(activity_log.find {|log| log["action"] == "added" && log["filename"]== "us_covid_2020.csv"}).not_to be nil
-      expect(activity_log.find {|log| log["action"] == "added" && log["filename"]== "orcid.csv"}).not_to be nil
+      expect(activity_log.find { |log| log["action"] == "deleted" && log["filename"] == "us_covid_2019.csv" }).not_to be nil
+      expect(activity_log.find { |log| log["action"] == "added" && log["filename"] == "us_covid_2020.csv" }).not_to be nil
+      expect(activity_log.find { |log| log["action"] == "added" && log["filename"] == "orcid.csv" }).not_to be nil
     end
   end
 
@@ -121,9 +121,9 @@ RSpec.describe WorkUploadsEditService do
 
       # it logs the activity
       activity_log = JSON.parse(work.work_activity.first.message)
-      expect(activity_log.find {|log| log["action"] == "deleted" && log["filename"]== "us_covid_2019.csv"}).not_to be nil
-      expect(activity_log.find {|log| log["action"] == "added" && log["filename"]== "us_covid_2019.csv"}).not_to be nil
-      expect(activity_log.find {|log| log["action"] == "added" && log["filename"]== "orcid.csv"}).not_to be nil
+      expect(activity_log.find { |log| log["action"] == "deleted" && log["filename"] == "us_covid_2019.csv" }).not_to be nil
+      expect(activity_log.find { |log| log["action"] == "added" && log["filename"] == "us_covid_2019.csv" }).not_to be nil
+      expect(activity_log.find { |log| log["action"] == "added" && log["filename"] == "orcid.csv" }).not_to be nil
     end
   end
 end

--- a/spec/services/work_upload_edit_service_spec.rb
+++ b/spec/services/work_upload_edit_service_spec.rb
@@ -2,6 +2,7 @@
 require "rails_helper"
 
 RSpec.describe WorkUploadsEditService do
+  let(:user) { FactoryBot.create :research_data_moderator }
   let(:work) { FactoryBot.create :draft_work }
   let(:uploaded_file) do
     fixture_file_upload("us_covid_2019.csv", "text/csv")
@@ -32,7 +33,8 @@ RSpec.describe WorkUploadsEditService do
     let(:params) { { "work_id" => "" }.with_indifferent_access }
 
     it "returns all existing files" do
-      updated_work = described_class.update_precurated_file_list(work, params)
+      upload_service = described_class.new(work, user)
+      updated_work = upload_service.update_precurated_file_list(params)
       list = updated_work.pre_curation_uploads
       expect(list.map(&:filename)).to eq([uploaded_file.original_filename])
       expect(a_request(:delete, attachment_url)).not_to have_been_made
@@ -51,7 +53,8 @@ RSpec.describe WorkUploadsEditService do
     end
 
     it "returns all existing files except the deleted one" do
-      updated_work = described_class.update_precurated_file_list(work, params)
+      upload_service = described_class.new(work, user)
+      updated_work = upload_service.update_precurated_file_list(params)
       list = updated_work.pre_curation_uploads
       expect(list.map(&:filename)).to eq([uploaded_file2.original_filename])
       expect(a_request(:delete, attachment_url)).to have_been_made.once
@@ -67,7 +70,8 @@ RSpec.describe WorkUploadsEditService do
     let(:params) { { "work_id" => "", "replaced_uploads" => { "1" => uploaded_file4 } }.with_indifferent_access }
 
     it "replaces the correct file" do
-      updated_work = described_class.update_precurated_file_list(work, params)
+      upload_service = described_class.new(work, user)
+      updated_work = upload_service.update_precurated_file_list(params)
       list = updated_work.pre_curation_uploads
 
       # remeber order of the files will be alphabetical
@@ -80,7 +84,8 @@ RSpec.describe WorkUploadsEditService do
     let(:params) { { "work_id" => "", "pre_curation_uploads" => [uploaded_file2, uploaded_file3] }.with_indifferent_access }
 
     it "replaces all the files" do
-      updated_work = described_class.update_precurated_file_list(work, params)
+      upload_service = described_class.new(work, user)
+      updated_work = upload_service.update_precurated_file_list(params)
       list = updated_work.reload.pre_curation_uploads
       expect(list.map(&:filename)).to eq([uploaded_file2.original_filename, uploaded_file3.original_filename])
       expect(a_request(:delete, attachment_url)).to have_been_made.once
@@ -91,7 +96,8 @@ RSpec.describe WorkUploadsEditService do
     let(:params) { { "work_id" => "", "pre_curation_uploads" => [uploaded_file, uploaded_file3] }.with_indifferent_access }
 
     it "replaces all the files" do
-      updated_work = described_class.update_precurated_file_list(work, params)
+      upload_service = described_class.new(work, user)
+      updated_work = upload_service.update_precurated_file_list(params)
       list = updated_work.pre_curation_uploads
       expect(list.map(&:filename)).to eq([uploaded_file.original_filename, uploaded_file3.original_filename])
 

--- a/spec/system/work_edit_spec.rb
+++ b/spec/system/work_edit_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "Creating and updating works", type: :system, js: true, mock_s3_q
       check("work-uploads-#{work.pre_curation_uploads[0].id}-delete")
       click_on "Save Work"
       expect(page).to have_content("us_covid_2020.csv")
-      expect(page).not_to have_content("us_covid_2019.csv")
+      expect(page).to have_content("deleted us_covid_2019.csv")
       expect(a_request(:delete, delete_url)).to have_been_made
       expect(ActiveStorage::PurgeJob).not_to have_received(:new)
     end


### PR DESCRIPTION
Logs file changes (add/delete) when done via the Work Edit page.

![Screen Shot 2022-10-24 at 2 17 51 PM](https://user-images.githubusercontent.com/568286/197597163-561bb0e8-4a01-42df-824e-51cc071f1d9f.png)

Works towards #517

The bulk of the changes in this PR are on the `WorkUploadsEditService` class. I made the methods in this class instance methods (rather than class methods) so that we can keep track of the changes. Notice the new calls to `track_change(...)` and `work.log_file_changes(@changes, @current_user)`. The rest of the logic stayed the same.
