### PR TITLE
Store metadata as json, not a string blob in a json field

### DIFF
--- a/app/models/pdc_metadata/resource.rb
+++ b/app/models/pdc_metadata/resource.rb
@@ -57,11 +57,11 @@ module PDCMetadata
 
     class << self
       # Creates a PDCMetadata::Resource from a JSON string
-      def new_from_json(json_string)
+      def new_from_json(json_data)
         resource = PDCMetadata::Resource.new
-        return resource if json_string.blank?
+        return resource if json_data.blank?
 
-        hash = JSON.parse(json_string)
+        hash = json_data
 
         set_basics(resource, hash)
         set_curator_controlled_metadata(resource, hash)

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -166,7 +166,7 @@ class Work < ApplicationRecord
 
   before_save do |work|
     # Ensure that the metadata JSON is persisted properly
-    work.metadata = work.resource.to_json
+    work.metadata = JSON.parse(work.resource.to_json)
     work.save_pre_curation_uploads
   end
 
@@ -175,6 +175,12 @@ class Work < ApplicationRecord
       work.attach_s3_resources if !work.pre_curation_uploads.empty? && work.pre_curation_uploads.length > work.post_curation_uploads.length
       work.reload
     end
+  end
+
+  # Deal with Historic works where the metadata was stored as a String
+  #   New metadata records should be stored as JSON not a string blob in a JSON field
+  after_initialize do |work|
+    work.metadata = JSON.parse(work.metadata) if work.metadata.is_a? String
   end
 
   validate do |work|
@@ -291,7 +297,7 @@ class Work < ApplicationRecord
 
   def resource=(resource)
     @resource = resource
-    self.metadata = resource.to_json
+    self.metadata = JSON.parse(resource.to_json)
   end
 
   def resource

--- a/lib/tasks/works.rake
+++ b/lib/tasks/works.rake
@@ -58,4 +58,9 @@ namespace :works do
       work.destroy
     end
   end
+
+  desc "Convert metadata to JSON"
+  task convert_metadata_to_JSON: :environment do
+    Work.all.each(&:save!) # each metadata record will be updated to JSON when we load it
+  end
 end

--- a/spec/factories/work.rb
+++ b/spec/factories/work.rb
@@ -37,19 +37,22 @@ FactoryBot.define do
     factory :shakespeare_and_company_work do
       collection { Collection.research_data }
       resource do
-        PDCMetadata::Resource.new_from_json({
-          "doi": "10.34770/pe9w-x904",
-          "ark": "ark:/88435/dsp01zc77st047",
-          "identifier_type": "DOI",
-          "titles": [{ "title": "Shakespeare and Company Project Dataset: Lending Library Members, Books, Events" }],
-          "description": "All data is related to the Shakespeare and Company bookshop and lending library opened and operated by Sylvia Beach in Paris, 1919–1962.",
-          "creators": [
-            { "value": "Kotin, Joshua", "name_type": "Personal", "given_name": "Joshua", "family_name": "Kotin", "affiliations": [], "sequence": "1" }
-          ],
-          "resource_type": "Dataset", "publisher": "Princeton University", "publication_year": "2020",
-          "version_number": "1",
-          "rights": { "identifier": "CC BY" }
-        }.to_json)
+        PDCMetadata::Resource.new_from_json(
+          {
+            "doi" => "10.34770/pe9w-x904",
+            "ark" => "ark:/88435/dsp01zc77st047",
+            "identifier_type" => "DOI",
+            "titles" => [{ "title" => "Shakespeare and Company Project Dataset: Lending Library Members, Books, Events" }],
+            "description" =>
+                                                "All data is related to the Shakespeare and Company bookshop and lending library opened and operated by Sylvia Beach in Paris, 1919–1962.",
+            "creators" => [
+              { "value" => "Kotin, Joshua", "name_type" => "Personal", "given_name" => "Joshua", "family_name" => "Kotin", "affiliations" => [], "sequence" => "1" }
+            ],
+            "resource_type" => "Dataset", "publisher" => "Princeton University", "publication_year" => "2020",
+            "version_number" => "1",
+            "rights" => { "identifier" => "CC BY" }
+          }
+        )
       end
       created_by_user_id { FactoryBot.create(:princeton_submitter).id }
     end
@@ -58,18 +61,18 @@ FactoryBot.define do
       collection { Collection.plasma_laboratory }
       resource do
         PDCMetadata::Resource.new_from_json({
-          "doi": "10.34770/not_yet_assigned",
-          "ark": "ark:/88435/dsp015d86p342b",
-          "identifier_type": "DOI",
-          "titles": [{ "title": "Electron Temperature Gradient Driven Transport Model for Tokamak Plasmas" }],
-          "description": "A new model for electron temperature gradient (ETG) modes is developed as a component of the Multi-Mode anomalous transport module.",
-          "creators": [
-            { "value": "Rafiq, Tariq", "name_type": "Personal", "given_name": "Tariq", "family_name": "Rafiq", "affiliations": [], "sequence": "1" }
-          ],
-          "resource_type": "Dataset", "publisher": "Princeton University", "publication_year": "2022",
-          "version_number": "1",
-          "rights": { "identifier": "CC BY" }
-        }.to_json)
+                                              "doi" => "10.34770/not_yet_assigned",
+                                              "ark" => "ark:/88435/dsp015d86p342b",
+                                              "identifier_type" => "DOI",
+                                              "titles" => [{ "title" => "Electron Temperature Gradient Driven Transport Model for Tokamak Plasmas" }],
+                                              "description" => "A new model for electron temperature gradient (ETG) modes is developed as a component of the Multi-Mode anomalous transport module.",
+                                              "creators" => [
+                                                { "value" => "Rafiq, Tariq", "name_type" => "Personal", "given_name" => "Tariq", "family_name" => "Rafiq", "affiliations" => [], "sequence" => "1" }
+                                              ],
+                                              "resource_type" => "Dataset", "publisher" => "Princeton University", "publication_year" => "2022",
+                                              "version_number" => "1",
+                                              "rights" => { "identifier" => "CC BY" }
+                                            })
       end
       created_by_user_id { FactoryBot.create(:pppl_submitter).id }
     end
@@ -88,7 +91,7 @@ FactoryBot.define do
       collection { Collection.research_data }
       resource do
         json_from_spec = File.read(Rails.root.join("spec", "fixtures", "cytoskeletal_metadata.json"))
-        PDCMetadata::Resource.new_from_json(json_from_spec)
+        PDCMetadata::Resource.new_from_json(JSON.parse(json_from_spec))
       end
       created_by_user_id { FactoryBot.create(:user).id }
     end

--- a/spec/models/pdc_metadata/resource_spec.rb
+++ b/spec/models/pdc_metadata/resource_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe PDCMetadata::Resource, type: :model do
 
   it "creates the expected json" do
     work = FactoryBot.create(:shakespeare_and_company_work)
-    expect(work.metadata).to eq(work.to_json)
+    expect(work.metadata).to eq(JSON.parse(work.to_json))
   end
 
   it "allows for collection tags" do
@@ -122,30 +122,31 @@ RSpec.describe PDCMetadata::Resource, type: :model do
   describe "##new_from_json" do
     let(:json) do
       {
-        "doi": doi,
-        "ark": "88435/dsp01zc77st047",
-        "titles": [{ "title": "Shakespeare and Company Project Dataset: Lending Library Members, Books, Events", "title_type" => nil }],
-        "description": "All data is related to the Shakespeare and Company bookshop and lending library opened and operated by Sylvia Beach in Paris, 1919–1962.",
-        "contributors": [
-          { "value": "Smith, Robert", "name_type": "Personal", "given_name": "Robert", "family_name": "Smith", "affiliations": [], "sequence": 1, "identifier": nil, type: "ProjectLeader" },
-          { "value": "Gallup, Simon", "name_type": "Personal", "given_name": "Simon", "family_name": "Gallup", "affiliations": [], "sequence": 2, "identifier": nil, type: "Other" }
+        "doi" => doi,
+        "ark" => "88435/dsp01zc77st047",
+        "titles" => [{ "title" => "Shakespeare and Company Project Dataset: Lending Library Members, Books, Events", "title_type" => nil }],
+        "description" => "All data is related to the Shakespeare and Company bookshop and lending library opened and operated by Sylvia Beach in Paris, 1919–1962.",
+        "contributors" => [
+          { "value" => "Smith, Robert", "name_type" => "Personal", "given_name" => "Robert", "family_name" => "Smith", "affiliations" => [], "sequence" => 1, "identifier" => nil,
+            "type" => "ProjectLeader" },
+          { "value" => "Gallup, Simon", "name_type" => "Personal", "given_name" => "Simon", "family_name" => "Gallup", "affiliations" => [], "sequence" => 2, "identifier" => nil, "type" => "Other" }
         ],
-        "creators": [
-          { "value": "Kotin, Joshua", "name_type": "Personal", "given_name": "Joshua", "family_name": "Kotin", "affiliations": [], "sequence": 1, "identifier": nil }
+        "creators" => [
+          { "value" => "Kotin, Joshua", "name_type" => "Personal", "given_name" => "Joshua", "family_name" => "Kotin", "affiliations" => [], "sequence" => 1, "identifier" => nil }
         ],
-        "resource_type": "Dataset",
+        "resource_type" => "Dataset",
         "resource_type_general" => "DATASET",
-        "publisher": "Princeton University",
-        "publication_year": "2020",
-        "collection_tags": ["ABC", "123"],
-        "keywords": ["red", "yellow", "green"],
-        "related_objects": [],
-        "rights": { "identifier" => "CC BY", "name" => "Creative Commons Attribution 4.0 International", "uri" => "https://creativecommons.org/licenses/by/4.0/" },
+        "publisher" => "Princeton University",
+        "publication_year" => "2020",
+        "collection_tags" => ["ABC", "123"],
+        "keywords" => ["red", "yellow", "green"],
+        "related_objects" => [],
+        "rights" => { "identifier" => "CC BY", "name" => "Creative Commons Attribution 4.0 International", "uri" => "https://creativecommons.org/licenses/by/4.0/" },
         "version_number" => 1,
         "funder_name" => nil,
         "award_number" => nil,
         "award_uri" => nil
-      }.to_json
+      }
     end
     it "parses the json" do
       resource = described_class.new_from_json(json)
@@ -153,7 +154,7 @@ RSpec.describe PDCMetadata::Resource, type: :model do
       expect(resource.collection_tags).to eq(["ABC", "123"])
       expect(resource.keywords).to eq(["red", "yellow", "green"])
       expect(resource.description).to eq("All data is related to the Shakespeare and Company bookshop and lending library opened and operated by Sylvia Beach in Paris, 1919–1962.")
-      expect(JSON.parse(resource.to_json)).to eq(JSON.parse(json))
+      expect(JSON.parse(resource.to_json)).to eq(json)
     end
   end
 end

--- a/spec/models/pdc_serialization/datacite_spec.rb
+++ b/spec/models/pdc_serialization/datacite_spec.rb
@@ -47,17 +47,17 @@ RSpec.describe PDCSerialization::Datacite, type: :model do
     let(:doi) { "https://doi.org/10.34770/pe9w-x904" }
     let(:work_resource) do
       json = {
-        "doi": doi,
-        "identifier_type": "DOI",
-        "titles": [{ "title": "Shakespeare and Company Project Dataset: Lending Library Members, Books, Events" }],
-        "description": "All data is related to the Shakespeare and Company bookshop and lending library opened and operated by Sylvia Beach in Paris, 1919–1962.",
-        "creators": [
-          { "value": "Kotin, Joshua", "name_type": "Personal", "given_name": "Joshua", "family_name": "Kotin", "affiliations": [], "sequence": "1" }
+        "doi" => doi,
+        "identifier_type" => "DOI",
+        "titles" => [{ "title" => "Shakespeare and Company Project Dataset: Lending Library Members, Books, Events" }],
+        "description" => "All data is related to the Shakespeare and Company bookshop and lending library opened and operated by Sylvia Beach in Paris, 1919–1962.",
+        "creators" => [
+          { "value" => "Kotin, Joshua", "name_type" => "Personal", "given_name" => "Joshua", "family_name" => "Kotin", "affiliations" => [], "sequence" => "1" }
         ],
-        "resource_type": "Dataset",
-        "publisher": "Princeton University",
-        "publication_year": "2020"
-      }.to_json
+        "resource_type" => "Dataset",
+        "publisher" => "Princeton University",
+        "publication_year" => "2020"
+      }
       PDCMetadata::Resource.new_from_json(json)
     end
     let(:datacite) { described_class.new_from_work_resource(work_resource) }
@@ -185,24 +185,24 @@ RSpec.describe PDCSerialization::Datacite, type: :model do
       context "with multiple titles" do
         let(:resource_titles) do
           [
-            PDCMetadata::Title.new(title: "example subtitle", title_type: "Subtitle"),
-            PDCMetadata::Title.new(title: "example alternative title", title_type: "AlternativeTitle"),
-            PDCMetadata::Title.new(title: "example translated title", title_type: "TranslatedTitle")
+            { "title" => "example subtitle", "title_type" => "Subtitle" },
+            { "title" => "example alternative title", "title_type" => "AlternativeTitle" },
+            { "title" => "example translated title", "title_type" => "TranslatedTitle" }
           ]
         end
         let(:work_resource) do
           json = {
-            "doi": doi,
-            "identifier_type": "DOI",
-            "titles": resource_titles,
-            "description": "All data is related to the Shakespeare and Company bookshop and lending library opened and operated by Sylvia Beach in Paris, 1919–1962.",
-            "creators": [
-              { "value": "Kotin, Joshua", "name_type": "Personal", "given_name": "Joshua", "family_name": "Kotin", "affiliations": [], "sequence": "1" }
+            "doi" => doi,
+            "identifier_type" => "DOI",
+            "titles" => resource_titles,
+            "description" => "All data is related to the Shakespeare and Company bookshop and lending library opened and operated by Sylvia Beach in Paris, 1919–1962.",
+            "creators" => [
+              { "value" => "Kotin, Joshua", "name_type" => "Personal", "given_name" => "Joshua", "family_name" => "Kotin", "affiliations" => [], "sequence" => "1" }
             ],
-            "resource_type": "Dataset",
-            "publisher": "Princeton University",
-            "publication_year": "2020"
-          }.to_json
+            "resource_type" => "Dataset",
+            "publisher" => "Princeton University",
+            "publication_year" => "2020"
+          }
           PDCMetadata::Resource.new_from_json(json)
         end
 

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -942,8 +942,9 @@ RSpec.describe Work, type: :model do
       }'
     end
     it "can change the entire resource" do
-      work.resource = PDCMetadata::Resource.new_from_json(resource_json)
-      expect(work.resource.to_json).to eq(JSON.parse(resource_json).to_json)
+      parsed_json = JSON.parse(resource_json)
+      work.resource = PDCMetadata::Resource.new_from_json(parsed_json)
+      expect(work.resource.to_json).to eq(parsed_json.to_json)
     end
   end
 


### PR DESCRIPTION
Allow jsonb metadata field to be actual json, so that is can be queried.

This code still allows for the metadata to be a string in the database also becuase it will parse the string.

fixes #772