### PR TITLE
Add related objects help text

### DIFF
--- a/app/views/works/_related_objects_table.html.erb
+++ b/app/views/works/_related_objects_table.html.erb
@@ -1,7 +1,7 @@
 <!-- Related Objects section -->
-<div class="section-title">
-  <b>Related Objects (i.e., published dependencies)</b>
-</div>
+<details><summary>Related Objects</summary>
+  If this item is backing any particular publication or is otherwise cited directly in published works, please provide the persistent identifier(s) for the referencing publication(s) (e.g., a complete DOI link).
+</details>
 
 <div class="related-objects">
   <table id="related-objects-table">


### PR DESCRIPTION
- Fix #754

I've also removed "(i.e., published dependencies)" from the label, since that seems to be covered by the longer text.