### PR TITLE
Tweak webmock configuration for more reliable local rspec runs

### DIFF
--- a/spec/models/pdc_metadata/resource_spec.rb
+++ b/spec/models/pdc_metadata/resource_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe PDCMetadata::Resource, type: :model do
     ds.ark = "ark:/88435/dsp01hx11xj13h"
     ds.rights = PDCMetadata::Rights.find("CC BY")
     ds.contributors = [contributor1, contributor2]
+    ds.publication_year = 2022
     ds
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -108,3 +108,8 @@ RSpec.configure do |config|
     end
   end
 end
+
+# Fix intermittent errors: "Failed to open TCP connection ... Too many open files"
+# https://stackoverflow.com/a/65946077
+# https://github.com/bblimke/webmock#connecting-on-nethttpstart
+WebMock.allow_net_connect!(net_http_connect_on_start: true)


### PR DESCRIPTION
I've just run rspec locally twice and both passed; I think two passes in a row would be unlikely for me before this change.
- Fix #804
- To get tests passing, I branched from #805: I suggest reviewing and merging that PR first.