### PR TITLE
Change test factory name to match state

### DIFF
--- a/spec/factories/work.rb
+++ b/spec/factories/work.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
       resource { FactoryBot.build :resource, doi: doi }
     end
 
-    factory :completed_work do
+    factory :awaiting_approval_work do
       transient do
         doi { "10.34770/123-abc" }
         ark { nil }

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -337,6 +337,7 @@ RSpec.describe Work, type: :model do
 
   describe "datasets waiting for approval by user type" do
     before do
+      FactoryBot.create(:approved_work, created_by_user_id: user.id)
       FactoryBot.create(:draft_work, created_by_user_id: user.id)
       FactoryBot.create(:draft_work, created_by_user_id: user.id)
       FactoryBot.create(:draft_work, created_by_user_id: pppl_user.id, collection_id: Collection.plasma_laboratory.id)

--- a/spec/system/authz_submitter_spec.rb
+++ b/spec/system/authz_submitter_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "Authz for submitters", type: :system, js: true do
     end
 
     it "should not be able to approve a work" do
-      work = FactoryBot.create :completed_work
+      work = FactoryBot.create :awaiting_approval_work
       sign_in submitter1
       visit work_path(work)
       expect(page).not_to have_button "Approve Dataset"

--- a/spec/system/authz_super_admin_spec.rb
+++ b/spec/system/authz_super_admin_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "Authz for super admins", type: :system, js: true do
 
     it "should be able to approve a work" do
       stub_datacite_doi
-      work = FactoryBot.create :completed_work
+      work = FactoryBot.create :awaiting_approval_work
 
       file_name = "us_covid_2019.csv"
       stub_work_s3_requests(work: work, file_name: file_name)

--- a/spec/system/migrate_submission_spec.rb
+++ b/spec/system/migrate_submission_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe "Form submission for a legacy dataset", type: :system, mock_ezid_
     end
 
     context "Approving a work with a DOI we own" do
-      let(:work) { FactoryBot.create :completed_work, doi: "#{Rails.configuration.datacite.prefix}/abc-123", ark: "ark:/88435/dsp01d791sj97j" }
+      let(:work) { FactoryBot.create :awaiting_approval_work, doi: "#{Rails.configuration.datacite.prefix}/abc-123", ark: "ark:/88435/dsp01d791sj97j" }
 
       it "updates the DOI and ARK url when approved" do
         expect(datacite_stub).to have_received("update")
@@ -139,7 +139,7 @@ RSpec.describe "Form submission for a legacy dataset", type: :system, mock_ezid_
     end
 
     context "Approving a work with a DOI we own do not own, but also has an ARK" do
-      let(:work) { FactoryBot.create :completed_work, doi: "10.99999/abc-123", ark: "ark:/88435/dsp01d791sj97j" }
+      let(:work) { FactoryBot.create :awaiting_approval_work, doi: "10.99999/abc-123", ark: "ark:/88435/dsp01d791sj97j" }
 
       it "updates the ARK url when approved" do
         expect(datacite_stub).not_to have_received("update")
@@ -150,7 +150,7 @@ RSpec.describe "Form submission for a legacy dataset", type: :system, mock_ezid_
     end
 
     context "Approving a work with a DOI we own do not own, but does not have an ARK" do
-      let(:work) { FactoryBot.create :completed_work, doi: "10.99999/abc-123", ark: nil }
+      let(:work) { FactoryBot.create :awaiting_approval_work, doi: "10.99999/abc-123", ark: nil }
       it "updates the ARK url when approved" do
         expect(datacite_stub).not_to have_received("update")
         expect(identifier).not_to have_received("target=")

--- a/spec/system/work_spec.rb
+++ b/spec/system/work_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe "Creating and updating works", type: :system do
 
   context "when editing a work" do
     let(:draft_work) { FactoryBot.create(:draft_work) }
-    let(:completed_work) { FactoryBot.create(:completed_work) }
+    let(:awaiting_approval_work) { FactoryBot.create(:awaiting_approval_work) }
     let(:user) { draft_work.created_by_user }
 
     it "uses the wizard if the work is in draft" do
@@ -150,8 +150,8 @@ RSpec.describe "Creating and updating works", type: :system do
 
     it "does not use the wizard if the work once the work is not in draft" do
       sign_in user
-      visit work_path(completed_work)
-      expect(page.html.include?("/works/#{completed_work.id}/edit")).to be true
+      visit work_path(awaiting_approval_work)
+      expect(page.html.include?("/works/#{awaiting_approval_work.id}/edit")).to be true
     end
 
     it "allows users to modify the order of the creators", js: true do


### PR DESCRIPTION
- Fix #787

When the issue was originally filed, it seemed like there might be a deeper issue, but I think it's just a naming issue. My guess is that originally `completed` meant that data entry was completed, but it seems to be a source of confusion, so I've renamed to match state, like other fixtures.
```diff
-    factory :completed_work do
+    factory :awaiting_approval_work do
      ...
      state { "awaiting_approval" }
```