### PR TITLE
Rearrange work fields

### DIFF
--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -113,11 +113,21 @@
 </p>
 
 <div>
-  <p>Description:<br/>
-    <span style="white-space: pre-wrap;"><%= @work.resource.description %></span>
-  </p>
-  <p>Publisher: <%= @work.resource.publisher %></p>
-  <p>Publication Year: <%= @work.resource.publication_year %></p>
+  <% if @can_curate %>
+    <p>Curator: <select id="curator_select">
+      <option value="no-one">(no one)</option>
+      <% @collection.administrators.each do |user| %>
+        <option value="<%= user.id %>" <%= @work.curator_user_id == user.id ? "selected" : "" %>><%= user.display_name_safe %></option>
+      <% end %>
+    </select></p>
+  <% else %>
+    <% if @work.curator_user_id.nil? %>
+      <p>Curator: none</p>
+    <% else %>
+      <p>Curator: <%= User.find(@work.curator_user_id).display_name_safe %></p>
+    <% end %>
+  <% end %>
+
   <% if @work.resource.doi %>
     <p>DOI:
       <span><%= link_to(@work.resource.doi, doi_url(@work.resource.doi), target: '_blank', rel: 'noopener noreferrer') %></span>
@@ -130,6 +140,36 @@
   <% if @work.resource.ark %>
     <p>ARK: <%= link_to(@work.resource.ark, ark_url(@work.resource.ark)) %></p>
   <% end %>
+
+  <p>Creator: <%= @work.created_by_user.uid %></p>
+
+  <% if @work.resource.contributors.count > 0 %>
+    <p>Contributors:
+      <% @work.resource.contributors.each_with_index do |contributor, ix| %>
+        <%= contributor_link(contributor, ix < (@work.resource.contributors.count-1) ) %>
+      <% end %>
+    </p>
+  <% end %>
+
+  <p>Description:<br/>
+    <span style="white-space: pre-wrap;"><%= @work.resource.description %></span>
+  </p>
+
+  <% if @work.resource.keywords.count > 0 %>
+    <p>Keywords:
+      <% @work.resource.keywords.each do |keyword| %>
+        <span class="badge bg-dark"><%= keyword %></span>
+      <% end %>
+    </p>
+  <% end %>
+
+  <% if @work.resource.rights.present? %>
+    <p>Rights: <%= @work.resource.rights.name %> (<%= link_to(@work.resource.rights.identifier, @work.resource.rights.uri, {target: "_blank"}) %>)</p>
+  <% end %>
+
+  <p>Publisher: <%= @work.resource.publisher %></p>
+  <p>Publication Year: <%= @work.resource.publication_year %></p>
+
   <% if @work.resource.version_number %>
     <p>Version: <%= @work.resource.version_number %></p>
   <% end %>
@@ -145,14 +185,6 @@
     <% end %>
   <% end %>
 
-  <% if @work.resource.contributors.count > 0 %>
-    <p>Contributors:
-      <% @work.resource.contributors.each_with_index do |contributor, ix| %>
-        <%= contributor_link(contributor, ix < (@work.resource.contributors.count-1) ) %>
-      <% end %>
-    </p>
-  <% end %>
-
   <% if @work.resource.related_objects.count > 0 %>
     <p>Related Objects:
       <% @work.resource.related_objects.each do |related_object| %>
@@ -161,18 +193,7 @@
     </p>
   <% end %>
 
-  <p>Added by: <%= @work.created_by_user.uid %></p>
   <p>Collection: <%= @collection.title %></p>
-  <% if @work.resource.rights.present? %>
-    <p>Rights: <%= @work.resource.rights.name %> (<%= link_to(@work.resource.rights.identifier, @work.resource.rights.uri, {target: "_blank"}) %>)</p>
-  <% end %>
-  <% if @work.resource.keywords.count > 0 %>
-    <p>Keywords:
-      <% @work.resource.keywords.each do |keyword| %>
-        <span class="badge bg-dark"><%= keyword %></span>
-      <% end %>
-    </p>
-  <% end %>
 
   <% if @work.resource.funder_name.present? %>
     <p>Funder Name: <%= @work.resource.funder_name %></p>
@@ -199,21 +220,6 @@
 
   <% if @work.submission_notes.present? %>
     <p>Notes: <%= @work.submission_notes %></p>
-  <% end %>
-
-  <% if @can_curate %>
-    <p>Curator: <select id="curator_select">
-      <option value="no-one">(no one)</option>
-      <% @collection.administrators.each do |user| %>
-        <option value="<%= user.id %>" <%= @work.curator_user_id == user.id ? "selected" : "" %>><%= user.display_name_safe %></option>
-      <% end %>
-    </select></p>
-  <% else %>
-    <% if @work.curator_user_id.nil? %>
-      <p>Curator: none</p>
-    <% else %>
-      <p>Curator: <%= User.find(@work.curator_user_id).display_name_safe %></p>
-    <% end %>
   <% end %>
 </div>
 

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -137,19 +137,8 @@
       </button>
     </p>
   <% end %>
-  <% if @work.resource.ark %>
-    <p>ARK: <%= link_to(@work.resource.ark, ark_url(@work.resource.ark)) %></p>
-  <% end %>
 
   <p>Creator: <%= @work.created_by_user.uid %></p>
-
-  <% if @work.resource.contributors.count > 0 %>
-    <p>Contributors:
-      <% @work.resource.contributors.each_with_index do |contributor, ix| %>
-        <%= contributor_link(contributor, ix < (@work.resource.contributors.count-1) ) %>
-      <% end %>
-    </p>
-  <% end %>
 
   <p>Description:<br/>
     <span style="white-space: pre-wrap;"><%= @work.resource.description %></span>
@@ -183,6 +172,18 @@
         </p>
       </div>
     <% end %>
+  <% end %>
+
+  <% if @work.resource.ark %>
+    <p>ARK: <%= link_to(@work.resource.ark, ark_url(@work.resource.ark)) %></p>
+  <% end %>
+
+  <% if @work.resource.contributors.count > 0 %>
+    <p>Contributors:
+      <% @work.resource.contributors.each_with_index do |contributor, ix| %>
+        <%= contributor_link(contributor, ix < (@work.resource.contributors.count-1) ) %>
+      <% end %>
+    </p>
   <% end %>
 
   <% if @work.resource.related_objects.count > 0 %>


### PR DESCRIPTION
- Towards #746

Fields in order (with fields _italicized_ that were not in mockup, but seemed to belong):
- _Curator_ (= "submitted by"?)
- DOI
- _ARK_
- Creator
- _Contributors_
- Description
- Keywords
- Rights
- Publisher
- Year
- Version
- Resource Type / General Type

The remaining fields are in this order:

- Related Objects
- Collection
- Funder
- Location / Location notes
- Notes