### PR TITLE
add css for headers in comments

### DIFF
--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -33,6 +33,46 @@
     margin-bottom: 0px;
   }
 
+  .comment-html h1, .comment-html h2, .comment-html h3, .comment-html h4, .comment-html h5, .comment-html h6 {
+    font-weight: bold;
+    font-size: 100%;
+    display: table;
+    margin-top: 0.5em;
+    padding: 1px;
+  }
+
+  .comment-html h1 {
+    padding-bottom: 2px;
+    border-bottom: 4px solid gray;
+  }
+
+  .comment-html h2 {
+    padding-bottom: 1.5px;
+    border-bottom: 2px solid gray;
+  }
+
+  .comment-html h3 {
+    border-bottom: 1px solid gray;
+  }
+
+  .comment-html h4 {
+    border: 1px solid gray;
+    padding: 1px 4px;
+  }
+
+  .comment-html h5 {
+    font-weight: normal;
+    border: 1px solid gray;
+    padding: 1px 4px;
+  }
+
+  .comment-html h6 {
+    font-weight: normal;
+    font-size: small;
+    border: 1px solid gray;
+    padding: 1px 4px;
+  }
+  
   .comment-user-link {
     color: rgb(36, 41, 47);
     background-color: rgb(255, 248, 197);


### PR DESCRIPTION
- Fix #622 

<img width="315" alt="Screen Shot 2022-12-02 at 3 57 33 PM" src="https://user-images.githubusercontent.com/730388/205385831-0bae2d47-3e7a-4692-bbe5-7ecada2a4240.png">

Tried to suggest a header hierarchy, without making the font larger.

This could be done differently, but let's try not to bikeshed this.

This  would be a little tidier in scss, but it looks like the pattern is for CSS to live close to the HTML it modifies, for the top-level ERBs, and I'm happy to continue that pattern.