### PR TITLE
Add OS licenses

### DIFF
--- a/app/models/pdc_metadata/rights.rb
+++ b/app/models/pdc_metadata/rights.rb
@@ -11,6 +11,8 @@ module PDCMetadata
 
     def self.all
       @all ||= [
+        Rights.new(identifier: "MIT", uri: "https://mit-license.org/", name: "MIT License"),
+        Rights.new(identifier: "GPLv3", uri: "https://www.gnu.org/licenses/gpl-3.0.en.html", name: "GNU General Public License"),
         Rights.new(identifier: "CC BY", uri: "https://creativecommons.org/licenses/by/4.0/", name: "Creative Commons Attribution 4.0 International"),
         Rights.new(identifier: "CC BY-SA", uri: "https://creativecommons.org/licenses/by-sa/4.0/", name: "Creative Commons Attribution-ShareAlike 4.0 International"),
         Rights.new(identifier: "CC BY-NC", uri: "https://creativecommons.org/licenses/by-nc/4.0/", name: "Creative Commons Attribution-NonCommercial 4.0 International"),

--- a/spec/system/work_spec.rb
+++ b/spec/system/work_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "Creating and updating works", type: :system do
     visit edit_work_path(work)
     find("#rights_identifier").find(:xpath, "option[2]").select_option
     click_on "Save Work"
-    expect(work.reload.resource.rights.identifier).to eq "CC BY"
+    expect(work.reload.resource.rights.identifier).to eq "MIT"
   end
 
   it "Renders the ResourceType", js: true do


### PR DESCRIPTION
- Fix #624
- Since we only have two of these, thought it made sense to list them above the CC licenses, so they don't get lost.
- I think GNU should be all-caps?
- Not sure about the best URLs to include here: The GNU one is "official"... but maybe you'd prefer something like https://opensource.org/licenses/gpl-license?

(PR targets my bundle branch... if we don't end up accepting that, I'll add a revert for the bundle config at the tip.)