### PR TITLE
Changing mailing to happen in one line so that it will send

### DIFF
--- a/app/models/work_activity_notification.rb
+++ b/app/models/work_activity_notification.rb
@@ -10,8 +10,13 @@ class WorkActivityNotification < ApplicationRecord
       if work.collection&.messages_enabled_for?(user: user)
 
         mailer = NotificationMailer.with(user: user, work_activity: work_activity)
-        message = mailer.build_message
-        message.deliver_later
+
+        #####
+        # Do not separate build_message and deliver_later on separate lines
+        #  You will get an error like `You've accessed the message before...` in production/staging
+        #  I spent a long time trying to replicate the error in a test, but could not
+        mailer.build_message.deliver_later
+        #####
       end
     end
   end


### PR DESCRIPTION
For some reason if you set the message to a local variable you get an error like `You've accessed the message before...` 
Changing it to a one liner allows the messages to send 

refs #687