### PR TITLE
Add clarification to "New Submission" text

### DIFF
--- a/app/views/works/new_submission.html.erb
+++ b/app/views/works/new_submission.html.erb
@@ -31,11 +31,17 @@
   <h1>New Submission</h1>
   <%= render "wizard_progress", wizard_step: 0 %>
 
-  <p>By starting this new submission, a draft DOI will be reserved for your deposit.</p>
+  <p>
+    You are starting a new submission.
+    By clicking on the "Create New" button, a draft DOI will be reserved for this deposit.
+  </p>
 
-  <p>If you have already started a submission for this deposit, then please
+  <p>
+    If you have already started a submission for this deposit, then please
     <a href="<%= user_path(current_user) %>">go your dashboard</a> and complete
-    the existing submission. If you would like to talk to a specialist about
+    the existing submission.
+    You can find more documentation on the <a href="https://researchdata.princeton.edu/research-lifecycle-guide/dataspace-help">PRDS Data Repository Help Page</a>.
+    If you would like to talk to a specialist about
     your submission, we may be reached at <a href="mailto:prds@princeton.edu">prds@princeton.edu</a>
   </p>
 


### PR DESCRIPTION
- Fix #655

This adds:
- "By clicking on the "Create New" button, ..."
- "You can find more documentation on the PRDS Data Repository Help Page."
