### PR TITLE
Create a partial that wraps data spans

### DIFF
--- a/app/assets/javascripts/edit_work_utils.js
+++ b/app/assets/javascripts/edit_work_utils.js
@@ -215,7 +215,7 @@ $(() => {
       el = $(creatorSpans[i]);
       creator = {
         num: el.data('num'),
-        orcid: el.data('orcid'),
+        identifier: el.data('identifier'),
         givenName: el.data('given-name'),
         familyName: el.data('family-name'),
         sequence: el.data('sequence'),
@@ -397,7 +397,7 @@ $(() => {
       const creator = creators[i];
       addCreatorHtml(
         creator.num,
-        creator.orcid,
+        creator.identifier,
         creator.givenName,
         creator.familyName,
         creator.sequence,
@@ -432,10 +432,10 @@ $(() => {
       const contributor = contributors[i];
       addContributorHtml(
         contributor.num,
-        contributor.orcid,
+        contributor.identifer,
         contributor.givenName,
         contributor.familyName,
-        contributor.role,
+        contributor.type,
         contributor.sequence,
       );
     }

--- a/app/views/works/_contributors_table.html.erb
+++ b/app/views/works/_contributors_table.html.erb
@@ -22,16 +22,7 @@
   </tbody>
 </table>
 
-<% @work.resource.contributors.each_with_index do |contributor, i| %>
-  <span class="hidden contributor-data"
-    data-num="<%= i + 1 %>"
-    data-orcid="<%= contributor.orcid %>"
-    data-given-name="<%= contributor.given_name %>"
-    data-family-name="<%= contributor.family_name %>"
-    data-role="<%= contributor.type %>"
-    data-sequence="<%= contributor.sequence || 0 %>">
-  </span>
-<% end %>
+<%= render 'hidden_data', records: @work.resource.contributors, name: 'contributor' %>
 
 <!-- Let the user add new contributors -->
 <div>

--- a/app/views/works/_hidden_data.html.erb
+++ b/app/views/works/_hidden_data.html.erb
@@ -1,0 +1,8 @@
+<% records.each_with_index do |record, i| %>
+  <span class="hidden <%= name %>-data"
+    data-num="<%= i + 1 %>"
+    <% record.instance_values.each_pair do |key, value| %>
+      data-<%= key.gsub("_","-") %>="<%= value %>"
+    <% end %>
+  ></span>
+<% end %>

--- a/app/views/works/_related_objects_table.html.erb
+++ b/app/views/works/_related_objects_table.html.erb
@@ -16,14 +16,7 @@
 </div>
 
 <% if @work %>
-  <% @work.resource.related_objects.each_with_index do |related_object, i| %>
-  <span class="hidden related-object-data"
-    data-num="<%= i + 1 %>"
-    data-related-identifier="<%= related_object.related_identifier %>"
-    data-related-identifier-type="<%= related_object.related_identifier_type %>"
-    data-relation-type="<%= related_object.relation_type %>"
-    ></span>
-  <% end %>
+  <%= render 'hidden_data', records: @work.resource.related_objects, name: 'related-object' %>
 <% end %>
 
 <!-- Let the user add new related objects -->

--- a/app/views/works/_required_creators_table.html.erb
+++ b/app/views/works/_required_creators_table.html.erb
@@ -25,8 +25,9 @@
   </tbody>
 </table>
 
-
-<%= render 'hidden_data', records: @work.resource.creators, name: 'creator' %>
+<% if @work %>
+  <%= render 'hidden_data', records: @work.resource.creators, name: 'creator' %>
+<% end %>
 
 <!-- Let the user add new creators -->
 <div>

--- a/app/views/works/_required_creators_table.html.erb
+++ b/app/views/works/_required_creators_table.html.erb
@@ -25,17 +25,8 @@
   </tbody>
 </table>
 
-<% if @work %>
-  <% @work.resource.creators.each_with_index do |creator, i| %>
-  <span class="hidden creator-data"
-    data-num="<%= i + 1 %>"
-    data-orcid="<%= creator.orcid %>"
-    data-given-name="<%= creator.given_name %>"
-    data-family-name="<%= creator.family_name %>"
-    data-sequence="<%= creator.sequence %>"
-    ></span>
-  <% end %>
-<% end %>
+
+<%= render 'hidden_data', records: @work.resource.creators, name: 'creator' %>
 
 <!-- Let the user add new creators -->
 <div>


### PR DESCRIPTION
Before tackling the multi-funders, I would like to clean up the existing code. Copy-pasting the existing pattern would be digging myself into a hole. One pain point is where field names change between contexts: It will be less confusing to be consistent. Down the road I think it would be simpler just to serialize the data to JSON, and read that as the input, but I don't want to change too many things at once.

Spans for data are also used in `app/views/collections/edit.html.erb`, but with more special case logic for the values of some fields, so I don't want to touch those right now.

"draft" until I can get four errors fixed:
```
rspec ./spec/system/curator_controlled_metadata_spec.rb:62 # Curator Controlled metadata tab As a super admin allows editing of curator controlled fields
rspec ./spec/system/curator_controlled_metadata_spec.rb:44 # Curator Controlled metadata tab As a collection admin allows editing of curator controlled fields
rspec ./spec/system/curator_controlled_metadata_spec.rb:19 # Curator Controlled metadata tab As a princeton submitter does not allow editing of curator controlled fields
rspec ./spec/system/work_spec.rb:66 # Creating and updating works Handles Rights field
```