### PR TITLE
Adding a rake task to clean out works for a user so we can clean out old tests data from staging & production

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -12,8 +12,8 @@ amazon: &amazon
   region: <%= S3QueryService.pre_curation_config.fetch(:region) %>
   bucket: <%= S3QueryService.pre_curation_config.fetch(:bucket) %>
 
-# development: &development
-#   <<: *amazon
+development: &development
+  <<: *amazon
 
 amazon_pre_curation:
   <% if Rails.env.development? %>


### PR DESCRIPTION
fixes #664
fixes #684

This allows us the delete works that we create, but not works others create.