### PR TITLE
Making UserWork explicitly related to Work so it is easier to delete a work

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -8,6 +8,7 @@ class Work < ApplicationRecord
   class InvalidCollectionError < ::ArgumentError; end
 
   has_many :work_activity, -> { order(updated_at: :desc) }, dependent: :destroy
+  has_many :user_work, -> { order(updated_at: :desc) }, dependent: :destroy
   has_many_attached :pre_curation_uploads, service: :amazon_pre_curation
 
   belongs_to :collection
@@ -16,6 +17,8 @@ class Work < ApplicationRecord
   attribute :profile, :string, default: "DATACITE"
 
   attr_accessor :user_entered_doi
+
+  alias state_history user_work
 
   include AASM
 
@@ -267,10 +270,6 @@ class Work < ApplicationRecord
                      end
                    end
     save!
-  end
-
-  def state_history
-    UserWork.where(work_id: id).order(updated_at: :desc)
   end
 
   def created_by_user

--- a/docs/how_to_delete_a_work.md
+++ b/docs/how_to_delete_a_work.md
@@ -7,8 +7,6 @@ These steps assume the work is assigned to a variable called `work`.
      service = S3QueryService.new(work, false)
      work.post_curation_uploads.each{|upload| service.client.delete_object({ bucket: service.bucket_name, key: upload.key})}
      ```
-1. Delete the UserWork records
-   * `UserWork.where(work_id: work.id).each(&:destroy)` 
 1. Finally destroy the work
    * `work.destroy`
 
@@ -17,6 +15,5 @@ Full script below...
 work.pre_curation_uploads.each(&:destroy)
 service = S3QueryService.new(work, false)
 work.post_curation_uploads.each{|upload| service.client.delete_object({ bucket: service.bucket_name, key: upload.key})}
-UserWork.where(work_id: work.id).each(&:destroy)
 work.destroy
 ```

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -955,4 +955,13 @@ RSpec.describe Work, type: :model do
       expect(work).not_to be_valid
     end
   end
+
+  describe "delete" do
+    it "cleans up all the related objects" do
+      work.complete_submission!(user)
+      expect { work.destroy }.to change { Work.count }.by(-1)
+                                                      .and change { UserWork.count }.by(-1)
+                                                                                    .and change { WorkActivity.count }.by(-2)
+    end
+  end
 end


### PR DESCRIPTION
Allows the deletion to occur automatically when a work is deleted.

Refs #684 