### PR TITLE
Document how to set envvars

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,20 @@ To stop database services:
 2. Enter the rails console: `bundle exec rails console`
 3. Elevate your privs: `User.new_super_admin("your NetID here")`
 
+### Development with AWS resources
+Tests should never depend on outside resources, and it's best minimize dependencies during development, too, but it can be useful. To give your local instance access to the staging S3 create `~/s3-envvars.sh`:
+```
+export AWS_S3_PRE_CURATE_BUCKET=pdc-describe-staging-precuration
+export AWS_S3_POST_CURATE_BUCKET=pdc-describe-staging-postcuration
+# For these last two, open Lastpass and look under `princeton_ansible/RDSS Globus AWS`:
+export AWS_S3_KEY_ID=...
+export AWS_S3_SECRET_KEY=...
+```
+Then source this file before starting rails:
+```
+$ . ~/s3-envvars.sh; bundle exec rails s -p 3000
+```
+
 ## DataCite integration
 We use DataCite to mint DOIs and in production you must to define the `DATACITE_*` environment values indicated [here](https://github.com/pulibrary/princeton_ansible/blob/main/group_vars/pdc_describe/production.yml) for the system to run. During development if you do not set these values the system will use a hard-coded DOI.
 


### PR DESCRIPTION
It sounds like different folks are doing different things. Here's one possibility that's just an addition to the docs, but down the road I think it would be even cleaner to do check in a script something like this:

```
#!/usr/bin/env bash
set -o errexit
export AWS_S3_PRE_CURATE_BUCKET=pdc-describe-staging-precuration
export AWS_S3_POST_CURATE_BUCKET=pdc-describe-staging-postcuration
# Change the content in lastpass to be the ENVVAR pair we need.
$(lpass show 'Shared-ITIMS-Passwords/princeton_ansible/RDSS Globus AWS' --notes)
bundle exec rails s -p 3000
```

This is something that I got stuck on for a little bit -- if there's a different way that it should be done, or it's already documented elsewhere, or there's some standard practice, great!
