### PR TITLE
preserve whitespace in description

### DIFF
--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -114,7 +114,7 @@
 
 <div>
   <p>Description:<br/>
-    <%= @work.resource.description %>
+    <span style="white-space: pre-wrap;"><%= @work.resource.description %></span>
   </p>
   <p>Publisher: <%= @work.resource.publisher %></p>
   <p>Publication Year: <%= @work.resource.publication_year %></p>


### PR DESCRIPTION
- Fix #617

Before:
> <img width="863" alt="Screen Shot 2022-12-05 at 1 03 29 PM" src="https://user-images.githubusercontent.com/730388/205716906-89576c8a-b861-4c8f-bd69-92aaded8a782.png">

After:
> <img width="523" alt="Screen Shot 2022-12-05 at 1 50 38 PM" src="https://user-images.githubusercontent.com/730388/205718640-e04d28ca-c053-4d7e-8127-670a000e43b5.png">

Along with the [`pre` tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre), there are [several CSS options](https://developer.mozilla.org/en-US/docs/Web/CSS/white-space) for controlling how HTML handles whitespace rendering, but without adding a lot of complexity we're not going to be able to treat line-wrapping newlines differently from others.

(I also think we may want to style the labels of fields differently from their content, but that should be handled separately.)