### PR TITLE
related objects in prov history

### DIFF
--- a/app/models/pdc_metadata/related_object.rb
+++ b/app/models/pdc_metadata/related_object.rb
@@ -31,9 +31,7 @@ module PDCMetadata
     end
 
     def compare_value
-      # TODO: Lookup relation types, ie "DOCUMENTS"
-      # TODO: More readable representation?
-      "#{related_identifier} | #{related_identifier_type} | #{relation_type}"
+      "#{related_identifier} ('#{relation_type}' relation #{related_identifier_type})"
     end
 
     def self.new_related_object(related_identifier, related_identifier_type, relation_type)

--- a/app/models/pdc_metadata/related_object.rb
+++ b/app/models/pdc_metadata/related_object.rb
@@ -30,6 +30,12 @@ module PDCMetadata
       @related_identifier
     end
 
+    def compare_value
+      # TODO: Lookup relation types, ie "DOCUMENTS"
+      # TODO: More readable representation?
+      "#{related_identifier} | #{related_identifier_type} | #{relation_type}"
+    end
+
     def self.new_related_object(related_identifier, related_identifier_type, relation_type)
       RelatedObject.new(related_identifier: related_identifier, related_identifier_type: related_identifier_type, relation_type: relation_type)
     end

--- a/app/models/pdc_metadata/title.rb
+++ b/app/models/pdc_metadata/title.rb
@@ -13,5 +13,9 @@ module PDCMetadata
     def main?
       @title_type.blank?
     end
+
+    def compare_value
+      "#{title} (#{title_type})"
+    end
   end
 end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -616,7 +616,7 @@ class Work < ApplicationRecord
     def validate_related_objects
       return if resource.related_objects.empty?
       invalid = resource.related_objects.reject(&:valid?)
-      errors.add(:base, "Related Obejcts are invalid: #{invalid.map(&:errors).join(', ')}") if invalid.count.positive?
+      errors.add(:base, "Related Objects are invalid: #{invalid.map(&:errors).join(', ')}") if invalid.count.positive?
     end
 
     def publish_doi(user)

--- a/app/services/resource_compare_service.rb
+++ b/app/services/resource_compare_service.rb
@@ -32,105 +32,104 @@ class ResourceCompareService
 
   private
 
-    def compare_resources
-      compare_objects(:titles)
-      compare_objects(:creators)
-      compare_objects(:contributors)
-      compare_objects(:related_objects)
-      compare_simple_values
-      compare_rights
-      compare_keywords
-      compare_collection_tags
-    end
+  def compare_resources
+    compare_objects(:titles)
+    compare_objects(:creators)
+    compare_objects(:contributors)
+    compare_objects(:related_objects)
+    compare_simple_values
+    compare_rights
+    compare_keywords
+    compare_collection_tags
+  end
 
-    ##
-    # Compares simple single values between the two resources.
-    def compare_simple_values
-      field_names = [:description, :publisher, :publication_year, :resource_type, :resource_type_general,
-                     :doi, :ark, :version_number]
+  ##
+  # Compares simple single values between the two resources.
+  def compare_simple_values
+    field_names = [:description, :publisher, :publication_year, :resource_type, :resource_type_general,
+                    :doi, :ark, :version_number]
 
-      field_names.each do |field_name|
-        before_value = @before.send(field_name)
-        after_value = @after.send(field_name)
-        if before_value != after_value
-          @differences[field_name] = [{ action: :changed, from: before_value, to: after_value }]
-        end
-      end
-    end
-
-    def compare_rights
-      before_value = @before.rights&.name
-      after_value = @after.rights&.name
+    field_names.each do |field_name|
+      before_value = @before.send(field_name)
+      after_value = @after.send(field_name)
       if before_value != after_value
-        @differences[:rights] = [{ action: :changed, from: before_value, to: after_value }]
+        @differences[field_name] = [{ action: :changed, from: before_value, to: after_value }]
       end
     end
+  end
 
-    def compare_keywords
-      changes = compare_arrays(@before.keywords, @after.keywords)
-      @differences[:keywords] = changes if changes.count > 0
+  def compare_rights
+    before_value = @before.rights&.name
+    after_value = @after.rights&.name
+    if before_value != after_value
+      @differences[:rights] = [{ action: :changed, from: before_value, to: after_value }]
+    end
+  end
+
+  def compare_keywords
+    changes = compare_arrays(@before.keywords, @after.keywords)
+    @differences[:keywords] = changes if changes.count > 0
+  end
+
+  def compare_collection_tags
+    changes = compare_arrays(@before.collection_tags, @after.collection_tags)
+    @differences[:collection_tags] = changes if changes.count > 0
+  end
+
+  ##
+  # Compares two arrays of simple string values.
+  # Returns an array with the changes (values removed, values added)
+  def compare_arrays(before_values, after_values)
+    changes = []
+    removed = before_values - after_values
+    added = after_values - before_values
+    common = (before_values + after_values).uniq - removed - added
+
+    before_values.each do |value|
+      changes << { action: :removed, value: value } unless value.in?(common)
     end
 
-    def compare_collection_tags
-      changes = compare_arrays(@before.collection_tags, @after.collection_tags)
-      @differences[:collection_tags] = changes if changes.count > 0
+    after_values.each do |value|
+      changes << { action: :added, value: value } if value.in?(added)
     end
 
-    ##
-    # Compares two arrays of simple string values.
-    # Returns an array with the changes (values removed, values added)
-    def compare_arrays(before_values, after_values)
-      changes = []
-      removed = before_values - after_values
-      added = after_values - before_values
-      common = (before_values + after_values).uniq - removed - added
+    changes
+  end
 
-      before_values.each do |value|
-        changes << { action: :removed, value: value } unless value.in?(common)
-      end
+  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/PerceivedComplexity
+  def compare_objects(method_sym)
+    changes = []
+    keys_before = @before.send(method_sym).map(&:compare_value)
+    keys_after = @after.send(method_sym).map(&:compare_value)
 
-      after_values.each do |value|
-        changes << { action: :added, value: value } if value.in?(added)
-      end
+    removed = keys_before - keys_after
+    added = keys_after - keys_before
+    common = (keys_before + keys_after).uniq - removed - added
 
-      changes
-    end
-
-    # rubocop:disable Metrics/MethodLength
-    # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/CyclomaticComplexity
-    # rubocop:disable Metrics/PerceivedComplexity
-    def compare_objects(method_sym)
-      changes = []
-      keys_before = @before.send(method_sym).map(&:compare_value)
-      keys_after = @after.send(method_sym).map(&:compare_value)
-
-      removed = keys_before - keys_after
-      added = keys_after - keys_before
-      common = (keys_before + keys_after).uniq - removed - added
-
-      @before.send(method_sym).each do |before_object|
-        if before_object.compare_value.in?(common)
-          after_object = @after.send(method_sym).find { |c| c.compare_value == before_object.compare_value }
-          if before_object.compare_value != after_object.compare_value
-            changes << { action: :changed, from: before_object.compare_value, to: after_object.compare_value }
-          end
-        elsif before_object.compare_value.in?(removed)
-          changes << { action: :removed, value: before_object.compare_value }
+    @before.send(method_sym).each do |before_object|
+      if before_object.compare_value.in?(common)
+        after_object = @after.send(method_sym).find { |c| c.compare_value == before_object.compare_value }
+        if before_object.compare_value != after_object.compare_value
+          changes << { action: :changed, from: before_object.compare_value, to: after_object.compare_value }
         end
+      elsif before_object.compare_value.in?(removed)
+        changes << { action: :removed, value: before_object.compare_value }
       end
-
-      @after.send(method_sym).each do |after_object|
-        if after_object.compare_value.in?(added)
-          changes << { action: :added, value: after_object.compare_value }
-        end
-      end
-
-      @differences[method_sym] = changes if changes.count > 0
     end
-    # rubocop:enable Metrics/PerceivedComplexity
-    # rubocop:enable Metrics/CyclomaticComplexity
-    # rubocop:enable Metrics/AbcSize
-    # rubocop:enable Metrics/MethodLength
+
+    @after.send(method_sym).each do |after_object|
+      if after_object.compare_value.in?(added)
+        changes << { action: :added, value: after_object.compare_value }
+      end
+    end
+
+    @differences[method_sym] = changes if changes.count > 0
+  end
+  # rubocop:enable Metrics/PerceivedComplexity
+  # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/MethodLength
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/services/resource_compare_service.rb
+++ b/app/services/resource_compare_service.rb
@@ -33,7 +33,7 @@ class ResourceCompareService
   private
 
     def compare_resources
-      compare_titles
+      compare_objects(:titles)
       compare_objects(:creators)
       compare_objects(:contributors)
       compare_objects(:related_objects)
@@ -95,47 +95,6 @@ class ResourceCompareService
 
       changes
     end
-
-    ##
-    # Compares the titles between the two resources. This is a bit tricky because we support many
-    # titles and the title itself is an object with two properties (title and title_type)
-    # Returns an array with the changes (values removed, values added, values changed)
-    # rubocop:disable Metrics/MethodLength
-    # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/CyclomaticComplexity
-    # rubocop:disable Metrics/PerceivedComplexity
-    def compare_titles
-      changes = []
-      keys_before = @before.titles.map(&:title_type)
-      keys_after = @after.titles.map(&:title_type)
-
-      removed = keys_before - keys_after
-      added = keys_after - keys_before
-      common = (keys_before + keys_after).uniq - removed - added
-
-      @before.titles.each do |before_title|
-        if before_title.title_type.in?(common)
-          after_title = @after.titles.find { |t| t.title_type == before_title.title_type }
-          if before_title.title != after_title.title
-            changes << { action: :changed, from: before_title.title, to: after_title.title }
-          end
-        elsif before_title.title_type.in?(removed)
-          changes << { action: :removed, value: before_title.title }
-        end
-      end
-
-      @after.titles.each do |after_title|
-        if after_title.title_type.in?(added)
-          changes << { action: :added, value: after_title.title }
-        end
-      end
-
-      @differences[:titles] = changes if changes.count > 0
-    end
-    # rubocop:enable Metrics/PerceivedComplexity
-    # rubocop:enable Metrics/CyclomaticComplexity
-    # rubocop:enable Metrics/AbcSize
-    # rubocop:enable Metrics/MethodLength
 
     # rubocop:disable Metrics/MethodLength
     # rubocop:disable Metrics/AbcSize

--- a/app/services/resource_compare_service.rb
+++ b/app/services/resource_compare_service.rb
@@ -32,102 +32,102 @@ class ResourceCompareService
 
   private
 
-  def compare_resources
-    compare_objects(:titles)
-    compare_objects(:creators)
-    compare_objects(:contributors)
-    compare_objects(:related_objects)
-    compare_simple_values
-    compare_rights
-    compare_keywords
-    compare_collection_tags
-  end
-
-  ##
-  # Compares simple single values between the two resources.
-  def compare_simple_values
-    field_names = [:description, :publisher, :publication_year, :resource_type, :resource_type_general,
-                    :doi, :ark, :version_number]
-
-    field_names.each do |field_name|
-      before_value = @before.send(field_name)
-      after_value = @after.send(field_name)
-      if before_value != after_value
-        @differences[field_name] = [{ action: :changed, from: before_value, to: after_value }]
-      end
-    end
-  end
-
-  def compare_rights
-    before_value = @before.rights&.name
-    after_value = @after.rights&.name
-    if before_value != after_value
-      @differences[:rights] = [{ action: :changed, from: before_value, to: after_value }]
-    end
-  end
-
-  def compare_keywords
-    changes = compare_arrays(@before.keywords, @after.keywords)
-    @differences[:keywords] = changes if changes.count > 0
-  end
-
-  def compare_collection_tags
-    changes = compare_arrays(@before.collection_tags, @after.collection_tags)
-    @differences[:collection_tags] = changes if changes.count > 0
-  end
-
-  ##
-  # Compares two arrays of simple string values.
-  # Returns an array with the changes (values removed, values added)
-  def compare_arrays(before_values, after_values)
-    changes = []
-    removed = before_values - after_values
-    added = after_values - before_values
-    common = (before_values + after_values).uniq - removed - added
-
-    before_values.each do |value|
-      changes << { action: :removed, value: value } unless value.in?(common)
+    def compare_resources
+      compare_objects(:titles)
+      compare_objects(:creators)
+      compare_objects(:contributors)
+      compare_objects(:related_objects)
+      compare_simple_values
+      compare_rights
+      compare_keywords
+      compare_collection_tags
     end
 
-    after_values.each do |value|
-      changes << { action: :added, value: value } if value.in?(added)
-    end
+    ##
+    # Compares simple single values between the two resources.
+    def compare_simple_values
+      field_names = [:description, :publisher, :publication_year, :resource_type, :resource_type_general,
+                     :doi, :ark, :version_number]
 
-    changes
-  end
-
-  # rubocop:disable Metrics/MethodLength
-  # rubocop:disable Metrics/AbcSize
-  # rubocop:disable Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/PerceivedComplexity
-  def compare_objects(method_sym)
-    changes = []
-    keys_before = @before.send(method_sym).map(&:compare_value)
-    keys_after = @after.send(method_sym).map(&:compare_value)
-
-    removed = keys_before - keys_after
-    added = keys_after - keys_before
-    common = (keys_before + keys_after).uniq - removed - added
-
-    @before.send(method_sym).each do |before_object|
-      if before_object.compare_value.in?(common)
-        after_object = @after.send(method_sym).find { |c| c.compare_value == before_object.compare_value }
-        if before_object.compare_value != after_object.compare_value
-          changes << { action: :changed, from: before_object.compare_value, to: after_object.compare_value }
+      field_names.each do |field_name|
+        before_value = @before.send(field_name)
+        after_value = @after.send(field_name)
+        if before_value != after_value
+          @differences[field_name] = [{ action: :changed, from: before_value, to: after_value }]
         end
-      elsif before_object.compare_value.in?(removed)
-        changes << { action: :removed, value: before_object.compare_value }
       end
     end
 
-    @after.send(method_sym).each do |after_object|
-      if after_object.compare_value.in?(added)
-        changes << { action: :added, value: after_object.compare_value }
+    def compare_rights
+      before_value = @before.rights&.name
+      after_value = @after.rights&.name
+      if before_value != after_value
+        @differences[:rights] = [{ action: :changed, from: before_value, to: after_value }]
       end
     end
 
-    @differences[method_sym] = changes if changes.count > 0
-  end
+    def compare_keywords
+      changes = compare_arrays(@before.keywords, @after.keywords)
+      @differences[:keywords] = changes if changes.count > 0
+    end
+
+    def compare_collection_tags
+      changes = compare_arrays(@before.collection_tags, @after.collection_tags)
+      @differences[:collection_tags] = changes if changes.count > 0
+    end
+
+    ##
+    # Compares two arrays of simple string values.
+    # Returns an array with the changes (values removed, values added)
+    def compare_arrays(before_values, after_values)
+      changes = []
+      removed = before_values - after_values
+      added = after_values - before_values
+      common = (before_values + after_values).uniq - removed - added
+
+      before_values.each do |value|
+        changes << { action: :removed, value: value } unless value.in?(common)
+      end
+
+      after_values.each do |value|
+        changes << { action: :added, value: value } if value.in?(added)
+      end
+
+      changes
+    end
+
+    # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/PerceivedComplexity
+    def compare_objects(method_sym)
+      changes = []
+      keys_before = @before.send(method_sym).map(&:compare_value)
+      keys_after = @after.send(method_sym).map(&:compare_value)
+
+      removed = keys_before - keys_after
+      added = keys_after - keys_before
+      common = (keys_before + keys_after).uniq - removed - added
+
+      @before.send(method_sym).each do |before_object|
+        if before_object.compare_value.in?(common)
+          after_object = @after.send(method_sym).find { |c| c.compare_value == before_object.compare_value }
+          if before_object.compare_value != after_object.compare_value
+            changes << { action: :changed, from: before_object.compare_value, to: after_object.compare_value }
+          end
+        elsif before_object.compare_value.in?(removed)
+          changes << { action: :removed, value: before_object.compare_value }
+        end
+      end
+
+      @after.send(method_sym).each do |after_object|
+        if after_object.compare_value.in?(added)
+          changes << { action: :added, value: after_object.compare_value }
+        end
+      end
+
+      @differences[method_sym] = changes if changes.count > 0
+    end
   # rubocop:enable Metrics/PerceivedComplexity
   # rubocop:enable Metrics/CyclomaticComplexity
   # rubocop:enable Metrics/AbcSize

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -935,7 +935,7 @@ RSpec.describe Work, type: :model do
       it "validates the work is not ready to submit" do
         expect(work.valid_to_submit).to be_falsey
         expect(work.errors.count).to eq(1)
-        expect(work.errors.first.type). to eq("Related Obejcts are invalid: Related Identifier Type is missing or invalid for http://related.example.com, Relationship Type is missing or invalid for http://related.example.com")
+        expect(work.errors.first.type). to eq("Related Objects are invalid: Related Identifier Type is missing or invalid for http://related.example.com, Relationship Type is missing or invalid for http://related.example.com")
       end
     end
   end


### PR DESCRIPTION
- Fix #627 
- Clean up copy and pasted code while I'm here.
- Make title comparison logic consistent with other objects.
- Base of this PR is my PR to change gem install location. If this is good, but that isn't, I'll add another commit on the tip of this branch to revert those bits.

Notes:
- Users were confused by `delete` + `add` when they expected just `change`; That's in the same neighborhood, but I don't see an issue for it. Just filed: https://github.com/pulibrary/pdc_describe/issues/645
- (More testing would be good but don't want to invest too much in it now if the machinery is going to change.)
- If this much is accepted, I would like to follow up with a quick refactor of the other compare methods for consistency.