### PR TITLE
Rearrange fields on work page

### DIFF
--- a/app/assets/javascripts/edit_work_utils.js
+++ b/app/assets/javascripts/edit_work_utils.js
@@ -469,17 +469,12 @@ $(() => {
   // The `cancel` property "prevents sorting if you start on elements matching the selector"
   // https://api.jqueryui.com/sortable/#method-cancel
   //
-  //  tr:has(th)      - prevents reordering the header (https://stackoverflow.com/a/17897706/446681)
   //  input           - prevents reordering on the textboxes (so they are still editable)
   //  select, option  - prevents reordering on the dropwdown (so they are still selectable)
   //  .delete-creator - prevents reording on the delete icon
   //
-  $('#creators-table-sortable').sortable({
-    cancel: 'tr:has(th), input, .delete-creator',
-  });
-
-  $('#contributors-table-sortable').sortable({
-    cancel: 'tr:has(th), input, select, option, .delete-contributor',
+  $('.sortable').sortable({
+    cancel: 'input, select, option, .delete-contributor, .delete-creator',
   });
 
   // Give the initial focus to the title.

--- a/app/views/works/_contributors_table.html.erb
+++ b/app/views/works/_contributors_table.html.erb
@@ -23,7 +23,7 @@
   <tbody id="contributors-table" class="sortable"></tbody>
   <tfoot>
     <tr>
-      <td>
+      <td colspan="3">
         <%= link_to "Add Another Contributor", "#", id: "btn-add-contributor", class: "btn btn-secondary" %>
       </td>
     </tr>

--- a/app/views/works/_contributors_table.html.erb
+++ b/app/views/works/_contributors_table.html.erb
@@ -9,8 +9,8 @@
   of rendering creators already on the record *and* creators added
   on the fly.
 -->
-<table id="contributors-table">
-  <tbody id="contributors-table-sortable">
+<table>
+  <thead id="contributors-table-sortable">
     <tr class="header-row">
       <th>ORCID</th>
       <th>Given name</th>
@@ -19,7 +19,15 @@
       <th>&nbsp;</th> <!-- move icon-->
       <th>&nbsp;</th> <!-- delete icon-->
     </tr>
-  </tbody>
+  </thead>
+  <tbody id="contributors-table"></tbody>
+  <tfoot>
+    <tr>
+      <td>
+        <%= link_to "Add Another Contributor", "#", id: "btn-add-contributor", class: "btn btn-secondary" %>
+      </td>
+    </tr>
+  </tfoot>
 </table>
 
 <% @work.resource.contributors.each_with_index do |contributor, i| %>
@@ -32,9 +40,3 @@
     data-sequence="<%= contributor.sequence || 0 %>">
   </span>
 <% end %>
-
-<!-- Let the user add new contributors -->
-<div>
-  <%= link_to "Add Another Contributor", "#", id: "btn-add-contributor", class: "btn btn-secondary" %>
-</div>
-

--- a/app/views/works/_contributors_table.html.erb
+++ b/app/views/works/_contributors_table.html.erb
@@ -10,7 +10,7 @@
   on the fly.
 -->
 <table>
-  <thead id="contributors-table-sortable">
+  <thead>
     <tr class="header-row">
       <th>ORCID</th>
       <th>Given name</th>
@@ -20,7 +20,7 @@
       <th>&nbsp;</th> <!-- delete icon-->
     </tr>
   </thead>
-  <tbody id="contributors-table"></tbody>
+  <tbody id="contributors-table" class="sortable"></tbody>
   <tfoot>
     <tr>
       <td>

--- a/app/views/works/_related_objects_table.html.erb
+++ b/app/views/works/_related_objects_table.html.erb
@@ -15,7 +15,7 @@
     <tbody id="related-objects-table"></tbody>
     <tfoot>
       <tr>
-        <td>
+        <td colspan="3">
           <%= link_to "Add Another Related Object", "#", id: "btn-add-related-object", class: "btn btn-secondary" %>
         </td>
       </tr>

--- a/app/views/works/_related_objects_table.html.erb
+++ b/app/views/works/_related_objects_table.html.erb
@@ -4,14 +4,22 @@
 </div>
 
 <div class="related-objects">
-  <table id="related-objects-table">
-    <tbody id="related-objects-table-body">
+  <table>
+    <thead>
       <tr class="header-row">
         <th>Related Identifier (Example: URI for a related publication or resource)</th>
         <th>Related Identifier Type</th>
         <th>Relation Type</th>
       </tr>
-    </tbody>
+    </thead>
+    <tbody id="related-objects-table"></tbody>
+    <tfoot>
+      <tr>
+        <td>
+          <%= link_to "Add Another Related Object", "#", id: "btn-add-related-object", class: "btn btn-secondary" %>
+        </td>
+      </tr>
+    </tfoot>
   </table>
 </div>
 
@@ -28,5 +36,5 @@
 
 <!-- Let the user add new related objects -->
 <div>
-  <%= link_to "Add Another Related Object", "#", id: "btn-add-related-object", class: "btn btn-secondary" %>
+  
 </div>

--- a/app/views/works/_related_objects_table.html.erb
+++ b/app/views/works/_related_objects_table.html.erb
@@ -33,8 +33,3 @@
     ></span>
   <% end %>
 <% end %>
-
-<!-- Let the user add new related objects -->
-<div>
-  
-</div>

--- a/app/views/works/_required_creators_table.html.erb
+++ b/app/views/works/_required_creators_table.html.erb
@@ -14,7 +14,7 @@
   on the fly.
 -->
 <table id="creators-table">
-  <thead id="creators-table-sortable">
+  <thead>
     <tr class="header-row">
       <th>ORCID</th>
       <th>Given name</th>
@@ -23,7 +23,7 @@
       <th>&nbsp;</th> <!-- delete icon-->
     </tr>
   </thead>
-  <tbody></tbody>
+  <tbody class="sortable"></tbody>
   <tfoot>
     <tr>
       <td>

--- a/app/views/works/_required_creators_table.html.erb
+++ b/app/views/works/_required_creators_table.html.erb
@@ -26,10 +26,8 @@
   <tbody class="sortable"></tbody>
   <tfoot>
     <tr>
-      <td>
+      <td colspan="3">
         <%= link_to "Add Another Creator", "#", id: "btn-add-creator", class: "btn btn-secondary" %>
-      </td>
-      <td>
         <%= link_to "Add me as a Creator", "#", id: "btn-add-me-creator", class: "btn btn-secondary" %>
       </td>
     </tr>

--- a/app/views/works/_required_creators_table.html.erb
+++ b/app/views/works/_required_creators_table.html.erb
@@ -14,7 +14,7 @@
   on the fly.
 -->
 <table id="creators-table">
-  <tbody id="creators-table-sortable">
+  <thead id="creators-table-sortable">
     <tr class="header-row">
       <th>ORCID</th>
       <th>Given name</th>
@@ -22,7 +22,18 @@
       <th>&nbsp;</th> <!-- move icon-->
       <th>&nbsp;</th> <!-- delete icon-->
     </tr>
-  </tbody>
+  </thead>
+  <tbody></tbody>
+  <tfoot>
+    <tr>
+      <td>
+        <%= link_to "Add Another Creator", "#", id: "btn-add-creator", class: "btn btn-secondary" %>
+      </td>
+      <td>
+        <%= link_to "Add me as a Creator", "#", id: "btn-add-me-creator", class: "btn btn-secondary" %>
+      </td>
+    </tr>
+  </tfoot>
 </table>
 
 <% if @work %>
@@ -36,10 +47,3 @@
     ></span>
   <% end %>
 <% end %>
-
-<!-- Let the user add new creators -->
-<div>
-  <%= link_to "Add Another Creator", "#", id: "btn-add-creator", class: "btn btn-secondary" %>
-  <%= link_to "Add me as a Creator", "#", id: "btn-add-me-creator", class: "btn btn-secondary" %>
-</div>
-

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -113,6 +113,20 @@
 </p>
 
 <div>
+  <% if @can_curate %>
+    <p>Curator: <select id="curator_select">
+      <option value="no-one">(no one)</option>
+      <% @collection.administrators.each do |user| %>
+        <option value="<%= user.id %>" <%= @work.curator_user_id == user.id ? "selected" : "" %>><%= user.display_name_safe %></option>
+      <% end %>
+    </select></p>
+  <% else %>
+    <% if @work.curator_user_id.nil? %>
+      <p>Curator: none</p>
+    <% else %>
+      <p>Curator: <%= User.find(@work.curator_user_id).display_name_safe %></p>
+    <% end %>
+  <% end %>
 
   <% if @work.resource.doi %>
     <p>DOI:
@@ -127,7 +141,7 @@
     <p>ARK: <%= link_to(@work.resource.ark, ark_url(@work.resource.ark)) %></p>
   <% end %>
 
-  <p>Creator(s): <%= @work.created_by_user.uid %></p>
+  <p>Creator: <%= @work.created_by_user.uid %></p>
 
   <% if @work.resource.contributors.count > 0 %>
     <p>Contributors:
@@ -206,21 +220,6 @@
 
   <% if @work.submission_notes.present? %>
     <p>Notes: <%= @work.submission_notes %></p>
-  <% end %>
-
-  <% if @can_curate %>
-    <p>Curator: <select id="curator_select">
-      <option value="no-one">(no one)</option>
-      <% @collection.administrators.each do |user| %>
-        <option value="<%= user.id %>" <%= @work.curator_user_id == user.id ? "selected" : "" %>><%= user.display_name_safe %></option>
-      <% end %>
-    </select></p>
-  <% else %>
-    <% if @work.curator_user_id.nil? %>
-      <p>Curator: none</p>
-    <% else %>
-      <p>Curator: <%= User.find(@work.curator_user_id).display_name_safe %></p>
-    <% end %>
   <% end %>
 </div>
 

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -113,11 +113,7 @@
 </p>
 
 <div>
-  <p>Description:<br/>
-    <span style="white-space: pre-wrap;"><%= @work.resource.description %></span>
-  </p>
-  <p>Publisher: <%= @work.resource.publisher %></p>
-  <p>Publication Year: <%= @work.resource.publication_year %></p>
+
   <% if @work.resource.doi %>
     <p>DOI:
       <span><%= link_to(@work.resource.doi, doi_url(@work.resource.doi), target: '_blank', rel: 'noopener noreferrer') %></span>
@@ -130,6 +126,36 @@
   <% if @work.resource.ark %>
     <p>ARK: <%= link_to(@work.resource.ark, ark_url(@work.resource.ark)) %></p>
   <% end %>
+
+  <p>Creator(s): <%= @work.created_by_user.uid %></p>
+
+  <% if @work.resource.contributors.count > 0 %>
+    <p>Contributors:
+      <% @work.resource.contributors.each_with_index do |contributor, ix| %>
+        <%= contributor_link(contributor, ix < (@work.resource.contributors.count-1) ) %>
+      <% end %>
+    </p>
+  <% end %>
+
+  <p>Description:<br/>
+    <span style="white-space: pre-wrap;"><%= @work.resource.description %></span>
+  </p>
+
+  <% if @work.resource.keywords.count > 0 %>
+    <p>Keywords:
+      <% @work.resource.keywords.each do |keyword| %>
+        <span class="badge bg-dark"><%= keyword %></span>
+      <% end %>
+    </p>
+  <% end %>
+
+  <% if @work.resource.rights.present? %>
+    <p>Rights: <%= @work.resource.rights.name %> (<%= link_to(@work.resource.rights.identifier, @work.resource.rights.uri, {target: "_blank"}) %>)</p>
+  <% end %>
+
+  <p>Publisher: <%= @work.resource.publisher %></p>
+  <p>Publication Year: <%= @work.resource.publication_year %></p>
+
   <% if @work.resource.version_number %>
     <p>Version: <%= @work.resource.version_number %></p>
   <% end %>
@@ -145,14 +171,6 @@
     <% end %>
   <% end %>
 
-  <% if @work.resource.contributors.count > 0 %>
-    <p>Contributors:
-      <% @work.resource.contributors.each_with_index do |contributor, ix| %>
-        <%= contributor_link(contributor, ix < (@work.resource.contributors.count-1) ) %>
-      <% end %>
-    </p>
-  <% end %>
-
   <% if @work.resource.related_objects.count > 0 %>
     <p>Related Objects:
       <% @work.resource.related_objects.each do |related_object| %>
@@ -161,18 +179,7 @@
     </p>
   <% end %>
 
-  <p>Added by: <%= @work.created_by_user.uid %></p>
   <p>Collection: <%= @collection.title %></p>
-  <% if @work.resource.rights.present? %>
-    <p>Rights: <%= @work.resource.rights.name %> (<%= link_to(@work.resource.rights.identifier, @work.resource.rights.uri, {target: "_blank"}) %>)</p>
-  <% end %>
-  <% if @work.resource.keywords.count > 0 %>
-    <p>Keywords:
-      <% @work.resource.keywords.each do |keyword| %>
-        <span class="badge bg-dark"><%= keyword %></span>
-      <% end %>
-    </p>
-  <% end %>
 
   <% if @work.resource.funder_name.present? %>
     <p>Funder Name: <%= @work.resource.funder_name %></p>


### PR DESCRIPTION
- Towards #746

Fields in order (with fields _italicized_ that were not in mockup, but seemed to belong):
- _Curator_ (= "submitted by"?)
- DOI
- _ARK_
- Creator
- _Contributors_
- Description
- Keywords
- Rights
- Publisher
- Year
- Version
- Resource Type / General Type

The remaining fields are in this order:

- Related Objects
- Collection
- Funder
- Location / Location notes
- Notes

