### PR TITLE
Use `<details>` to provide more details in fold down

### DIFF
--- a/app/views/works/_required_form.html.erb
+++ b/app/views/works/_required_form.html.erb
@@ -17,7 +17,10 @@
 
 <!-- Description (one for now)-->
 <div class="field">
-  Description:<span class="required-field">*</span><br>
+  <details>
+    <summary>Description:<span class="required-field">*</span></summary>
+    Please enter a brief summary of this item specifically &mdash; not identical to the abstract of a corresponding paper. The focus should be on the nature of the materials constituting the item (scope, purpose, methods, etc.), as opposed to substantive claims made in related publications.
+  </details>
   <textarea type="text" id="description" name="description" class="input-text-long" rows="5" cols="120"
     placeholder="Please enter a brief summary describing the unique attributes of this submission. (e.g., The purpose, scope, methods, dependencies, etc. for the object(s) deposited to this submission.) It should be unique from a description or abstract used for a corresponding paper."
   ><%= @work.resource.description %></textarea>


### PR DESCRIPTION
- Fix #660

(The original issue mentions that the descriptive text should be normal weight... but in this case the title isn't actually bold. I've filed #673 for consistency here.)

I don't think this is exactly the picture @hhkitsune had in mind, but it lets us present the information without being too distracting to users once they are familiar with the software. Feedback welcome!

Collapsed:
<img width="664" alt="Screen Shot 2022-12-06 at 3 11 56 PM" src="https://user-images.githubusercontent.com/730388/206013825-ecafe61a-09f2-47ca-b0c8-021462c34f87.png">

Expanded:
<img width="739" alt="Screen Shot 2022-12-06 at 3 12 15 PM" src="https://user-images.githubusercontent.com/730388/206013956-672a1622-03f9-40e0-a5c4-ca5805cf2fdd.png">
