### PR TITLE
Refactor: Same idiom as compare_objects

### DIFF
--- a/app/services/resource_compare_service.rb
+++ b/app/services/resource_compare_service.rb
@@ -36,6 +36,12 @@ class ResourceCompareService
       compare_titles
       compare_creators
       compare_contributors
+      [:description, :publisher, :publication_year,
+        :resource_type, :resource_type_general,
+        :doi, :ark, :version_number
+      ].each do |field_name|
+        compare_simple_value(field_name)
+      end
       compare_simple_values
       compare_rights
       compare_keywords
@@ -43,17 +49,12 @@ class ResourceCompareService
     end
 
     ##
-    # Compares simple single values between the two resources.
-    def compare_simple_values
-      field_names = [:description, :publisher, :publication_year, :resource_type, :resource_type_general,
-                     :doi, :ark, :version_number]
-
-      field_names.each do |field_name|
-        before_value = @before.send(field_name)
-        after_value = @after.send(field_name)
-        if before_value != after_value
-          @differences[field_name] = [{ action: :changed, from: before_value, to: after_value }]
-        end
+    # Compares simple single value between the two resources.
+    def compare_simple_value(method_sym)
+      before_value = @before.send(method_sym)
+      after_value = @after.send(method_sym)
+      if before_value != after_value
+        @differences[method_sym] = [{ action: :changed, from: before_value, to: after_value }]
       end
     end
 

--- a/app/services/resource_compare_service.rb
+++ b/app/services/resource_compare_service.rb
@@ -37,9 +37,8 @@ class ResourceCompareService
       compare_creators
       compare_contributors
       [:description, :publisher, :publication_year,
-        :resource_type, :resource_type_general,
-        :doi, :ark, :version_number
-      ].each do |field|
+       :resource_type, :resource_type_general,
+       :doi, :ark, :version_number].each do |field|
         compare_simple_values(field)
       end
       compare_rights

--- a/app/services/resource_compare_service.rb
+++ b/app/services/resource_compare_service.rb
@@ -39,18 +39,18 @@ class ResourceCompareService
       [:description, :publisher, :publication_year,
         :resource_type, :resource_type_general,
         :doi, :ark, :version_number
-      ].each do |field_name|
-        compare_simple_value(field_name)
+      ].each do |field|
+        compare_simple_values(field)
       end
-      compare_simple_values
       compare_rights
-      compare_keywords
-      compare_collection_tags
+      [:keywords, :collection_tags].each do |field|
+        compare_arrays(field)
+      end
     end
 
     ##
     # Compares simple single value between the two resources.
-    def compare_simple_value(method_sym)
+    def compare_simple_values(method_sym)
       before_value = @before.send(method_sym)
       after_value = @after.send(method_sym)
       if before_value != after_value
@@ -66,20 +66,12 @@ class ResourceCompareService
       end
     end
 
-    def compare_keywords
-      changes = compare_arrays(@before.keywords, @after.keywords)
-      @differences[:keywords] = changes if changes.count > 0
-    end
-
-    def compare_collection_tags
-      changes = compare_arrays(@before.collection_tags, @after.collection_tags)
-      @differences[:collection_tags] = changes if changes.count > 0
-    end
-
     ##
     # Compares two arrays of simple string values.
     # Returns an array with the changes (values removed, values added)
-    def compare_arrays(before_values, after_values)
+    def compare_arrays(method_sym)
+      before_values = @before.send(method_sym)
+      after_values = @after.send(method_sym)
       changes = []
       removed = before_values - after_values
       added = after_values - before_values
@@ -93,7 +85,7 @@ class ResourceCompareService
         changes << { action: :added, value: value } if value.in?(added)
       end
 
-      changes
+      @differences[method_sym] = changes if changes.count > 0
     end
 
     ##


### PR DESCRIPTION
Refactoring for consistency with #668, with no change in behavior: Instead of having a compare method for each field, make generic methods which take the field to modify as an argument.