### PR TITLE
Fix URI bug when editting a work in a local development environment

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 class ApplicationController < ActionController::Base
+  include ActiveStorage::SetCurrent
+
   protect_from_forgery with: :exception
   before_action :authenticate_user!
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 class ApplicationController < ActionController::Base
+  # This is necessary only for localhost development, with storage configured for the filesystem,
+  # but it shouldn't cause problems in other environments that use S3.
+  # Including this concern lets the disk service generate URLs using
+  # the same host, protocol, and port as the current request.
   include ActiveStorage::SetCurrent
 
   protect_from_forgery with: :exception


### PR DESCRIPTION
- Seems to fix #662: I can now edit a work. [Rails docs](https://edgeapi.rubyonrails.org/classes/ActiveStorage/SetCurrent.html).
- Leaving #682 open: The configuration process confuses me, [particularly in development.rb](https://github.com/pulibrary/pdc_describe/pull/301/files?diff=unified&w=1#diff-d3c4b3f41072daa416f1920511e9b2e26caea8c5cec0a14cb9508589a4dafa47):
```diff
-  config.active_storage.service = :local
+  config.active_storage.service = :amazon
```
