### PR TITLE
Fixes issue with default value being lost for resource_type_general

### DIFF
--- a/app/services/form_to_resource_service.rb
+++ b/app/services/form_to_resource_service.rb
@@ -40,7 +40,7 @@ class FormToResourceService
         resource.version_number = params["version_number"] if params["version_number"].present?
         resource.collection_tags = params["collection_tags"].split(",").map(&:strip) if params["collection_tags"]
         resource.resource_type = params["resource_type"] if params["resource_type"]
-        resource.resource_type_general = params["resource_type_general"]&.to_sym
+        resource.resource_type_general = params["resource_type_general"]&.to_sym if params["resource_type_general"]
         resource
       end
 

--- a/spec/system/work_spec.rb
+++ b/spec/system/work_spec.rb
@@ -9,6 +9,21 @@ RSpec.describe "Creating and updating works", type: :system do
     stub_s3
   end
 
+  it "Defaults correct values for resource_type and resource_type_general", js: true do
+    sign_in user
+    visit user_path(user)
+    click_on "Submit New"
+    fill_in "title_main", with: "Supreme"
+    within("#creator_row_1") do
+      fill_in "given_name_1", with: "Sonia"
+      fill_in "family_name_1", with: "Sotomayor"
+    end
+    click_on "Create New"
+    work = Work.last
+    expect(work.resource.resource_type).to eq "Dataset"
+    expect(work.resource.resource_type_general).to eq :DATASET
+  end
+
   it "Prevents empty title", js: true do
     sign_in user
     visit user_path(user)


### PR DESCRIPTION
The code was defaulting the `resource_type_general` to `:DATASET` correctly but we were losing that value when coming through the New Submission process (which renders a form without this value). 

This PR makes sure we preserve the value already on `resource_type_general` when no new value comes in the form, we already were doing this for `resource_type`.

Closes #699 