### PR TITLE
Server-side publish files to post-curation buckets

### DIFF
--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -533,6 +533,7 @@ RSpec.describe Work, type: :model do
       stub_work_s3_requests(work: awaiting_approval_work, file_name: file_name)
       awaiting_approval_work.pre_curation_uploads.attach(uploaded_file)
       stub_datacite_doi
+      # This is the test that I am using
       awaiting_approval_work.approve!(curator_user)
       expect(awaiting_approval_work.reload.state).to eq("approved")
     end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -132,8 +132,6 @@ RSpec.describe Work, type: :model do
     work.approve!(curator_user)
     # The put for precuration upload
     expect(a_request(:put, "https://example-bucket.s3.amazonaws.com/#{work.s3_object_key}/#{file_name}")).to have_been_made
-    # The put for postcuration move on save
-    expect(a_request(:put, "https://example-bucket-post.s3.amazonaws.com/#{work.s3_object_key}/#{file_name}")).to have_been_made
     expect(work.state_history.first.state).to eq "approved"
     expect(work.reload.state).to eq("approved")
   end
@@ -175,7 +173,7 @@ RSpec.describe Work, type: :model do
     let(:s3_client) { instance_double(Aws::S3::Client) }
 
     before do
-      allow(s3_client).to receive(:put_object)
+      allow(s3_client).to receive(:copy_object)
       allow(s3_client).to receive(:head_object).with(bucket: "example-bucket", key: "10.34770/123-abc/#{work.id}").and_raise(Aws::S3::Errors::NotFound.new(true, "test error"))
       allow(s3_client).to receive(:head_object).with(bucket: "example-bucket", key: "10.34770/123-abc/#{work.id}/us_covid_2019.csv").and_return(true)
       allow(s3_client).to receive(:head_object).with(bucket: "example-bucket", key: "10.34770/123-abc/#{work.id}/us_covid_2019_2.csv").and_return(true)
@@ -200,6 +198,7 @@ RSpec.describe Work, type: :model do
       work.reload
       2.times { work.pre_curation_uploads.attach(uploaded_file) }
       work.save!
+      allow(pre_curated_query_service).to receive(:publish_files).and_return([work.pre_curation_uploads.first, work.pre_curation_uploads.last])
     end
 
     context "when a Work is approved" do
@@ -212,16 +211,7 @@ RSpec.describe Work, type: :model do
         work.approve!(curator_user)
         work.reload
 
-        expect(s3_client).to have_received(:put_object).with({
-                                                               body: "test_content",
-                                                               bucket: "example-bucket",
-                                                               key: "10.34770/123-abc/#{work.id}/us_covid_2019.csv"
-                                                             }).at_least(1).time
-        expect(s3_client).to have_received(:put_object).with({
-                                                               body: "test_content",
-                                                               bucket: "example-bucket",
-                                                               key: "10.34770/123-abc/#{work.id}/us_covid_2019_2.csv"
-                                                             }).at_least(1).time
+        expect(pre_curated_query_service).to have_received(:publish_files).once
         expect(work.pre_curation_uploads).to be_empty
         expect(work.post_curation_uploads).not_to be_empty
         expect(work.post_curation_uploads.length).to eq(2)
@@ -533,7 +523,7 @@ RSpec.describe Work, type: :model do
       stub_work_s3_requests(work: awaiting_approval_work, file_name: file_name)
       awaiting_approval_work.pre_curation_uploads.attach(uploaded_file)
       stub_datacite_doi
-      # This is the test that I am using
+
       awaiting_approval_work.approve!(curator_user)
       expect(awaiting_approval_work.reload.state).to eq("approved")
     end

--- a/spec/services/s3_query_service_spec.rb
+++ b/spec/services/s3_query_service_spec.rb
@@ -128,6 +128,16 @@ RSpec.describe S3QueryService, mock_s3_query_service: false do
       fake_s3_resp.stub(:to_h).and_return(s3_hash)
     end
 
+    describe "#publish_files" do
+      it "calls S3 copy_object twice, once for each file" do
+        s3_stub = Aws::S3::Client.new(stub_responses: true)
+        subject.stub(:client).and_return(s3_stub)
+        allow(subject.client).to receive(:copy_object)
+        subject.publish_files
+        expect(subject.client).to have_received(:copy_object).twice
+      end
+    end
+
     describe "#data_profile" do
       context "when an error is encountered requesting the file resources" do
         let(:output) { subject.data_profile }

--- a/spec/support/work_s3_requests_specs.rb
+++ b/spec/support/work_s3_requests_specs.rb
@@ -26,7 +26,7 @@ XML
     # Use the built-in AWS S3 stub
     s3 = Aws::S3::Client.new(stub_responses: true)
     allow(Aws::S3::Client).to receive(:new).and_return(s3)
-    s3.stub_responses(:head_object, [Aws::S3::Errors::NotFound.new("1","2"), true])
+    s3.stub_responses(:head_object, [Aws::S3::Errors::NotFound.new("1", "2"), true])
 
     @works = if work.nil?
                works

--- a/spec/support/work_s3_requests_specs.rb
+++ b/spec/support/work_s3_requests_specs.rb
@@ -24,6 +24,7 @@ XML
   # rubocop:disable Metrics/AbcSize
   def stub_work_s3_requests(works: [], work: nil, file_name: nil)
     # Use the built-in AWS S3 stub
+    # (https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/stubbing.html)
     s3 = Aws::S3::Client.new(stub_responses: true)
     allow(Aws::S3::Client).to receive(:new).and_return(s3)
     s3.stub_responses(:head_object, [Aws::S3::Errors::NotFound.new("1", "2"), true])

--- a/spec/support/work_s3_requests_specs.rb
+++ b/spec/support/work_s3_requests_specs.rb
@@ -53,7 +53,26 @@ XML
 
         ## Implicit context: S3 Bucket exists for a pre-curation Work, Work is being updated into the post-curation state
         # Stub the request for moving the S3 file attachment object to the post curation bucket
-        stub_request(:put, "https://example-bucket-post.s3.amazonaws.com/#{w.s3_object_key}/#{file_name}").to_return(status: 200)
+        #
+        # With this stub the test throws error "Seahorse::Client::NetworkingError: Empty or incomplete response body"
+        # stub_request(:put, "https://example-bucket-post.s3.amazonaws.com/#{w.s3_object_key}/#{file_name}").to_return(status: 200)
+        #
+        # Commenting that stub gives the (expected) error suggesting how to stub the request
+        # which is the code below. But this also produces error "Seahorse::Client::NetworkingError: Empty or incomplete response body"
+        #
+        stub_request(:put, "https://example-bucket-post.s3.amazonaws.com/10.34770/123-abc/1/us_covid_2019.csv").
+          with(
+            headers: {
+            'Accept'=>'*/*',
+            'Accept-Encoding'=>'',
+            'Authorization'=> /.+/,
+            'Content-Length'=>'0',
+            'Host'=>'example-bucket-post.s3.amazonaws.com',
+            'User-Agent'=>'aws-sdk-ruby3/3.130.2 ruby/3.0.3 x86_64-darwin19 aws-sdk-s3/1.113.2',
+            'X-Amz-Content-Sha256'=> /.+/,
+            'X-Amz-Copy-Source'=>'/example-bucket/10.34770/123-abc/1/us_covid_2019.csv',
+            }).
+          to_return(status: 200)
 
         # Build the request body for the request to query the contents of the S3 directory object
         s3_list_objects_response = build_s3_list_objects_response(work: w, file_name: file_name)


### PR DESCRIPTION
Changed code to copy of files from pre-curation to post-curation S3 buckets to use Amazon's own copy method so that files are copied between S3 buckets rather than require a server download and re-upload.

Closes #538 