### PR TITLE
Show changes fold-down

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -167,6 +167,12 @@ details {
       margin-left: 0.5rem;
     }
   }
+
+  summary.show-changes {
+    &::after {
+      content: 'Show Changes';
+    }
+  }
 }
 
 .copy-doi-label-normal {

--- a/app/models/work_activity.rb
+++ b/app/models/work_activity.rb
@@ -149,7 +149,7 @@ class WorkActivity < ApplicationRecord
         mapped = change.map { |value| change_value_html(value) }
         values = mapped.join
 
-        children = "<p><b>#{field}</b>: #{values}</p>"
+        children = "<details><summary class='show-changes'>#{field}</summary>#{values}</details>"
         text += event_html(children: children)
       end
 


### PR DESCRIPTION
- Towards #745:

> Details are available by clicking on the expansion button

Using `<details>` again, since the functionality is similar to the context help.

Screen shot with resource_type collapsed, and rights expanded:

<img width="320" alt="Screen Shot 2022-12-21 at 4 39 54 PM" src="https://user-images.githubusercontent.com/730388/209007571-f2fc905b-b94b-4441-8a26-d364f080cdca.png">
