### PR TITLE
Where {pre,post}_curation_uploads strings are the same, consolidate

### DIFF
--- a/app/views/works/_uploads.html.erb
+++ b/app/views/works/_uploads.html.erb
@@ -5,13 +5,13 @@
       <div class="files card-body">
         <!-- Only render file download table if there are files in S3 -->
         <% if @work.pre_curation_uploads.empty? %>
-          <p><%= t('works.form.pre_curation_uploads.empty') %></p>
+          <p><%= t('works.form.curation_uploads.empty') %></p>
         <% else %>
           <table id="files-table" class="table">
             <thead>
               <tr>
-                <th scope="col" nowrap="nowrap"><span><%= t('works.form.pre_curation_uploads.filename') %></span></th>
-                <th scope="col"><span><%= t('works.form.pre_curation_uploads.created_at') %></span></th>
+                <th scope="col" nowrap="nowrap"><span><%= t('works.form.curation_uploads.filename') %></span></th>
+                <th scope="col"><span><%= t('works.form.curation_uploads.created_at') %></span></th>
               </tr>
             </thead>
             <tbody>

--- a/app/views/works/uploads/_post_curation_s3_resources.html.erb
+++ b/app/views/works/uploads/_post_curation_s3_resources.html.erb
@@ -6,14 +6,14 @@
         <table id="files-table" class="table">
           <thead>
             <tr>
-              <th scope="col" nowrap="nowrap"><span><%= t('works.form.post_curation_uploads.filename') %></span></th>
-              <th scope="col"><span><%= t('works.form.post_curation_uploads.created_at') %></span></th>
+              <th scope="col" nowrap="nowrap"><span><%= t('works.form.curation_uploads.filename') %></span></th>
+              <th scope="col"><span><%= t('works.form.curation_uploads.created_at') %></span></th>
             </tr>
           </thead>
           <tbody>
             <% if @work.uploads.empty? %>
               <tr class="files">
-                <td><span><%= t('works.form.post_curation_uploads.empty') %></span></td>
+                <td><span><%= t('works.form.curation_uploads.empty') %></span></td>
                 <td><span></span></td>
               </tr>
               <% else %>

--- a/app/views/works/uploads/_pre_curation_s3_resources.html.erb
+++ b/app/views/works/uploads/_pre_curation_s3_resources.html.erb
@@ -6,14 +6,14 @@
         <table id="files-table" class="table">
           <thead>
             <tr>
-              <th scope="col" nowrap="nowrap"><span><%= t('works.form.pre_curation_uploads.filename') %></span></th>
-              <th scope="col"><span><%= t('works.form.pre_curation_uploads.created_at') %></span></th>
+              <th scope="col" nowrap="nowrap"><span><%= t('works.form.curation_uploads.filename') %></span></th>
+              <th scope="col"><span><%= t('works.form.curation_uploads.created_at') %></span></th>
             </tr>
           </thead>
           <tbody>
             <% if @work.uploads.empty? %>
               <tr class="files">
-                <td><span><%= t('works.form.pre_curation_uploads.empty') %></span></td>
+                <td><span><%= t('works.form.curation_uploads.empty') %></span></td>
                 <td><span></span></td>
               </tr>
               <% else %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,20 +49,16 @@ en:
         actions: 'Once you have uploaded your files, select the "continue" button.'
         go_back: 'Go Back'
         continue: 'Continue'
-      pre_curation_uploads:
-        heading: "Uncurated Files"
-        filename: "Filename"
-        created_at: "Time of Upload"
-        replace_upload: "Replace Upload"
-        empty: "No files in S3"
-        delete_upload: "Delete Upload"
-      post_curation_uploads:
-        heading: "Curated Files"
+      curation_uploads:
         filename: "Filename"
         created_at: "Time of Upload"
         size: "Size"
         replace_upload: "Replace Upload"
         empty: "No files in S3"
         delete_upload: "Delete Upload"
+      pre_curation_uploads:
+        heading: "Uncurated Files"
+      post_curation_uploads:
+        heading: "Curated Files"
     approved:
       uneditable: "This work has been approved.  Edits are no longer available."


### PR DESCRIPTION
- Prep-work for #657

Eliminate differences in the code that don't actually matter so we can isolate the differences that do matter. With these changes, the differences in the ERB are reduced to:

```diff
diff app/views/works/uploads/_{pre,post}_curation_s3_resources.html.erb
20c20
<                 <% @work.pre_curation_uploads.sort_by(&:filename).each_with_index do |file, ix| %>
---
>                 <% @work.post_curation_uploads.sort_by(&:filename).each_with_index do |file, ix| %>
25c25
<                       <a href="<%= rails_blob_path(file, disposition: "attachment") %>" class="documents-file-link" target="_blank" title="<%= file.filename %>"><%= pre_curation_uploads_file_name(file: file) %></a>
---
>                       <a href="<%= file.globus_url %>" class="documents-file-link" target="_blank" title="<%= file.filename %>"><%= post_curation_uploads_file_name(file: file) %></a>
29c29
<                     <span><%= file.created_at %></span>
---
>                     <span><%= file.last_modified %></span>
```