### PR TITLE
Validate work state

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -51,6 +51,13 @@ class Work < ApplicationRecord
     after_all_events :track_state_change
   end
 
+  def state=(new_state)
+    new_state_sym = new_state.to_sym
+    valid_states = self.class.aasm.states.map(&:name)
+    raise(StandardError, "Invalid state '#{new_state}'") unless valid_states.include?(new_state_sym)
+    aasm_write_state(new_state_sym)
+  end
+
   ##
   # Is this work editable by a given user?
   # A work is editable when:

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -55,7 +55,7 @@ class Work < ApplicationRecord
     new_state_sym = new_state.to_sym
     valid_states = self.class.aasm.states.map(&:name)
     raise(StandardError, "Invalid state '#{new_state}'") unless valid_states.include?(new_state_sym)
-    aasm_write_state(new_state_sym)
+    aasm_write_state_without_persistence(new_state_sym)
   end
 
   ##

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -55,8 +55,8 @@ RSpec.describe Work, type: :model do
   end
 
   it "prevents invalid state assignment" do
-    work = Work.new()
-    expect { work.state = 'sorry' }.to raise_error(StandardError, /Invalid state 'sorry'/)
+    work = Work.new
+    expect { work.state = "sorry" }.to raise_error(StandardError, /Invalid state 'sorry'/)
   end
 
   describe "#editable_by?" do

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -54,6 +54,10 @@ RSpec.describe Work, type: :model do
     expect { work.save! }.to raise_error ActiveRecord::RecordInvalid
   end
 
+  # it "prevents invalid state assignment" do
+  #   work = Work.new()
+  # end
+
   describe "#editable_by?" do
     subject(:work) { FactoryBot.create(:tokamak_work) }
     let(:submitter) { work.created_by_user }

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -54,9 +54,10 @@ RSpec.describe Work, type: :model do
     expect { work.save! }.to raise_error ActiveRecord::RecordInvalid
   end
 
-  # it "prevents invalid state assignment" do
-  #   work = Work.new()
-  # end
+  it "prevents invalid state assignment" do
+    work = Work.new()
+    expect { work.state = 'sorry' }.to raise_error(StandardError, /Invalid state 'sorry'/)
+  end
 
   describe "#editable_by?" do
     subject(:work) { FactoryBot.create(:tokamak_work) }


### PR DESCRIPTION
- Fix: #563
- Blocked by: #571

The tests currently set an invalid state, so those tests will error out in this branch. I made an attempt to fix that in #571... but I'm not super confident about that work, so I didn't base this branch on that one. Where ever the fix comes from, that PR or a different one, once it's merged to main, merge main to this branch, and it should be green.

Overriding the setter and catching the error at the earliest possible point feels good, but there may be other approaches. I looked at `no_direct_assignment`, but that causes tons of FactoryBot errors.