### PR TITLE
Field help: Replace triangle with question mark

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -126,21 +126,26 @@ input[readonly] {
   background: #f4f4f4;
 }
 
-summary {
-  font-size: medium;
-  font-weight: bold;
-  list-style-type: none;
-}
-summary::after {
-  content: '?';
-  font-weight: bold;
-  padding: 0rem .25rem;
-  border: 1px solid black;
-  border-radius: .25rem;
-}
+
+
 details {
   font-size: smaller;
-}
-details[open] summary::after {
-  background-color: #ddd;
+
+  &[open] summary::after {
+    background-color: #ddd;
+  }
+
+  summary {
+    font-size: medium;
+    font-weight: bold;
+    list-style-type: none;
+
+    &::after {
+      content: '?';
+      font-weight: bold;
+      padding: 0rem .25rem;
+      border: 1px solid black;
+      border-radius: .25rem;
+    }
+  }
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -125,3 +125,22 @@ input[readonly] {
   border-style: solid;
   background: #f4f4f4;
 }
+
+summary {
+  font-size: medium;
+  font-weight: bold;
+  list-style-type: none;
+}
+summary::after {
+  content: '?';
+  font-weight: bold;
+  padding: 0rem .25rem;
+  border: 1px solid black;
+  border-radius: .25rem;
+}
+details {
+  font-size: smaller;
+}
+details[open] summary::after {
+  background-color: #ddd;
+}


### PR DESCRIPTION
- Fix #694
- Replace triangle on left with question mark on right, in a round-rect
- Light grey background when help is shown, so the button itself toggles
- Help text is smaller than label
- Bold the field label

<img width="389" alt="Screen Shot 2022-12-09 at 4 21 07 PM" src="https://user-images.githubusercontent.com/730388/206798011-70366238-6718-49f6-a771-5bb7ec4d7137.png">


Not sure if there's a lower-level file that this CSS would better belong in?
