### PR TITLE
Use moderator instead of curator

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -166,7 +166,7 @@ class User < ApplicationRecord
     display_name.presence || uid
   end
 
-  def curator?
+  def moderator?
     admin_collections.count > 0
   end
 

--- a/app/views/collections/edit.html.erb
+++ b/app/views/collections/edit.html.erb
@@ -58,7 +58,7 @@
     <span id="add-submitter-message"></span>
 </div>
 
-<h2 class="user-section-heading">Curators</h2>
+<h2 class="user-section-heading">Moderators</h2>
 <p>Users that are allowed to approve submissions to this collection</p>
 <ul id="curator-list">
 <% @collection.administrators.each do |user| %>
@@ -72,7 +72,7 @@
 
 <div>
     <input id="admin-uid-to-add" placeholder="netid"></input>
-    <%= link_to "Add Curator", "#", id: "btn-add-admin", class: "btn btn-secondary" %>
+    <%= link_to "Add Moderator", "#", id: "btn-add-admin", class: "btn btn-secondary" %>
     <span id="add-admin-message"></span>
 </div>
 

--- a/app/views/shared/_user_actions.html.erb
+++ b/app/views/shared/_user_actions.html.erb
@@ -5,7 +5,7 @@
   <div class="dropdown-menu" aria-labelledby="dropdownMenuButton" role="menu">
     <%= link_to "My Dashboard", user_path(current_user), class: "dropdown-item", role: "menuitem" %>
     <%= link_to "My Profile", edit_user_path(current_user), class: "dropdown-item", role: "menuitem" %>
-    <% if current_user.curator? %>
+    <% if current_user.moderator? %>
       <%= link_to "Create Dataset", new_work_path, class: "dropdown-item", role: "menuitem" %>
     <% end %>
     <%= link_to "Log Out", main_app.destroy_user_session_path, class: 'dropdown-item', role: "menuitem" %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -9,7 +9,7 @@
         </div>
       </fieldset>
 
-      <% if @user.curator? %>
+      <% if @user.moderator? %>
         <section class="card container">
           <h2>Collections</h2>
           <fieldset>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -6,8 +6,8 @@
   <%= @my_dashboard ? "Welcome " : "" %><%= @user.display_name_safe %>
   <% if @user.super_admin? %>
     <span class="badge rounded-pill bg-primary text-bg-secondary">Administrator</span>
-  <% elsif @user.curator? %>
-    <span class="badge rounded-pill bg-primary text-bg-secondary">Curator</span>
+  <% elsif @user.moderator? %>
+    <span class="badge rounded-pill bg-primary text-bg-secondary">Moderator</span>
   <% end %>
 </h2>
 
@@ -21,8 +21,8 @@
 
 <% if @user.super_admin? %>
   <!-- not sure we want to display the collections here, it's pointless -->
-<% elsif @user.curator? %>
-  <p>Curator for:
+<% elsif @user.moderator? %>
+  <p>Moderator for:
     <%= @user.admin_collections.map do |collection|
       link_to(collection.title, collection_path(collection))
     end.to_sentence.html_safe %></p>

--- a/spec/system/authz_admin_spec.rb
+++ b/spec/system/authz_admin_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "Authz for curators", type: :system, js: true do
         expect(new_submitter.can_admin?(Collection.research_data)).to eq false
         visit edit_collection_path(Collection.research_data)
         fill_in "admin-uid-to-add", with: new_submitter.uid
-        click_on "Add Curator"
+        click_on "Add Moderator"
         expect(page).to have_content new_submitter.uid
         expect(new_submitter.reload.can_admin?(Collection.research_data)).to eq true
       end
@@ -65,7 +65,7 @@ RSpec.describe "Authz for curators", type: :system, js: true do
         expect(research_data_moderator.can_admin?(Collection.plasma_laboratory)).to eq false
         visit collection_path(Collection.plasma_laboratory)
         expect(page).not_to have_content "Add Submitter"
-        expect(page).not_to have_content "Add Curator"
+        expect(page).not_to have_content "Add Moderator"
       end
 
       it "can NOT edit works" do

--- a/spec/system/authz_submitter_spec.rb
+++ b/spec/system/authz_submitter_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "Authz for submitters", type: :system, js: true do
       sign_in submitter1
       visit collection_path(submitter1.default_collection)
       expect(page).not_to have_content "Add Submitter"
-      expect(page).not_to have_content "Add Curator"
+      expect(page).not_to have_content "Add Moderator"
       visit edit_collection_path(submitter1.default_collection)
       expect(page).not_to have_content "Update Collection"
       expect(current_path).to eq "/collections"

--- a/spec/system/authz_super_admin_spec.rb
+++ b/spec/system/authz_super_admin_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "Authz for super admins", type: :system, js: true do
       sign_in super_admin
       visit edit_collection_path(collection)
       expect(page).to have_content "Add Submitter"
-      expect(page).to have_content "Add Curator"
+      expect(page).to have_content "Add Moderator"
       fill_in "collection_title", with: title3
       click_on "Update Collection"
       expect(current_path).to eq collection_path(collection)

--- a/spec/system/collection_edit_spec.rb
+++ b/spec/system/collection_edit_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "Editing collections" do
     sign_in collection_admin_user
     visit edit_collection_path(collection)
     fill_in "admin-uid-to-add", with: "admin123"
-    click_on "Add Curator"
+    click_on "Add Moderator"
     expect(page).to have_content "admin123"
   end
 


### PR DESCRIPTION
Changed the word curator to moderator in places where it represents a user's ability to moderate a collection and kept curator in places where it represents a user's ability to curate a particular work.

Closes #214 

# User Dashboard
![Screen Shot 2022-12-14 at 10 22 46 AM](https://user-images.githubusercontent.com/568286/207638602-6aea4165-b481-4ca7-8a0d-091ae4266666.png)

# Collection Edit
![Screen Shot 2022-12-14 at 10 25 41 AM](https://user-images.githubusercontent.com/568286/207638613-24a8bf45-352a-498a-a90e-f935ae8aaccc.png)
