### PR TITLE
Ensures that invalid or `nil` Collections associated with Works raise errors

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -68,7 +68,11 @@ class WorksController < ApplicationController
     @work.attach_s3_resources
     respond_to do |format|
       format.html do
-        @can_curate = current_user.can_admin?(@work.collection)
+        # Ensure that the Work belongs to a Collection
+        @collection = @work.collection
+        raise(Work::InvalidCollectionError, "The Work #{@work.id} does not belong to any Collection") unless @collection
+
+        @can_curate = current_user.can_admin?(@collection)
         @work.mark_new_notifications_as_read(current_user.id)
       end
       format.json { render json: @work.resource }

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -4,6 +4,9 @@
 class Work < ApplicationRecord
   MAX_UPLOADS = 20
 
+  # Errors for cases where there is no valid Collection
+  class InvalidCollectionError < ::ArgumentError; end
+
   has_many :work_activity, -> { order(updated_at: :desc) }, dependent: :destroy
   has_many_attached :pre_curation_uploads, service: :amazon_pre_curation
 

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -44,10 +44,10 @@
 </style>
 
 <div>
-  <% if @work.draft?  || @work.awaiting_approval? || current_user.has_role?(:collection_admin, @work.collection) %>
+  <% if @work.draft?  || @work.awaiting_approval? || current_user.has_role?(:collection_admin, @collection) %>
     <%= link_to("Edit", edit_work_path(@work, wizard: @work.draft?), class: "btn btn-primary") %>
   <% end %>
-  <% if @work.awaiting_approval? && current_user.has_role?(:collection_admin, @work.collection) %>
+  <% if @work.awaiting_approval? && current_user.has_role?(:collection_admin, @collection) %>
     <%= button_to("Approve Dataset", approve_work_path(@work), class: "btn btn-secondary", method: :post) %>
   <% elsif @work.approved? %>
     <%= button_to("Withdraw Dataset", withdraw_work_path(@work), class: "btn btn-secondary", method: :post) %>
@@ -116,7 +116,7 @@
   <% end %>
 
   <p>Added by: <%= @work.created_by_user.uid %></p>
-  <p>Collection: <%= @work.collection.title %></p>
+  <p>Collection: <%= @collection.title %></p>
   <% if @work.resource.rights.present? %>
     <p>Rights: <%= @work.resource.rights.name %> (<%= link_to(@work.resource.rights.identifier, @work.resource.rights.uri, {target: "_blank"}) %>)</p>
   <% end %>
@@ -146,7 +146,7 @@
   <% if @can_curate %>
     <p>Curator: <select id="curator_select">
       <option value="no-one">(no one)</option>
-      <% @work.collection.administrators.each do |user| %>
+      <% @collection.administrators.each do |user| %>
         <option value="<%= user.id %>" <%= @work.curator_user_id == user.id ? "selected" : "" %>><%= user.display_name_safe %></option>
       <% end %>
     </select></p>

--- a/spec/requests/works_spec.rb
+++ b/spec/requests/works_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe "/works", type: :request do
+  let(:user) { FactoryBot.create :user }
+
+  describe "GET /work" do
+    let(:work) do
+      FactoryBot.create(:tokamak_work)
+    end
+
+    before do
+      stub_work_s3_requests(work: work)
+    end
+
+    it "will not show a work page unless the user is logged in" do
+      get work_url(work)
+      expect(response.code).to eq "302"
+      redirect_location = response.header["Location"]
+      expect(redirect_location).to eq "http://www.example.com/sign_in"
+    end
+
+    context "when authenticated" do
+      before do
+        sign_in(user)
+      end
+
+      it "will show the work page displaying the work metadata" do
+        get work_url(work)
+
+        expect(response.code).to eq "200"
+        expect(response.body).to include("Electron Temperature Gradient Driven Transport Model for Tokamak Plasmas")
+      end
+
+      context "when the work does not have a valid collection" do
+        let(:work) do
+          stubbed = instance_double(Work)
+          allow(stubbed).to receive(:s3_object_key).and_return("test-key")
+          stubbed
+        end
+
+        before do
+          allow(work).to receive(:id).and_return("test-id")
+          allow(work).to receive(:collection).and_return(nil)
+          allow(work).to receive(:attach_s3_resources)
+
+          allow(Work).to receive(:find).and_return(work)
+        end
+
+        it "will raise an error" do
+          expect { get work_url(work) }.to raise_error(Work::InvalidCollectionError, "The Work test-id does not belong to any Collection")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #633 and modifies `spec/support/work_s3_requests_specs.rb` in order to stub HTTP requests for cases where Works have no S3 file attachment objects.