### PR TITLE
Specify year in test object, so it will match xml fixture

### DIFF
--- a/spec/models/pdc_metadata/resource_spec.rb
+++ b/spec/models/pdc_metadata/resource_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe PDCMetadata::Resource, type: :model do
     ds.ark = "ark:/88435/dsp01hx11xj13h"
     ds.rights = PDCMetadata::Rights.find("CC BY")
     ds.contributors = [contributor1, contributor2]
+    ds.publication_year = 2022
     ds
   end
 


### PR DESCRIPTION
If we don't manually set the year in the test, we get the current year, and the comparison with the XML will fail.