### PR TITLE
Use an absolute rather than relative module path

### DIFF
--- a/app/lib/diff.rb
+++ b/app/lib/diff.rb
@@ -6,7 +6,7 @@ class SimpleDiff
   def initialize(old_value, new_value)
     old_value ||= ""
     new_value ||= ""
-    @changes = Diff::LCS.sdiff(old_value, new_value).chunk(&:action).map do |action, changes|
+    @changes = ::Diff::LCS.sdiff(old_value, new_value).chunk(&:action).map do |action, changes|
       {
         action: action,
         old: changes.map(&:old_element).join,


### PR DESCRIPTION
Add leading `::` and see if it helps with `uninitialized constant SimpleDiff::Diff`: Not sure why we sporadically hit that error, but when we do it's seeing `Diff` as something under `SimpleDiff` rather than as top level. This should fix that.