### PR TITLE
Disable headers in markdown

### DIFF
--- a/app/models/work_activity.rb
+++ b/app/models/work_activity.rb
@@ -59,8 +59,10 @@ class WorkActivity < ApplicationRecord
         user_info = user&.display_name_safe || uid
         "<a class='comment-user-link' title='#{user_info}' href='{USER-PATH-PLACEHOLDER}/#{uid}'>#{at_uid}</a>"
       end
-      # allow ``` for code blocks (Kramdown only supports ~~~)
+      # Allow ``` for code blocks (Kramdown only supports ~~~)
       text = text.gsub("```", "~~~")
+      # Escape line-starting hash marks: Headers are distracting.
+      text = text.gsub(/^#+/, "\\#")
       parsed_document = Kramdown::Document.new(text)
       parsed_document.to_html
     end

--- a/app/models/work_activity.rb
+++ b/app/models/work_activity.rb
@@ -59,10 +59,8 @@ class WorkActivity < ApplicationRecord
         user_info = user&.display_name_safe || uid
         "<a class='comment-user-link' title='#{user_info}' href='{USER-PATH-PLACEHOLDER}/#{uid}'>#{at_uid}</a>"
       end
-      # Allow ``` for code blocks (Kramdown only supports ~~~)
-      text = text.gsub("```", "~~~")
-      # Escape line-starting hash marks: Headers are distracting.
-      text = text.gsub(/^#+/, "\\#")
+      # Allow ``` for code blocks (Kramdown only supports ~~~) / Disable headers in markdown.
+      text = text.gsub("```", "~~~").gsub(/^#+/, "\\#")
       parsed_document = Kramdown::Document.new(text)
       parsed_document.to_html
     end


### PR DESCRIPTION
- Fix #622

I have mixed feelings about this: Every special case we add is something that could be confusing down the line... And from my own experience, sometime h3 or h4 headers are useful in organizing a longer comment.