### PR TITLE
Correct display of year in prov log for newly created work

### DIFF
--- a/app/lib/simple_diff.rb
+++ b/app/lib/simple_diff.rb
@@ -4,8 +4,8 @@ require "diff/lcs"
 
 class SimpleDiff
   def initialize(old_value, new_value)
-    old_value ||= ""
-    new_value ||= ""
+    old_value = old_value.to_s
+    new_value = new_value.to_s
     @changes = ::Diff::LCS.sdiff(old_value, new_value).chunk(&:action).map do |action, changes|
       {
         action: action,

--- a/spec/lib/diff_spec.rb
+++ b/spec/lib/diff_spec.rb
@@ -9,12 +9,14 @@ RSpec.describe SimpleDiff do
   it "handles single character change" do
     expect(SimpleDiff.new("cat", "bat").to_html).to eq "<del>c</del><ins>b</ins>at"
   end
+
   it "handles nil old" do
     expect(SimpleDiff.new(nil, "dog").to_html).to eq "<ins>dog</ins>"
   end
   it "handles nil new" do
     expect(SimpleDiff.new("dog", nil).to_html).to eq "<del>dog</del>"
   end
+
   it "handles addition" do
     expect(SimpleDiff.new("dog", "In the dog house").to_html).to eq "<ins>In the </ins>dog<ins> house</ins>"
   end
@@ -24,9 +26,21 @@ RSpec.describe SimpleDiff do
   it "handles mixed" do
     expect(SimpleDiff.new("quick brown", "brown fox").to_html).to eq "<del>quick </del>brown<ins> fox</ins>"
   end
+
+  it "handles number to equivalent string" do
+    expect(SimpleDiff.new(2022, "2022").to_html).to eq ""
+  end
+  it "handles string to equivalent number" do
+    expect(SimpleDiff.new("2022", 2022).to_html).to eq ""
+  end
+  it "handles numbers" do
+    expect(SimpleDiff.new(2022, 2023).to_html).to eq ""
+  end
+
   it "encodes html" do
     expect(SimpleDiff.new("1 < 2", "2 > 1").to_html).to eq "<del>1</del><ins>2</ins> <del>&lt;</del><ins>&gt;</ins> <del>2</del><ins>1</ins>"
   end
+
   it "abbreviates really long strings" do
     expect(SimpleDiff.new(
       "This does not repeat the entire string if its just a tiny typo in the middle that changes.",

--- a/spec/lib/diff_spec.rb
+++ b/spec/lib/diff_spec.rb
@@ -28,13 +28,13 @@ RSpec.describe SimpleDiff do
   end
 
   it "handles number to equivalent string" do
-    expect(SimpleDiff.new(2022, "2022").to_html).to eq ""
+    expect(SimpleDiff.new(2022, "2022").to_html).to eq "2022"
   end
   it "handles string to equivalent number" do
-    expect(SimpleDiff.new("2022", 2022).to_html).to eq ""
+    expect(SimpleDiff.new("2022", 2022).to_html).to eq "2022"
   end
   it "handles numbers" do
-    expect(SimpleDiff.new(2022, 2023).to_html).to eq ""
+    expect(SimpleDiff.new(2022, 2023).to_html).to eq "202<del>2</del><ins>3</ins>"
   end
 
   it "encodes html" do


### PR DESCRIPTION
Underlying library has strange behavior when given a number. Convert everything to string before diff.

- Fix #788