### PR TITLE
Copy button to copy DOI's URL to the clipboard

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -2,3 +2,4 @@
 //= link_directory ../stylesheets .css
 //= link edit_work_utils.js
 //= link edit_collection_utils.js
+//= link show_work_utils.js

--- a/app/assets/javascripts/show_work_utils.js
+++ b/app/assets/javascripts/show_work_utils.js
@@ -1,0 +1,56 @@
+$(() => {
+  // Sets the elements to the proper CSS classes once a value has been copied to the clipboard.
+  function setCopiedToClipboard(iconEl, labelEl, normalClass, copiedClass) {
+    $(iconEl).removeClass('bi-clipboard');
+    $(iconEl).addClass('bi-clipboard-check');
+    $(labelEl).text('COPIED');
+    $(labelEl).removeClass(normalClass);
+    $(labelEl).addClass(copiedClass);
+  }
+
+  // Resets the elements to the proper CSS classes (e.g. displays as if the copy has not happened)
+  function resetCopyToClipboard(iconEl, labelEl, normalClass, copiedClass) {
+    $(labelEl).text('COPY');
+    $(labelEl).removeClass(copiedClass);
+    $(labelEl).addClass(normalClass);
+    $(iconEl).addClass('bi-clipboard');
+    $(iconEl).removeClass('bi-clipboard-check');
+  }
+
+  // Sets icon and label to indicate that an error happened when copying a value to the clipboard
+  function errorCopyToClipboard(iconEl, errorMsg) {
+    $(iconEl).removeClass('bi-clipboard');
+    $(iconEl).addClass('bi-clipboard-minus');
+    console.log(errorMsg);
+  }
+
+  // Copies a value to the clipboard and notifies the user
+  // value - value to copy to the clipboard
+  // iconEl - selector for the HTML element with the clipboard icon
+  // labelEl - selector for the HTML element with the COPY label next to the icon
+  // normalClass - CSS to style the label with initially
+  // copiedClass - CSS to style the label with after a value has been copied to the clipboard
+  // iconEl and labelEl could be any jQuery valid selector (e.g. ".some-id" or a reference
+  //  to an element)
+  function copyToClipboard(value, iconEl, labelEl, normalClass, copiedClass) {
+    // Copy value to the clipboard....
+    navigator.clipboard.writeText(value).then(() => {
+      // ...and notify the user
+      setCopiedToClipboard(iconEl, labelEl, normalClass, copiedClass);
+      setTimeout(() => {
+        resetCopyToClipboard(iconEl, labelEl, normalClass, copiedClass);
+      }, 20000);
+    }, () => {
+      errorCopyToClipboard(iconEl, 'Copy to clipboard failed');
+    });
+    // Clear focus from the button.
+    document.activeElement.blur();
+  }
+
+  // Setup the DOI's COPY button to copy the DOI URL to the clipboard
+  $('#copy-doi').click(() => {
+    var doi = $('#copy-doi').data('url');
+    copyToClipboard(doi, '#copy-doi-icon', '#copy-doi-label', 'copy-doi-label-normal', 'copy-doi-label-copied');
+    return false;
+  });
+});

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -149,3 +149,13 @@ details {
     }
   }
 }
+
+.copy-doi-label-normal {
+  font-size: 8pt;
+  color: #212529;
+}
+
+.copy-doi-label-copied {
+  font-size: 8pt;
+  color: green;
+}

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -246,56 +246,11 @@
   <% end %>
 </div>
 
+<%= javascript_include_tag 'show_work_utils' %>
+
 <script>
   $(function() {
-   // Sets the elements to the proper CSS classes once a value has been copied to the clipboard.
-   var setCopiedToClipboard = function(iconEl, labelEl, normalClass, copiedClass) {
-      $(iconEl).removeClass("bi-clipboard");
-      $(iconEl).addClass("bi-clipboard-check");
-      $(labelEl).text("COPIED");
-      $(labelEl).removeClass(normalClass);
-      $(labelEl).addClass(copiedClass);
-    }
-
-    // Resets the elements to the proper CSS classes (e.g. displays as if the copy has not happened)
-    var resetCopyToClipboard = function(iconEl, labelEl, normalClass, copiedClass) {
-      $(labelEl).text("COPY");
-      $(labelEl).removeClass(copiedClass);
-      $(labelEl).addClass(normalClass);
-      $(iconEl).addClass("bi-clipboard");
-      $(iconEl).removeClass("bi-clipboard-check");
-    }
-
-    // Sets icon and label to indicate that an error happened when copying a value to the clipboard
-    var errorCopyToClipboard = function(iconEl, errorMsg) {
-      $(iconEl).removeClass("bi-clipboard");
-      $(iconEl).addClass("bi-clipboard-minus")
-      console.log(errorMsg);
-    }
-
-    // Copies a value to the clipboard and notifies the user
-    // value - value to copy to the clipboard
-    // iconEl - selector for the HTML element with the clipboard icon
-    // labelEl - selector for the HTML element with the COPY label next to the icon
-    // normalClass - CSS to style the label with initially
-    // copiedClass - CSS to style the label with after a value has been copied to the clipboard
-    // iconEl and labelEl could be any jQuery valid selector (e.g. ".some-id" or a reference to an element)
-    var copyToClipboard = function(value, iconEl, labelEl, normalClass, copiedClass) {
-        // Copy value to the clipboard....
-        navigator.clipboard.writeText(value).then(function() {
-          // ...and notify the user
-          setCopiedToClipboard(iconEl, labelEl, normalClass, copiedClass);
-          setTimeout(function() {
-            resetCopyToClipboard(iconEl, labelEl, normalClass, copiedClass);
-          }, 20000);
-        }, function() {
-          errorCopyToClipboard(iconEl, "Copy to clipboard failed");
-        });
-        // Clear focus from the button.
-        document.activeElement.blur();
-    }
-
-    // Issues HTTP POST to update the curator assigned to the work.
+     // Issues HTTP POST to update the curator assigned to the work.
     $("#curator_select").on("change", function(event) {
       var newCuratorId = event.currentTarget.value;
       var url = '<%= work_assign_curator_url(id: @work.id, uid: "uid-placeholder") %>';
@@ -329,13 +284,6 @@
       hidden: '#hidden_inputbox',
       source: userList,
       trigger: "@"
-    });
-
-    // Setup the DOI's COPY button to copy the DOI URL to the clipboard
-    $("#copy-doi").click(function(_x) {
-      var doi = this.dataset["url"];
-      copyToClipboard(doi, "#copy-doi-icon", "#copy-doi-label", "copy-doi-label-normal", "copy-doi-label-copied");
-      return false;
     });
   });
 </script>

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -72,7 +72,7 @@
     border: 1px solid gray;
     padding: 1px 4px;
   }
-  
+
   .comment-user-link {
     color: rgb(36, 41, 47);
     background-color: rgb(255, 248, 197);
@@ -119,7 +119,13 @@
   <p>Publisher: <%= @work.resource.publisher %></p>
   <p>Publication Year: <%= @work.resource.publication_year %></p>
   <% if @work.resource.doi %>
-    <p>DOI: <%= link_to(@work.resource.doi, doi_url(@work.resource.doi)) %></p>
+    <p>DOI:
+      <span><%= link_to(@work.resource.doi, doi_url(@work.resource.doi), target: '_blank', rel: 'noopener noreferrer') %></span>
+      <button id="copy-doi" class="btn btn-sm" data-url="<%= doi_url(@work.resource.doi) %>" title="Copy DOI URL to the clipboard">
+        <i id="copy-doi-icon" class="bi bi-clipboard" title="Copy DOI URL to the clipboard"></i>
+        <span id="copy-doi-label" class="copy-doi-label-normal">COPY</span>
+      </button>
+    </p>
   <% end %>
   <% if @work.resource.ark %>
     <p>ARK: <%= link_to(@work.resource.ark, ark_url(@work.resource.ark)) %></p>
@@ -242,6 +248,53 @@
 
 <script>
   $(function() {
+   // Sets the elements to the proper CSS classes once a value has been copied to the clipboard.
+   var setCopiedToClipboard = function(iconEl, labelEl, normalClass, copiedClass) {
+      $(iconEl).removeClass("bi-clipboard");
+      $(iconEl).addClass("bi-clipboard-check");
+      $(labelEl).text("COPIED");
+      $(labelEl).removeClass(normalClass);
+      $(labelEl).addClass(copiedClass);
+    }
+
+    // Resets the elements to the proper CSS classes (e.g. displays as if the copy has not happened)
+    var resetCopyToClipboard = function(iconEl, labelEl, normalClass, copiedClass) {
+      $(labelEl).text("COPY");
+      $(labelEl).removeClass(copiedClass);
+      $(labelEl).addClass(normalClass);
+      $(iconEl).addClass("bi-clipboard");
+      $(iconEl).removeClass("bi-clipboard-check");
+    }
+
+    // Sets icon and label to indicate that an error happened when copying a value to the clipboard
+    var errorCopyToClipboard = function(iconEl, errorMsg) {
+      $(iconEl).removeClass("bi-clipboard");
+      $(iconEl).addClass("bi-clipboard-minus")
+      console.log(errorMsg);
+    }
+
+    // Copies a value to the clipboard and notifies the user
+    // value - value to copy to the clipboard
+    // iconEl - selector for the HTML element with the clipboard icon
+    // labelEl - selector for the HTML element with the COPY label next to the icon
+    // normalClass - CSS to style the label with initially
+    // copiedClass - CSS to style the label with after a value has been copied to the clipboard
+    // iconEl and labelEl could be any jQuery valid selector (e.g. ".some-id" or a reference to an element)
+    var copyToClipboard = function(value, iconEl, labelEl, normalClass, copiedClass) {
+        // Copy value to the clipboard....
+        navigator.clipboard.writeText(value).then(function() {
+          // ...and notify the user
+          setCopiedToClipboard(iconEl, labelEl, normalClass, copiedClass);
+          setTimeout(function() {
+            resetCopyToClipboard(iconEl, labelEl, normalClass, copiedClass);
+          }, 20000);
+        }, function() {
+          errorCopyToClipboard(iconEl, "Copy to clipboard failed");
+        });
+        // Clear focus from the button.
+        document.activeElement.blur();
+    }
+
     // Issues HTTP POST to update the curator assigned to the work.
     $("#curator_select").on("change", function(event) {
       var newCuratorId = event.currentTarget.value;
@@ -276,6 +329,13 @@
       hidden: '#hidden_inputbox',
       source: userList,
       trigger: "@"
+    });
+
+    // Setup the DOI's COPY button to copy the DOI URL to the clipboard
+    $("#copy-doi").click(function(_x) {
+      var doi = this.dataset["url"];
+      copyToClipboard(doi, "#copy-doi-icon", "#copy-doi-label", "copy-doi-label-normal", "copy-doi-label-copied");
+      return false;
     });
   });
 </script>

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -250,7 +250,7 @@
 
 <script>
   $(function() {
-     // Issues HTTP POST to update the curator assigned to the work.
+    // Issues HTTP POST to update the curator assigned to the work.
     $("#curator_select").on("change", function(event) {
       var newCuratorId = event.currentTarget.value;
       var url = '<%= work_assign_curator_url(id: @work.id, uid: "uid-placeholder") %>';

--- a/spec/system/work_show_spec.rb
+++ b/spec/system/work_show_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "Creating and updating works", type: :system, js: true do
   let(:user) { work.created_by_user }
 
   before do
+    Capybara.default_max_wait_time = 10
     stub_s3
     page.driver.browser.manage.window.resize_to(2000, 2000)
   end
@@ -15,5 +16,13 @@ RSpec.describe "Creating and updating works", type: :system, js: true do
     visit work_path(work)
     expect(page).to have_content "IS_CITED_BY"
     expect(page).to have_content "https://www.biorxiv.org/content/10.1101/545517v1"
+  end
+
+  it "copies DOI to the clipboard" do
+    sign_in user
+    visit work_path(work)
+    expect(page).to have_content "COPY"
+    find("button#copy-doi").click
+    expect(page).to have_content "COPIED"
   end
 end

--- a/spec/system/work_show_spec.rb
+++ b/spec/system/work_show_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe "Creating and updating works", type: :system, js: true do
   let(:user) { work.created_by_user }
 
   before do
-    Capybara.default_max_wait_time = 10
     stub_s3
     page.driver.browser.manage.window.resize_to(2000, 2000)
   end
@@ -21,8 +20,19 @@ RSpec.describe "Creating and updating works", type: :system, js: true do
   it "copies DOI to the clipboard" do
     sign_in user
     visit work_path(work)
-    expect(page).to have_content "COPY"
-    find("button#copy-doi").click
-    expect(page).to have_content "COPIED"
+    expect(page.html.include?('<button id="copy-doi"')).to be true
+
+    # A test as follows would be preferrable
+    #
+    # ```
+    #   expect(page).to have_content "COPY"
+    #   click_on "COPY"
+    #   expect(page).to have_content "COPIED"
+    # ```
+    #
+    # but unfortunately this kind of test only works when we run RSpec like this:
+    #
+    #   RUN_IN_BROWSER=true bundle exec rspec spec/system/work_show_spec.rb
+    #
   end
 end


### PR DESCRIPTION
Added a button to the DOI display to copy the DOI URL to the clipboard (just like we do in PDC Discovery). 

This is slightly different than what was asked on the original ticket (#696) but I discussed it with @hhkitsune and we thought mimicking PDC Discovery was a good approach.

![DOI copy](https://user-images.githubusercontent.com/568286/207103412-9d3bd559-baa7-4ca4-b637-83b97ae1d106.png)

Closes #696