### PR TITLE
Use a multi-line JSON string in spec for readability

### DIFF
--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -894,21 +894,53 @@ RSpec.describe Work, type: :model do
 
   describe "resource=" do
     let(:resource_json) do
-      '{"titles":[{"title":"Planet of the Blue Rain","title_type":null},' \
-        '{"title":"the subtitle","title_type":"Subtitle"}],' \
-        '"description":"a new description",' \
-        '"collection_tags":["new-colletion-tag1","new-collection-tag2"],' \
-        '"creators":[{"value":"Morrison, Toni","name_type":"Personal","given_name":"Toni","family_name":"Morrison",' \
-        '"identifier":null,"affiliations":[],"sequence":1}],' \
-        '"resource_type":"digitized video",' \
-        '"resource_type_general":"AUDIOVISUAL",' \
-        '"publisher":"Princeton University","publication_year":2022,"ark":"new-ark","doi":"new-doi",' \
-        '"rights":{"identifier":"CC BY","uri":"https://creativecommons.org/licenses/by/4.0/",' \
-        '"name":"Creative Commons Attribution 4.0 International"},' \
-        '"version_number":"1","related_objects":[],"keywords":[],"contributors":[],' \
-        '"funder_name":"National Science Foundation",' \
-        '"award_number":"nsf-123",' \
-        '"award_uri":"http://nsg.gov/award/123"}'
+      '
+{
+  "titles": [
+    {
+      "title": "Planet of the Blue Rain",
+      "title_type": null
+    },
+    {
+      "title": "the subtitle",
+      "title_type": "Subtitle"
+    }
+  ],
+  "description": "a new description",
+  "collection_tags": [
+    "new-colletion-tag1",
+    "new-collection-tag2"
+  ],
+  "creators": [
+    {
+      "value": "Morrison, Toni",
+      "name_type": "Personal",
+      "given_name": "Toni",
+      "family_name": "Morrison",
+      "identifier": null,
+      "affiliations": [],
+      "sequence": 1
+    }
+  ],
+  "resource_type": "digitized video",
+  "resource_type_general": "AUDIOVISUAL",
+  "publisher": "Princeton University",
+  "publication_year": 2022,
+  "ark": "new-ark",
+  "doi": "new-doi",
+  "rights": {
+    "identifier": "CC BY",
+    "uri": "https://creativecommons.org/licenses/by/4.0/",
+    "name": "Creative Commons Attribution 4.0 International"
+  },
+  "version_number": "1",
+  "related_objects": [],
+  "keywords": [],
+  "contributors": [],
+  "funder_name": "National Science Foundation",
+  "award_number": "nsf-123",
+  "award_uri": "http://nsg.gov/award/123"
+}'
     end
     it "can change the entire resource" do
       work.resource = PDCMetadata::Resource.new_from_json(resource_json)

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -894,53 +894,52 @@ RSpec.describe Work, type: :model do
 
   describe "resource=" do
     let(:resource_json) do
-      '
-{
-  "titles": [
-    {
-      "title": "Planet of the Blue Rain",
-      "title_type": null
-    },
-    {
-      "title": "the subtitle",
-      "title_type": "Subtitle"
-    }
-  ],
-  "description": "a new description",
-  "collection_tags": [
-    "new-colletion-tag1",
-    "new-collection-tag2"
-  ],
-  "creators": [
-    {
-      "value": "Morrison, Toni",
-      "name_type": "Personal",
-      "given_name": "Toni",
-      "family_name": "Morrison",
-      "identifier": null,
-      "affiliations": [],
-      "sequence": 1
-    }
-  ],
-  "resource_type": "digitized video",
-  "resource_type_general": "AUDIOVISUAL",
-  "publisher": "Princeton University",
-  "publication_year": 2022,
-  "ark": "new-ark",
-  "doi": "new-doi",
-  "rights": {
-    "identifier": "CC BY",
-    "uri": "https://creativecommons.org/licenses/by/4.0/",
-    "name": "Creative Commons Attribution 4.0 International"
-  },
-  "version_number": "1",
-  "related_objects": [],
-  "keywords": [],
-  "contributors": [],
-  "funder_name": "National Science Foundation",
-  "award_number": "nsf-123",
-  "award_uri": "http://nsg.gov/award/123"
-}'
+      '{
+        "titles": [
+          {
+            "title": "Planet of the Blue Rain",
+            "title_type": null
+          },
+          {
+            "title": "the subtitle",
+            "title_type": "Subtitle"
+          }
+        ],
+        "description": "a new description",
+        "collection_tags": [
+          "new-colletion-tag1",
+          "new-collection-tag2"
+        ],
+        "creators": [
+          {
+            "value": "Morrison, Toni",
+            "name_type": "Personal",
+            "given_name": "Toni",
+            "family_name": "Morrison",
+            "identifier": null,
+            "affiliations": [],
+            "sequence": 1
+          }
+        ],
+        "resource_type": "digitized video",
+        "resource_type_general": "AUDIOVISUAL",
+        "publisher": "Princeton University",
+        "publication_year": 2022,
+        "ark": "new-ark",
+        "doi": "new-doi",
+        "rights": {
+          "identifier": "CC BY",
+          "uri": "https://creativecommons.org/licenses/by/4.0/",
+          "name": "Creative Commons Attribution 4.0 International"
+        },
+        "version_number": "1",
+        "related_objects": [],
+        "keywords": [],
+        "contributors": [],
+        "funder_name": "National Science Foundation",
+        "award_number": "nsf-123",
+        "award_uri": "http://nsg.gov/award/123"
+      }'
     end
     it "can change the entire resource" do
       work.resource = PDCMetadata::Resource.new_from_json(resource_json)

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -944,7 +944,7 @@ RSpec.describe Work, type: :model do
     end
     it "can change the entire resource" do
       work.resource = PDCMetadata::Resource.new_from_json(resource_json)
-      expect(work.resource.to_json).to eq(resource_json)
+      expect(work.resource.to_json).to eq(JSON.parse(resource_json).to_json)
     end
   end
 


### PR DESCRIPTION
Needed to touch this in the process of making funders multi-valued, and thought it could be more readable. This PR only changes the formatting. Surprised that there were no rubocop warnings locally.