### PR TITLE
Connect WorkActivity to WorkActivityNotifications so we have a cleaner deletion process

### DIFF
--- a/app/models/work_activity.rb
+++ b/app/models/work_activity.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/ClassLength
 class WorkActivity < ApplicationRecord
   belongs_to :work
+
+  has_many :work_activity_notifications, dependent: :destroy
 
   USER_REFERENCE = /@[\w]*/.freeze # e.g. @xy123
 
@@ -125,3 +128,4 @@ class WorkActivity < ApplicationRecord
       end
     end
 end
+# rubocop:enable Metrics/ClassLength

--- a/docs/how_to_delete_a_work.md
+++ b/docs/how_to_delete_a_work.md
@@ -9,8 +9,6 @@ These steps assume the work is assigned to a variable called `work`.
      ```
 1. Delete the UserWork records
    * `UserWork.where(work_id: work.id).each(&:destroy)` 
-1. Delete the Work Activities
-   * `WorkActivity.where(work_id: work.id).each(&:destroy)`
 1. Finally destroy the work
    * `work.destroy`
 
@@ -20,6 +18,5 @@ work.pre_curation_uploads.each(&:destroy)
 service = S3QueryService.new(work, false)
 work.post_curation_uploads.each{|upload| service.client.delete_object({ bucket: service.bucket_name, key: upload.key})}
 UserWork.where(work_id: work.id).each(&:destroy)
-WorkActivity.where(work_id: work.id).each{|work_activity| WorkActivityNotification.where(work_activity_id: work_activity.id).each(&:destroy); work_activity.destroy}
 work.destroy
 ```


### PR DESCRIPTION
This allows a user to run `work_activity.destroy` and have the dependent WorkActivityNotifications also destroyed.

Without this, you need to run  `WorkActivityNotification.where(work_activity_id: work_activity.id).each(&:destroy)` before running the `work_activity.destroy`

Otherwise you will get:
```
ActiveRecord::InvalidForeignKey:
       PG::ForeignKeyViolation: ERROR:  update or delete on table "work_activities" violates foreign key constraint "fk_rails_2a0cd9ebed" on table "work_activity_notifications"
       DETAIL:  Key (id)=(3) is still referenced from table "work_activity_notifications".
```