### PR TITLE
Remove Title placeholder and add details folddown

### DIFF
--- a/app/views/works/_required_title.html.erb
+++ b/app/views/works/_required_title.html.erb
@@ -1,13 +1,16 @@
 <!-- Render the main title (notice that we don't display a dropdown for this title) -->
 <div class="field">
-  Title:<span class="required-field" title="Title for your submission must be indicated">*</span>
-  <span id="title-required-message" class="hidden">
-    <i class="bi bi-exclamation-diamond-fill required-field"></i>&nbsp;Must provide a title
-  </span>
-  <br>
+  <details>
+    <summary>
+      Title:<span class="required-field" title="Title for your submission must be indicated">*</span>
+      <span id="title-required-message" class="hidden">
+        <i class="bi bi-exclamation-diamond-fill required-field"></i>&nbsp;Must provide a title
+      </span>
+    </summary>
+    Provide an informative and distinctive title for the item as a whole &mdash; not identical to that of a corresponding paper.
+  </details>
   <input type="text" id="title_main" name="title_main" class="input-text-long"
     value="<%= @work&.resource&.main_title %>"
-    placeholder="The title should be unique and different from one used for a corresponding paper."
   />
   <% if allow_many %>
     <span>


### PR DESCRIPTION
- Fix #658

Removing the placeholder not explicitly requested, but since the text is much the same, and the detail fold-down seems to be preferred, thought it would be ok to delete.