### PR TITLE
Ensuring that Work#approve logs a message indicating that the Work was successfully published by the curator user

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -462,6 +462,7 @@ class Work < ApplicationRecord
       update_ark_information
       publish_precurated_files
       save!
+      WorkActivity.add_system_activity(id, "successfully published", user.id)
     end
 
     # Update EZID (our provider of ARKs) with the new information for this work.

--- a/app/models/work_activity.rb
+++ b/app/models/work_activity.rb
@@ -15,7 +15,7 @@ class WorkActivity < ApplicationRecord
   belongs_to :work
   has_many :work_activity_notifications, dependent: :destroy
 
-  def self.add_system_activity(work_id, message, user_id, activity_type: "SYSTEM")
+  def self.add_system_activity(work_id, message, user_id, activity_type: SYSTEM)
     activity = WorkActivity.new(
       work_id: work_id,
       activity_type: activity_type,

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -577,6 +577,20 @@ RSpec.describe Work, type: :model do
 
         expect(draft_work.curator).to eq(curator_user)
       end
+
+      it "sends a notification for the approval of the work" do
+        allow(WorkActivity).to receive(:add_system_activity)
+        draft_work = FactoryBot.create(:draft_work)
+        file_name = uploaded_file.original_filename
+        stub_work_s3_requests(work: draft_work, file_name: file_name)
+        draft_work.pre_curation_uploads.attach(uploaded_file)
+
+        draft_work.complete_submission!(user)
+        draft_work.update_curator(curator_user.id, user)
+        draft_work.approve!(curator_user)
+
+        expect(WorkActivity).to have_received(:add_system_activity).with(draft_work.id, "successfully published", curator_user.id)
+      end
     end
 
     it "is approved" do


### PR DESCRIPTION
Resolves #361 