### PR TITLE
Reorder and rename resource methods for readability

### DIFF
--- a/app/models/pdc_metadata/resource.rb
+++ b/app/models/pdc_metadata/resource.rb
@@ -63,16 +63,16 @@ module PDCMetadata
 
         hash = JSON.parse(json_string)
 
-        resource = curator_controlled_metadata(hash, resource)
-
         resource.description = hash["description"]
+        resource.publisher = hash["publisher"]
+        resource.publication_year = hash["publication_year"]
+        resource.rights = rights(hash["rights"])
+
+        resource = curator_controlled_metadata(hash, resource)
         titles_from_json(resource, hash["titles"])
         creators_from_json(resource, hash["creators"])
         contributors_from_json(resource, hash["contributors"])
         related_objects_from_json(resource, hash["related_objects"] || [])
-        resource.publisher = hash["publisher"]
-        resource.publication_year = hash["publication_year"]
-        resource.rights = rights(hash["rights"])
         resource = additional_metadata(hash, resource)
 
         resource

--- a/app/models/pdc_metadata/resource.rb
+++ b/app/models/pdc_metadata/resource.rb
@@ -69,11 +69,11 @@ module PDCMetadata
         resource.rights = rights(hash["rights"])
 
         set_curator_controlled_metadata(resource, hash)
-        titles_from_json(resource, hash["titles"])
-        creators_from_json(resource, hash["creators"])
-        contributors_from_json(resource, hash["contributors"])
-        related_objects_from_json(resource, hash["related_objects"] || [])
-        resource = additional_metadata(hash, resource)
+        set_additional_metadata(resource, hash)
+        set_titles(resource, hash)
+        set_creators(resource, hash)
+        set_contributors(resource, hash)
+        set_related_objects(resource, hash)
 
         resource
       end
@@ -90,42 +90,37 @@ module PDCMetadata
 
       private
 
-        def set_curator_controlled_metadata(resource, hash)
-          resource.doi = hash["doi"]
-          resource.ark = hash["ark"]
-          resource.version_number = hash["version_number"]
-          resource.collection_tags = collection_tags(hash["collection_tags"])
-          resource.resource_type = hash["resource_type"]
-          resource.resource_type_general = hash["resource_type_general"]&.to_sym
-          resource
-        end
-
-        def additional_metadata(hash, resource)
-          resource.keywords = hash["keywords"] || []
-          resource.funder_name = hash["funder_name"]
-          resource.award_number = hash["award_number"]
-          resource.award_uri = hash["award_uri"]
-          resource
-        end
-
         def rights(form_rights)
           PDCMetadata::Rights.find(form_rights["identifier"]) if form_rights
         end
 
-        def collection_tags(form_tags)
-          form_tags || []
+        def set_curator_controlled_metadata(resource, hash)
+          resource.doi = hash["doi"]
+          resource.ark = hash["ark"]
+          resource.version_number = hash["version_number"]
+          resource.collection_tags = hash["collection_tags"] || []
+          resource.resource_type = hash["resource_type"]
+          resource.resource_type_general = hash["resource_type_general"]&.to_sym
         end
 
-        def titles_from_json(resource, titles)
-          return if titles.blank?
+        def set_additional_metadata(resource, hash)
+          resource.keywords = hash["keywords"] || []
+          resource.funder_name = hash["funder_name"]
+          resource.award_number = hash["award_number"]
+          resource.award_uri = hash["award_uri"]
+        end
 
-          titles.each do |title|
+        def set_titles(resource, hash)
+          titles = hash["titles"] || []
+
+          title.each do |title|
             resource.titles << PDCMetadata::Title.new(title: title["title"], title_type: title["title_type"])
           end
         end
 
-        def related_objects_from_json(resource, related_objects)
-          return if related_objects.blank?
+        def set_related_objects(resource, hash)
+          related_objects = hash["related_objects"] || []
+
           related_objects.each do |related_object|
             next if related_object["related_identifier"].blank? && related_object["related_identifier_type"].blank?
             resource.related_objects << PDCMetadata::RelatedObject.new(
@@ -136,8 +131,8 @@ module PDCMetadata
           end
         end
 
-        def creators_from_json(resource, creators)
-          return if creators.blank?
+        def set_creators(resource, hash)
+          creators = hash["creators"] || []
 
           creators.each do |creator|
             resource.creators << Creator.from_hash(creator)
@@ -145,8 +140,8 @@ module PDCMetadata
           resource.creators.sort_by!(&:sequence)
         end
 
-        def contributors_from_json(resource, contributors)
-          return if contributors.blank?
+        def set_contributors(resource, contributors)
+          contributors = hash["contributors"] || []
 
           contributors.each do |contributor|
             resource.contributors << Creator.contributor_from_hash(contributor)

--- a/app/models/pdc_metadata/resource.rb
+++ b/app/models/pdc_metadata/resource.rb
@@ -63,11 +63,7 @@ module PDCMetadata
 
         hash = JSON.parse(json_string)
 
-        resource.description = hash["description"]
-        resource.publisher = hash["publisher"]
-        resource.publication_year = hash["publication_year"]
-        resource.rights = rights(hash["rights"])
-
+        set_basics(resource, hash)
         set_curator_controlled_metadata(resource, hash)
         set_additional_metadata(resource, hash)
         set_titles(resource, hash)
@@ -92,6 +88,13 @@ module PDCMetadata
 
         def rights(form_rights)
           PDCMetadata::Rights.find(form_rights["identifier"]) if form_rights
+        end
+
+        def set_basics(resource, hash)
+          resource.description = hash["description"]
+          resource.publisher = hash["publisher"]
+          resource.publication_year = hash["publication_year"]
+          resource.rights = rights(hash["rights"])
         end
 
         def set_curator_controlled_metadata(resource, hash)

--- a/app/models/pdc_metadata/resource.rb
+++ b/app/models/pdc_metadata/resource.rb
@@ -68,7 +68,7 @@ module PDCMetadata
         resource.publication_year = hash["publication_year"]
         resource.rights = rights(hash["rights"])
 
-        resource = curator_controlled_metadata(hash, resource)
+        set_curator_controlled_metadata(resource, hash)
         titles_from_json(resource, hash["titles"])
         creators_from_json(resource, hash["creators"])
         contributors_from_json(resource, hash["contributors"])
@@ -90,7 +90,7 @@ module PDCMetadata
 
       private
 
-        def curator_controlled_metadata(hash, resource)
+        def set_curator_controlled_metadata(resource, hash)
           resource.doi = hash["doi"]
           resource.ark = hash["ark"]
           resource.version_number = hash["version_number"]

--- a/app/models/pdc_metadata/resource.rb
+++ b/app/models/pdc_metadata/resource.rb
@@ -113,7 +113,7 @@ module PDCMetadata
         def set_titles(resource, hash)
           titles = hash["titles"] || []
 
-          title.each do |title|
+          titles.each do |title|
             resource.titles << PDCMetadata::Title.new(title: title["title"], title_type: title["title_type"])
           end
         end
@@ -140,7 +140,7 @@ module PDCMetadata
           resource.creators.sort_by!(&:sequence)
         end
 
-        def set_contributors(resource, contributors)
+        def set_contributors(resource, hash)
           contributors = hash["contributors"] || []
 
           contributors.each do |contributor|


### PR DESCRIPTION
- Set all the simple fields first
- For the complex cases, establish a consistent parameter order, and make the method names verb-y
- Establish consistent behavior: all the methods modify the resource in place

No change in behavior.