### PR TITLE
Updating replacement key to be upload key

### DIFF
--- a/app/services/work_uploads_edit_service.rb
+++ b/app/services/work_uploads_edit_service.rb
@@ -33,8 +33,8 @@ class WorkUploadsEditService
 
     def replace_uploads(replaced_uploads_params)
       new_uploads = []
-      work.pre_curation_uploads.each_with_index do |existing, i|
-        key = i.to_s
+      work.pre_curation_uploads.each_with_index do |existing|
+        key = existing.key
         next unless replaced_uploads_params.key?(key)
         new_uploads << replaced_uploads_params[key]
         track_change(:deleted, existing.filename.to_s)

--- a/app/views/works/_uploads_form.html.erb
+++ b/app/views/works/_uploads_form.html.erb
@@ -33,7 +33,7 @@
                     </td>
                     <td><span><%= upload.created_at %></span></td>
                     <td>
-                      <input id="work-deposit-uploads" name="work[replaced_uploads][<%= upload.id %>]" type="file" />
+                      <input id="work-deposit-uploads-<%= upload.id %>" name="work[replaced_uploads][<%= upload.key %>]" type="file" />
                     </td>
                     <td>
                       <input id="work-uploads-<%= upload.id %>-delete" name="work[deleted_uploads][<%= upload.key %>]" type="checkbox" value="1"/>

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -299,21 +299,21 @@ RSpec.describe WorksController do
         file.close
         file
       end
-      let(:uploaced_temp_file1) { Rack::Test::UploadedFile.new(temp_file1.path, "text/plain") }
+      let(:uploaded_temp_file1) { Rack::Test::UploadedFile.new(temp_file1.path, "text/plain") }
       let(:temp_file2) do
         file = Tempfile.new("temp_file2")
         file.write("hello world 2")
         file.close
         file
       end
-      let(:uploaced_temp_file2) { Rack::Test::UploadedFile.new(temp_file2.path, "text/plain") }
+      let(:uploaded_temp_file2) { Rack::Test::UploadedFile.new(temp_file2.path, "text/plain") }
       let(:temp_file3) do
         file = Tempfile.new("temp_file3")
         file.write("hello world 3")
         file.close
         file
       end
-      let(:uploaced_temp_file3) { Rack::Test::UploadedFile.new(temp_file3.path, "text/plain") }
+      let(:uploaded_temp_file3) { Rack::Test::UploadedFile.new(temp_file3.path, "text/plain") }
 
       after do
         temp_file1.unlink
@@ -327,8 +327,8 @@ RSpec.describe WorksController do
 
       let(:uploaded_files) do
         {
-          "0" => uploaded_file1,
-          "2" => uploaded_file2
+          work.pre_curation_uploads[0].key => uploaded_file1,
+          work.pre_curation_uploads[2].key => uploaded_file2
         }
       end
 
@@ -340,9 +340,9 @@ RSpec.describe WorksController do
         stub_request(:delete, /#{bucket_url}/).to_return(status: 200)
         stub_request(:put, /#{bucket_url}/).to_return(status: 200)
 
-        work.pre_curation_uploads.attach(uploaced_temp_file1)
-        work.pre_curation_uploads.attach(uploaced_temp_file2)
-        work.pre_curation_uploads.attach(uploaced_temp_file3)
+        work.pre_curation_uploads.attach(uploaded_temp_file1)
+        work.pre_curation_uploads.attach(uploaded_temp_file2)
+        work.pre_curation_uploads.attach(uploaded_temp_file3)
 
         params = {
           "title_main" => "test dataset updated",

--- a/spec/services/work_upload_edit_service_spec.rb
+++ b/spec/services/work_upload_edit_service_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe WorkUploadsEditService do
       work.pre_curation_uploads.attach(uploaded_file2)
       work.pre_curation_uploads.attach(uploaded_file3)
     end
-    let(:params) { { "work_id" => "", "replaced_uploads" => { "1" => uploaded_file4 } }.with_indifferent_access }
+    let(:params) { { "work_id" => "", "replaced_uploads" => { work.pre_curation_uploads[1].key => uploaded_file4 } }.with_indifferent_access }
 
     it "replaces the correct file" do
       upload_service = described_class.new(work, user)

--- a/spec/system/work_edit_spec.rb
+++ b/spec/system/work_edit_spec.rb
@@ -41,6 +41,9 @@ RSpec.describe "Creating and updating works", type: :system, js: true, mock_s3_q
     let(:uploaded_file2) do
       fixture_file_upload("us_covid_2020.csv", "text/csv")
     end
+    let(:uploaded_file3) do
+      fixture_file_upload("orcid.csv", "text/csv")
+    end
     let(:bucket_url) do
       "https://example-bucket.s3.amazonaws.com/"
     end
@@ -79,6 +82,31 @@ RSpec.describe "Creating and updating works", type: :system, js: true, mock_s3_q
       click_on "Save Work"
       expect(page).to have_content("us_covid_2020.csv")
       expect(page).to have_content("deleted us_covid_2019.csv")
+      expect(a_request(:delete, delete_url)).to have_been_made
+      expect(ActiveStorage::PurgeJob).not_to have_received(:new)
+    end
+
+    it "allows users to replace one of the uploads" do
+      allow(ActiveStorage::PurgeJob).to receive(:new).and_call_original
+      # Make the screen larger so the save button is alway on screen.  This avoids random `Element is not clickable` errors
+      page.driver.browser.manage.window.resize_to(2000, 2000)
+      expect(page).to have_content "Filename"
+      expect(page).to have_content "Created At"
+      expect(page).to have_content "Replace Upload"
+      expect(page).to have_content "Delete Upload"
+      within(".files.card-body") do
+        expect(page).to have_content("us_covid_2019.csv")
+        expect(page).to have_content("us_covid_2020.csv")
+      end
+      attach_file("work-deposit-uploads-#{work.pre_curation_uploads.first.id}", Rails.root.join("spec", "fixtures", "files", "orcid.csv"))
+      click_on "Save Work"
+      within(".files.card-body") do
+        expect(page).to have_content("orcid.csv")
+        expect(page).to have_content("us_covid_2020.csv")
+        expect(page).not_to have_content("us_covid_2019.csv")
+      end
+      expect(page).to have_content("deleted us_covid_2019.csv")
+      expect(page).to have_content("added orcid.csv")
       expect(a_request(:delete, delete_url)).to have_been_made
       expect(ActiveStorage::PurgeJob).not_to have_received(:new)
     end


### PR DESCRIPTION
This will allow the replacement to be more accurate and replace the expected upload.

fixes #557 