### PR TITLE
Removing cleanup code for JSON blob in string to actual JSON in postgres jsonb field

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -178,12 +178,6 @@ class Work < ApplicationRecord
     end
   end
 
-  # Deal with Historic works where the metadata was stored as a String
-  #   New metadata records should be stored as JSON not a string blob in a JSON field
-  after_initialize do |work|
-    work.metadata = JSON.parse(work.metadata) if work.metadata.is_a? String
-  end
-
   validate do |work|
     if none?
       work.validate_doi

--- a/lib/tasks/works.rake
+++ b/lib/tasks/works.rake
@@ -58,9 +58,4 @@ namespace :works do
       work.destroy
     end
   end
-
-  desc "Convert metadata to JSON"
-  task convert_metadata_to_JSON: :environment do
-    Work.all.each(&:save!) # each metadata record will be updated to JSON when we load it
-  end
 end


### PR DESCRIPTION

fixes #775
refs #772

On staging we can now select the keys of all the works without error:
```
pdc_describe_staging=> select json_object_keys(metadata::json) from works;
  json_object_keys    
-----------------------
 ark
 doi
 rights
 titles
 creators
 keywords
 award_uri
 publisher
 description
 funder_name
 award_number
 contributors
 resource_type
 version_number
 collection_tags
 related_objects
 publication_year
 resource_type_general
 ark
 doi
....
```
 On production there are no records:
```
pdc_describe_prod=> select json_object_keys(metadata::json) from works;
 json_object_keys 
------------------
(0 rows)
```