### PR TITLE
In README install instructions, change "node" to "nodejs"

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Cataloging application for PDC content and more
     1. [asdf](https://asdf-vm.com/guide/getting-started.html#_2-download-asdf)
 1. Install asdf dependencies
     1. `asdf plugin add ruby`
-    1. `asdf plugin add node`
+    1. `asdf plugin add nodejs`
     1. `asdf plugin add yarn`
     1. `asdf install`
     1. ... but because asdf is not a dependency manager, if there are errors, you may need to install other dependencies. For example: `brew install gpg`


### PR DESCRIPTION
```
% asdf plugin add node
plugin node not found in repository
% asdf install
nodejs plugin is not installed
% asdf plugin add nodejs
```

Not sure whether it was a typo originally, or if something has changed upstream.