### PR TITLE
Apply a blue background to help button

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -138,9 +138,8 @@ input[readonly] {
 details {
   font-size: smaller;
 
-  &[open] summary::after {
-    background-color: #ddd;
-  }
+  // A different style could be applied when the component is open.
+  // &[open] summary::after { }
 
   summary {
     font-size: medium;
@@ -151,8 +150,10 @@ details {
       content: '?';
       font-weight: bold;
       padding: 0rem .25rem;
-      border: 1px solid black;
+      background-color: #0d6efd;
+      color: #fff;
       border-radius: .25rem;
+      border: 0;
     }
   }
 }


### PR DESCRIPTION
This matches the CSS on the sidebar buttons (with the exception of the padding around the text.)

It removes special styling for the button in the open state.

<img width="97" alt="Screen Shot 2022-12-12 at 5 29 32 PM" src="https://user-images.githubusercontent.com/730388/207172214-595cbf88-23b6-4587-b6f9-633b6e5e208e.png">


- Fix #710