### PR TITLE
Cleanup form_to_resource_service

### DIFF
--- a/app/services/form_to_resource_service.rb
+++ b/app/services/form_to_resource_service.rb
@@ -66,7 +66,7 @@ class FormToResourceService
 
       def new_title(title, title_type)
         return if title.blank?
-        PDCMetadata::Title.new(title, title_type)
+        PDCMetadata::Title.new(title: title, title_type: title_type)
       end
 
       # Related Objects:

--- a/app/services/form_to_resource_service.rb
+++ b/app/services/form_to_resource_service.rb
@@ -78,18 +78,17 @@ class FormToResourceService
         PDCMetadata::Creator.new_person(given_name, family_name, orcid, sequence)
       end
 
+      ## TODO: Do the right thing with blank form entries
       def process_related_objects(params, resource)
-        resource.related_objects = (1..params["related_object_count"].to_i).filter_map do |i|
-          related_identifier = params["related_identifier_#{i}"]
-          related_identifier_type = params["related_identifier_type_#{i}"]
-          relation_type = params["relation_type_#{i}"]
-          new_related_object(related_identifier, related_identifier_type, relation_type)
+        (1..params["related_object_count"].to_i).each do |i|
+          next if params["related_identifier_#{i}"].blank? && params["related_identifier_type_#{i}"].blank? # do not store blank related identifiers
+          related_object = PDCMetadata::RelatedObject.new(
+                            related_identifier: params["related_identifier_#{i}"],
+                            related_identifier_type: params["related_identifier_type_#{i}"],
+                            relation_type: params["relation_type_#{i}"]
+                          )
+          resource.related_objects << related_object
         end
-      end
-
-      def new_related_object(related_identifier, related_identifier_type, relation_type)
-        return if related_identifier.blank? && related_identifier_type.blank? && relation_type.blank?
-        PDCMetadata::RelatedObject.new(related_identifier, related_identifier_type, relation_type)
       end
 
       def process_contributors(params, resource)

--- a/app/services/form_to_resource_service.rb
+++ b/app/services/form_to_resource_service.rb
@@ -64,10 +64,18 @@ class FormToResourceService
       end
 
       def process_creators(params, resource)
-        (1..params["creator_count"].to_i).each do |i|
-          creator = new_creator(params["given_name_#{i}"], params["family_name_#{i}"], params["orcid_#{i}"], params["sequence_#{i}"])
-          resource.creators << creator unless creator.nil?
+        resource.creators = (1..params["creator_count"].to_i).filter_map do |i|
+          given_name = params["given_name_#{i}"]
+          family_name = params["family_name_#{i}"]
+          orcid = params["orcid_#{i}"]
+          sequence = params["sequence_#{i}"]
+          new_creator(given_name, family_name, orcid, sequence)
         end
+      end
+
+      def new_creator(given_name, family_name, orcid, sequence)
+        return if family_name.blank? && given_name.blank? && orcid.blank?
+        PDCMetadata::Creator.new_person(given_name, family_name, orcid, sequence)
       end
 
       ## TODO: Do the right thing with blank form entries
@@ -84,20 +92,14 @@ class FormToResourceService
       end
 
       def process_contributors(params, resource)
-        (1..params["contributor_count"].to_i).each do |i|
+        resource.contributors = (1..params["contributor_count"].to_i).filter_map do |i|
           given_name = params["contributor_given_name_#{i}"]
           family_name = params["contributor_family_name_#{i}"]
           orcid = params["contributor_orcid_#{i}"]
           type = params["contributor_role_#{i}"]
           sequence = params["contributor_sequence_#{i}"]
-          contributor = new_contributor(given_name, family_name, orcid, type, sequence)
-          resource.contributors << contributor unless contributor.nil?
+          new_contributor(given_name, family_name, orcid, type, sequence)
         end
-      end
-
-      def new_creator(given_name, family_name, orcid, sequence)
-        return if family_name.blank? && given_name.blank? && orcid.blank?
-        PDCMetadata::Creator.new_person(given_name, family_name, orcid, sequence)
       end
 
       def new_contributor(given_name, family_name, orcid, type, sequence)

--- a/app/services/form_to_resource_service.rb
+++ b/app/services/form_to_resource_service.rb
@@ -30,7 +30,7 @@ class FormToResourceService
 
     private
 
-      def process_curator_controlled(params)
+      def process_curator_controlled(params, resource)
         resource.doi = params["doi"] if params["doi"].present?
         resource.ark = params["ark"] if params["ark"].present?
         resource.version_number = params["version_number"] if params["version_number"].present?

--- a/app/services/form_to_resource_service.rb
+++ b/app/services/form_to_resource_service.rb
@@ -52,17 +52,21 @@ class FormToResourceService
 
       def process_titles(params, resource)
         resource.titles << PDCMetadata::Title.new(title: params["title_main"])
-        (1..params["existing_title_count"].to_i).each do |i|
-          if params["title_#{i}"].present?
-            resource.titles << PDCMetadata::Title.new(title: params["title_#{i}"], title_type: params["title_type_#{i}"])
-          end
-        end
+        resource.titles.concat((1..params["existing_title_count"].to_i).filter_map do |i|
+          title = params["title_#{i}"]
+          title_type = params["title_type_#{i}"]
+          new_title(title, title_type)
+        end)
+        resource.titles.concat((1..params["new_title_count"].to_i).filter_map do |i|
+          title = params["new_title_#{i}"]
+          title_type = params["new_title_type_#{i}"]
+          new_title(title, title_type)
+        end)
+      end
 
-        (1..params["new_title_count"].to_i).each do |i|
-          if params["new_title_#{i}"].present?
-            resource.titles << PDCMetadata::Title.new(title: params["new_title_#{i}"], title_type: params["new_title_type_#{i}"])
-          end
-        end
+      def new_title(title, title_type)
+        return if title.blank?
+        PDCMetadata::Title.new(title, title_type)
       end
 
       # Related Objects:

--- a/app/services/form_to_resource_service.rb
+++ b/app/services/form_to_resource_service.rb
@@ -78,17 +78,18 @@ class FormToResourceService
         PDCMetadata::Creator.new_person(given_name, family_name, orcid, sequence)
       end
 
-      ## TODO: Do the right thing with blank form entries
       def process_related_objects(params, resource)
-        (1..params["related_object_count"].to_i).each do |i|
-          next if params["related_identifier_#{i}"].blank? && params["related_identifier_type_#{i}"].blank? # do not store blank related identifiers
-          related_object = PDCMetadata::RelatedObject.new(
-                            related_identifier: params["related_identifier_#{i}"],
-                            related_identifier_type: params["related_identifier_type_#{i}"],
-                            relation_type: params["relation_type_#{i}"]
-                          )
-          resource.related_objects << related_object
+        resource.related_objects = (1..params["related_object_count"].to_i).filter_map do |i|
+          related_identifier = params["related_identifier_#{i}"]
+          related_identifier_type = params["related_identifier_type_#{i}"]
+          relation_type = params["relation_type_#{i}"]
+          new_related_object(related_identifier, related_identifier_type, relation_type)
         end
+      end
+
+      def new_related_object(related_identifier, related_identifier_type, relation_type)
+        return if related_identifier.blank? && related_identifier_type.blank? && relation_type.blank?
+        PDCMetadata::RelatedObject.new(related_identifier, related_identifier_type, relation_type)
       end
 
       def process_contributors(params, resource)

--- a/app/services/form_to_resource_service.rb
+++ b/app/services/form_to_resource_service.rb
@@ -37,7 +37,6 @@ class FormToResourceService
         resource.collection_tags = params["collection_tags"].split(",").map(&:strip) if params["collection_tags"]
         resource.resource_type = params["resource_type"] if params["resource_type"]
         resource.resource_type_general = params["resource_type_general"]&.to_sym if params["resource_type_general"]
-        resource
       end
 
       def reset_resource_to_work(work)

--- a/app/services/form_to_resource_service.rb
+++ b/app/services/form_to_resource_service.rb
@@ -68,15 +68,17 @@ class FormToResourceService
       # Related Objects:
 
       def process_related_objects(params, resource)
-        (1..params["related_object_count"].to_i).each do |i|
-          next if params["related_identifier_#{i}"].blank? && params["related_identifier_type_#{i}"].blank? # do not store blank related identifiers
-          related_object = PDCMetadata::RelatedObject.new(
-                            related_identifier: params["related_identifier_#{i}"],
-                            related_identifier_type: params["related_identifier_type_#{i}"],
-                            relation_type: params["relation_type_#{i}"]
-                          )
-          resource.related_objects << related_object
+        resource.related_objects = (1..params["related_object_count"].to_i).filter_map do |i|
+          related_identifier = params["related_identifier_#{i}"]
+          related_identifier_type = params["related_identifier_type_#{i}"]
+          relation_type = params["relation_type_#{i}"]
+          new_related_object(related_identifier, related_identifier_type, relation_type)
         end
+      end
+
+      def new_related_object(related_identifier, related_identifier_type, relation_type)
+        return if related_identifier.blank? && related_identifier_type.blank? && relation_type.blank?
+        PDCMetadata::RelatedObject.new(related_identifier: related_identifier, related_identifier_type: related_identifier_type, relation_type: relation_type)
       end
 
       # Creators:


### PR DESCRIPTION
- At the top level, in `convert`, group all the simple field setters, and group all the calls to `process` methods, and reorder the calls and definitions to be consistent.
- If `resource` is modified in place, we don't need to return and reassign it: Make the methods simple and consistent.
- Create consistent paired `process_fields`/`new_field` methods.
- Use `filter_map` to drop the empty rows.

(I'll be adding to this file for #759, and I wanted to establish a pattern I can follow.)