### PR TITLE
Diff simple text fields in the change log

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,3 +94,5 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem "diff-lcs", "~> 1.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -482,6 +482,7 @@ DEPENDENCIES
   datacite!
   datacite-mapping
   devise
+  diff-lcs (~> 1.5)
   ezid-client!
   factory_bot_rails
   faraday
@@ -518,4 +519,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   2.3.22
+   2.3.26

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -125,3 +125,12 @@ input[readonly] {
   border-style: solid;
   background: #f4f4f4;
 }
+
+.activity-history-item {
+  del {
+    background-color: #EE9090;
+  }
+  ins {
+    background-color: #90EE90;
+  }
+}

--- a/app/models/work_activity.rb
+++ b/app/models/work_activity.rb
@@ -96,9 +96,9 @@ class WorkActivity < ApplicationRecord
       elsif value["action"] == "removed"
         change_removed_html(value["value"])
       elsif value["action"] == "diff"
-        value["diff"].map{ |chunk|
-          old_html = CGI::escapeHTML(chunk['old'])
-          new_html = CGI::escapeHTML(chunk['new'])
+        value["diff"].map do |chunk|
+          old_html = CGI.escapeHTML(chunk["old"])
+          new_html = CGI.escapeHTML(chunk["new"])
           case chunk["action"]
           when "!"
             "<del>#{old_html}</del><ins>#{new_html}</ins>"
@@ -109,7 +109,7 @@ class WorkActivity < ApplicationRecord
           when "-"
             "<del>#{old_html}</del>"
           end
-        }.join
+        end.join
       else
         change_set_html(value["from"], value["to"])
       end

--- a/app/models/work_activity.rb
+++ b/app/models/work_activity.rb
@@ -96,20 +96,7 @@ class WorkActivity < ApplicationRecord
       elsif value["action"] == "removed"
         change_removed_html(value["value"])
       elsif value["action"] == "diff"
-        value["diff"].map do |chunk|
-          old_html = CGI.escapeHTML(chunk["old"])
-          new_html = CGI.escapeHTML(chunk["new"])
-          case chunk["action"]
-          when "!"
-            "<del>#{old_html}</del><ins>#{new_html}</ins>"
-          when "="
-            new_html
-          when "+"
-            "<ins>#{new_html}</ins>"
-          when "-"
-            "<del>#{old_html}</del>"
-          end
-        end.join
+
       else
         change_set_html(value["from"], value["to"])
       end
@@ -125,6 +112,18 @@ class WorkActivity < ApplicationRecord
       <<-HTML
         <i>(removed)</i> <span>#{value}</span><br/>
       HTML
+    end
+
+    def change_diff_html(value)
+      value["diff"].map do |chunk|
+        old_html = CGI.escapeHTML(chunk["old"])
+        new_html = CGI.escapeHTML(chunk["new"])
+        if chunk["action"] == "="
+          new_html
+        else
+          (old_html.empty? ? "" : "<del>#{old_html}</del>") + (new_html.empty? ? "" : "<ins>#{new_html}</ins>")
+        end
+      end.join
     end
 
     def change_set_html(from, to)

--- a/app/models/work_activity.rb
+++ b/app/models/work_activity.rb
@@ -97,7 +97,7 @@ class WorkActivity < ApplicationRecord
       elsif value["action"] == "removed"
         change_removed_html(value["value"])
       elsif value["action"] == "diff"
-        change_diff_html(value["value"])
+        change_diff_html(value["diff"])
       else
         change_set_html(value["from"], value["to"])
       end
@@ -115,8 +115,8 @@ class WorkActivity < ApplicationRecord
       HTML
     end
 
-    def change_diff_html(value)
-      value["diff"].map do |chunk|
+    def change_diff_html(diff)
+      diff.map do |chunk|
         old_html = CGI.escapeHTML(chunk["old"])
         new_html = CGI.escapeHTML(chunk["new"])
         if chunk["action"] == "="

--- a/app/models/work_activity.rb
+++ b/app/models/work_activity.rb
@@ -81,7 +81,6 @@ class WorkActivity < ApplicationRecord
 
     # Returns the message formatted to display _metadata_ changes that were logged as an activity
     def metadata_changes_html
-      text = ""
       changes = JSON.parse(message)
       changes.keys.each do |field|
         values = changes[field].map { |value| change_value_html(value) }.join
@@ -95,6 +94,21 @@ class WorkActivity < ApplicationRecord
         change_added_html(value["value"])
       elsif value["action"] == "removed"
         change_removed_html(value["value"])
+      elsif value["action"] == "diff"
+        value["diff"].map{ |chunk|
+          old_html = CGI::escapeHTML(chunk['old'])
+          new_html = CGI::escapeHTML(chunk['new'])
+          case chunk["action"]
+          when "!"
+            "<del>#{old_html}</del><ins>#{new_html}</ins>"
+          when "="
+            new_html
+          when "+"
+            "<ins>#{new_html}</ins>"
+          when "-"
+            "<del>#{old_html}</del>"
+          end
+        }.join
       else
         change_set_html(value["from"], value["to"])
       end

--- a/app/models/work_activity.rb
+++ b/app/models/work_activity.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/ClassLength
 class WorkActivity < ApplicationRecord
   belongs_to :work
 
@@ -96,7 +97,7 @@ class WorkActivity < ApplicationRecord
       elsif value["action"] == "removed"
         change_removed_html(value["value"])
       elsif value["action"] == "diff"
-
+        change_diff_html(value["value"])
       else
         change_set_html(value["from"], value["to"])
       end
@@ -139,3 +140,4 @@ class WorkActivity < ApplicationRecord
       end
     end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/models/work_activity.rb
+++ b/app/models/work_activity.rb
@@ -81,6 +81,7 @@ class WorkActivity < ApplicationRecord
 
     # Returns the message formatted to display _metadata_ changes that were logged as an activity
     def metadata_changes_html
+      text = ""
       changes = JSON.parse(message)
       changes.keys.each do |field|
         values = changes[field].map { |value| change_value_html(value) }.join

--- a/app/services/resource_compare_service.rb
+++ b/app/services/resource_compare_service.rb
@@ -19,8 +19,10 @@ require "diff/lcs"
 #
 # rubocop:disable Metrics/ClassLength
 
-def diff(old, new)
-  Diff::LCS.sdiff(old, new).chunk(&:action).map do |action, changes|
+def diff(old_value, new_value)
+  old_value ||= ""
+  new_value ||= ""
+  Diff::LCS.sdiff(old_value, new_value).chunk(&:action).map do |action, changes|
     {
       action: action,
       old: changes.map(&:old_element).join,

--- a/app/services/resource_compare_service.rb
+++ b/app/services/resource_compare_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'diff/lcs'
+require "diff/lcs"
 
 # Compares two PDCMetadata::Resource objects and provides a hash with the `differences`
 #

--- a/spec/models/work_activity_spec.rb
+++ b/spec/models/work_activity_spec.rb
@@ -5,6 +5,33 @@ describe WorkActivity, type: :model do
   let(:user) { FactoryBot.create :user }
   let(:work) { FactoryBot.create(:draft_work) }
 
+  describe "#message_html" do
+    let(:work_activity) do
+      activity = WorkActivity.new(
+        work_id: work.id,
+        activity_type: 'CHANGES',
+        message: {"fake_field_name": [
+          {
+            "action":"diff",
+            "diff":[
+              {"action":"-","old":"a","new":""},
+              {"action":"=","old":"b","new":"b"},
+              {"action":"+","old":"","new":"c"},
+              {"action":"!","old":"?","new":"!"}
+            ]
+          }
+        ]}.to_json,
+        created_by_user_id: user.id
+      )
+      activity.save!
+      activity
+    end
+
+    it "formats diff as html" do
+      expect(work_activity.message_html).to eq("<p><b>fake_field_name</b>: <del>a</del>b<ins>c</ins><del>?</del><ins>!</ins></p>")
+    end
+  end
+
   describe "#notify_users" do
     let(:message) { "test message for @#{user.uid}" }
     let(:work_activity) do

--- a/spec/models/work_activity_spec.rb
+++ b/spec/models/work_activity_spec.rb
@@ -9,18 +9,18 @@ describe WorkActivity, type: :model do
     let(:work_activity) do
       activity = WorkActivity.new(
         work_id: work.id,
-        activity_type: 'CHANGES',
-        message: {"fake_field_name": [
+        activity_type: "CHANGES",
+        message: { "fake_field_name": [
           {
-            "action":"diff",
-            "diff":[
-              {"action":"-","old":"a","new":""},
-              {"action":"=","old":"b","new":"b"},
-              {"action":"+","old":"","new":"c"},
-              {"action":"!","old":"?","new":"!"}
+            "action": "diff",
+            "diff": [
+              { "action": "-", "old": "a", "new": "" },
+              { "action": "=", "old": "b", "new": "b" },
+              { "action": "+", "old": "", "new": "c" },
+              { "action": "!", "old": "?", "new": "!" }
             ]
           }
-        ]}.to_json,
+        ] }.to_json,
         created_by_user_id: user.id
       )
       activity.save!

--- a/spec/services/resource_compare_service_spec.rb
+++ b/spec/services/resource_compare_service_spec.rb
@@ -12,11 +12,22 @@ describe ResourceCompareService do
   it "detects simple changes" do
     work1 = FactoryBot.create(:shakespeare_and_company_work)
     work2 = FactoryBot.create(:shakespeare_and_company_work)
-    work2 .resource.description = "hello"
+    work2 .resource.description = "All data related to Shakespeare and Company bookshop"
     compare = described_class.new(work1.resource, work2.resource)
     expect(compare.identical?).to be false
-    expect(compare.differences[:description].first[:action]).to be :changed
-    expect(compare.differences[:description].first[:to]).to be "hello"
+    expect(compare.differences[:description].first[:action]).to be :diff
+    expect(compare.differences[:description].first[:diff]).to eq [
+      {:action=>"=", :new=>"All data ", :old=>"All data "},
+      {:action=>"-", :new=>"", :old=>"is "},
+      {:action=>"=", :new=>"related to ", :old=>"related to "},
+      {:action=>"-", :new=>"", :old=>"the "},
+      {:action=>"=",
+       :new=>"Shakespeare and Company bookshop",
+       :old=>"Shakespeare and Company bookshop"},
+      {:action=>"-",
+       :new=>"",
+       :old=>
+        " and lending library opened and operated by Sylvia Beach in Paris, 1919–1962."}]
   end
 
   it "detects changes in multi-value properties" do

--- a/spec/services/resource_compare_service_spec.rb
+++ b/spec/services/resource_compare_service_spec.rb
@@ -17,17 +17,17 @@ describe ResourceCompareService do
     expect(compare.identical?).to be false
     expect(compare.differences[:description].first[:action]).to be :diff
     expect(compare.differences[:description].first[:diff]).to eq [
-      {:action=>"=", :new=>"All data ", :old=>"All data "},
-      {:action=>"-", :new=>"", :old=>"is "},
-      {:action=>"=", :new=>"related to ", :old=>"related to "},
-      {:action=>"-", :new=>"", :old=>"the "},
-      {:action=>"=",
-       :new=>"Shakespeare and Company bookshop",
-       :old=>"Shakespeare and Company bookshop"},
-      {:action=>"-",
-       :new=>"",
-       :old=>
-        " and lending library opened and operated by Sylvia Beach in Paris, 1919–1962."}]
+      { action: "=", new: "All data ", old: "All data " },
+      { action: "-", new: "", old: "is " },
+      { action: "=", new: "related to ", old: "related to " },
+      { action: "-", new: "", old: "the " },
+      { action: "=",
+        new: "Shakespeare and Company bookshop",
+        old: "Shakespeare and Company bookshop" },
+      { action: "-",
+        new: "",
+        old: " and lending library opened and operated by Sylvia Beach in Paris, 1919–1962." }
+    ]
   end
 
   it "detects changes in multi-value properties" do


### PR DESCRIPTION
- Towards #645

Want to get feedback on this much before going farther. Right now it's doing a character-by-character diff: If the change was a typo fix, this makes it easy to see... but if the whole string has changed, it will still try to find a minimal set of differences, and the result may be hard to read.

In this PR, the diff is done when the data changes. An alternative approach would be to leave `resource_compare_service.rb` as is and do the diff at render time.

This adds a little CSS, but another option would be to increase [`text-decoration-thickness`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness).
<img width="244" alt="Screen Shot 2022-12-08 at 11 34 25 PM" src="https://user-images.githubusercontent.com/730388/206624798-6a53945c-1451-448a-8fc3-9f524ea53d85.png">

