### PR TITLE
Refine the draft-DOI message

### DIFF
--- a/app/views/works/_required_form.html.erb
+++ b/app/views/works/_required_form.html.erb
@@ -1,17 +1,16 @@
-<% if @wizard_mode %>
-  <div>
-    <p class="doi-text">By initiating this new submission, we have reserved a draft DOI for your use. This unique
-      identifier will become searchable at the completion of this process.</p>
+<div class="field">  
+  <p class="doi-text">
+    By initiating this new submission, we have reserved a draft DOI for your use.
+    This DOI will not go live until the data review process is complete,
+    but you can provide this DOI to a publisher now.
+    This unique identifier will become searchable at the completion of this process.
+  </p>
+  <% if @wizard_mode %>
     <input id="doi" name="doi" value="<%= @work.resource.doi %>" readonly/>
-  </div>
-  <div>&nbsp;</div>
-<% else %>
-  <div class="field">
-    <p class="doi-text">By initiating this new submission, we have reserved a draft DOI for your use.<br/>
-      This unique identifier will become fully minted and searchable at the completion of this process.</p>
+  <% else %>
     <p>DOI: <%= @work.resource.doi %></p>
-  </div>
-<% end %>
+  <% end %>
+</div>
 
 <%= render(partial: 'works/required_title', locals: {allow_many: true}) %>
 


### PR DESCRIPTION
- Fix #697

Currently there are two slightly different messages depending on whether you're in the wizard or not:
```diff
... This unique identifier will become searchable at the completion of this process.
... This unique identifier will become fully minted and searchable at the completion of this process.
```

My assumption is that this was not intentional, and so to make the messaging consistent, I've moved the conditional inside, so it only wraps the DOI.