### PR TITLE
Separate comments from other changes

### DIFF
--- a/app/views/works/_work_activity.html.erb
+++ b/app/views/works/_work_activity.html.erb
@@ -1,7 +1,10 @@
 <div class="activity-history-item activity-history-<%= event_type %>-item">
   <div class="activity-history-<%= event_type %>-title">
-    <b><%= activity.created_by_user&.display_name_safe || "Unknown user outside the system" %></b>
-    <%= activity.created_at.time.strftime("%B %d, %Y %H:%M") %>
+    <% timestamp = activity.created_at.time.strftime("%B %d, %Y %H:%M") %>
+
+    <%= timestamp + " by" if event_type == 'log' %>
+    <%= activity.created_by_user&.display_name_safe || "Unknown user outside the system" %>
+    <%= "at " + timestamp if event_type == 'comment' %>
   </div>
   <span class="comment-html"><%= activity.message_html.gsub('{USER-PATH-PLACEHOLDER}', users_path).html_safe %></span>
 </div>

--- a/app/views/works/_work_activity_history.html.erb
+++ b/app/views/works/_work_activity_history.html.erb
@@ -2,6 +2,9 @@
   <% comments, changes = @work.activities.partition { |act| act.activity_type == 'SYSTEM' } %>
 
   <h2>Comments</h2>
+  <% if comments.size == 0 %>
+    No comments
+  <% end %>
   <% comments.each do |activity| %>
     <%= render partial: 'work_activity', locals: {
       activity: activity,
@@ -10,10 +13,14 @@
   <% end %>
 
   <h2>Activity History</h2>
+  <% if changes.size == 0 %>
+    No activity
+  <% end %>
   <% changes.each do |activity| %>
     <%= render partial: 'work_activity', locals: {
       activity: activity,
       event_type: 'log'
     } %>
   <% end %>
+  
 </div>

--- a/app/views/works/_work_activity_history.html.erb
+++ b/app/views/works/_work_activity_history.html.erb
@@ -1,6 +1,8 @@
 <div>
+  <% comments, changes = @work.activities.partition { |act| act.activity_type == 'SYSTEM' } %>
+
   <h2>Comments</h2>
-  <% @work.activities.select{|activity| activity.activity_type == 'SYSTEM' }.each do |activity| %>
+  <% comments.each do |activity| %>
     <%= render partial: 'work_activity', locals: {
       activity: activity,
       event_type: 'comment'
@@ -8,7 +10,7 @@
   <% end %>
 
   <h2>Activity History</h2>
-  <% @work.activities.select{|activity| activity.activity_type != 'SYSTEM' }.each do |activity| %>
+  <% changes.each do |activity| %>
     <%= render partial: 'work_activity', locals: {
       activity: activity,
       event_type: 'log'

--- a/app/views/works/_work_activity_history.html.erb
+++ b/app/views/works/_work_activity_history.html.erb
@@ -1,11 +1,19 @@
 <div id="activity-history">
-  <% if @work.work_activity.count > 0 %>
-    <h2>Activity History</h2>
-    <% @work.activities.each do |activity| %>
-      <%= render partial: 'work_activity', locals: {
-        activity: activity,
-        event_type: ['CHANGES', 'FILE-CHANGES'].include?(activity.activity_type) ? 'log' : 'comment'
-      } %>
-    <% end %>
+  <h2>Comments</h2>
+  <% @work.activities.select{|activity| activity.activity_type == 'SYSTEM' }.each do |activity| %>
+    <%= render partial: 'work_activity', locals: {
+      activity: activity,
+      event_type: 'comment'
+    } %>
+  <% end %>
+
+
+  <h2>Activity History</h2>
+  <% @work.activities.select{|activity| activity.activity_type != 'SYSTEM' }.each do |activity| %>
+    <em><%= activity.activity_type %><em>
+    <%= render partial: 'work_activity', locals: {
+      activity: activity,
+      event_type: 'log'
+    } %>
   <% end %>
 </div>

--- a/app/views/works/_work_activity_history.html.erb
+++ b/app/views/works/_work_activity_history.html.erb
@@ -1,5 +1,5 @@
 <div>
-  <% comments, changes = @work.activities.partition { |act| act.activity_type == 'COMMENT' } %>
+  <% comments, changes = @work.activities.partition { |act| ["COMMENT", "SYSTEM"].include? act.activity_type } %>
 
   <h2>Comments</h2>
   <% if comments.size == 0 %>
@@ -12,7 +12,7 @@
     } %>
   <% end %>
 
-  <h2>Activity History</h2>
+  <h2>Change History</h2>
   <% if changes.size == 0 %>
     No activity
   <% end %>

--- a/app/views/works/_work_activity_history.html.erb
+++ b/app/views/works/_work_activity_history.html.erb
@@ -1,5 +1,5 @@
 <div>
-  <% comments, changes = @work.activities.partition { |act| act.activity_type == 'SYSTEM' } %>
+  <% comments, changes = @work.activities.partition { |act| act.activity_type == 'COMMENT' } %>
 
   <h2>Comments</h2>
   <% if comments.size == 0 %>

--- a/app/views/works/_work_activity_history.html.erb
+++ b/app/views/works/_work_activity_history.html.erb
@@ -1,4 +1,4 @@
-<div id="activity-history">
+<div>
   <h2>Comments</h2>
   <% @work.activities.select{|activity| activity.activity_type == 'SYSTEM' }.each do |activity| %>
     <%= render partial: 'work_activity', locals: {
@@ -7,10 +7,8 @@
     } %>
   <% end %>
 
-
   <h2>Activity History</h2>
   <% @work.activities.select{|activity| activity.activity_type != 'SYSTEM' }.each do |activity| %>
-    <em><%= activity.activity_type %><em>
     <%= render partial: 'work_activity', locals: {
       activity: activity,
       event_type: 'log'

--- a/app/views/works/_work_activity_history.html.erb
+++ b/app/views/works/_work_activity_history.html.erb
@@ -1,10 +1,6 @@
 <div id="activity-history">
   <% if @work.work_activity.count > 0 %>
     <h2>Activity History</h2>
-    <div class="form-check form-switch">
-      <input id="show-change-history" class="form-check-input" type="checkbox" role="switch" id="flexSwitchCheckDefault" checked>
-      <label class="form-check-label" for="flexSwitchCheckDefault">Show change history</label>
-    </div>
     <% @work.activities.each do |activity| %>
       <%= render partial: 'work_activity', locals: {
         activity: activity,

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -277,10 +277,5 @@
       source: userList,
       trigger: "@"
     });
-
-    // Toggle display of change history
-    $("#show-change-history").on("click", function(el) {
-      $(".activity-history-log-item").toggleClass("hidden");
-    });
   });
 </script>

--- a/spec/system/work_edit_spec.rb
+++ b/spec/system/work_edit_spec.rb
@@ -154,15 +154,13 @@ RSpec.describe "Creating and updating works", type: :system, js: true, mock_s3_q
       allow(Time).to receive(:now) { now }
     end
 
-    it "toggles the display of changes" do
+    it "displays changes" do
       sign_in user
       visit edit_work_path(work)
       fill_in "title_main", with: "UPDATED" + work.resource.titles.first.title
       click_on "Save Work"
       # This depends on the timezone configured in application.rb:
       expect(page.find(".activity-history-log-title", visible: true)).to have_content "December 31, 2021 19:00"
-      uncheck "show-change-history"
-      expect(page.find(".activity-history-log-title", visible: false).tag_name).to eq "div"
     end
   end
 


### PR DESCRIPTION
- Fix #677
- Change "Activity History" to "Change History" for clarity
- Remove view toggle, since they are separate sections.
- Add a "No comments" / "No changes" message if needed, rather than hiding the entire section. (With more sections, I think conditional display can get more confusing.)


<img width="328" alt="Screen Shot 2022-12-08 at 6 16 11 PM" src="https://user-images.githubusercontent.com/730388/206587459-152f2269-53df-48d2-97da-a6c806ae1d49.png">

