### PR TITLE
Simplify logic: use `find_by_value` instead of `elsif` chain

### DIFF
--- a/app/models/pdc_serialization/datacite.rb
+++ b/app/models/pdc_serialization/datacite.rb
@@ -159,7 +159,8 @@ module PDCSerialization
             if title.main?
               ::Datacite::Mapping::Title.new(value: title.title)
             else
-              ::Datacite::Mapping::Title.new(value: title.title, type: ::Datacite::Mapping::TitleType.find_by_value(title.title_type))
+              title_type = ::Datacite::Mapping::TitleType.find_by_value(title.title_type)
+              ::Datacite::Mapping::Title.new(value: title.title, type: title_type) if title_type
             end
           end.compact
         end

--- a/app/models/pdc_serialization/datacite.rb
+++ b/app/models/pdc_serialization/datacite.rb
@@ -158,12 +158,8 @@ module PDCSerialization
           titles.map do |title|
             if title.main?
               ::Datacite::Mapping::Title.new(value: title.title)
-            elsif title.title_type == "Subtitle"
-              ::Datacite::Mapping::Title.new(value: title.title, type: ::Datacite::Mapping::TitleType::SUBTITLE)
-            elsif title.title_type == "AlternativeTitle"
-              ::Datacite::Mapping::Title.new(value: title.title, type: ::Datacite::Mapping::TitleType::ALTERNATIVE_TITLE)
-            elsif title.title_type == "TranslatedTitle"
-              ::Datacite::Mapping::Title.new(value: title.title, type: ::Datacite::Mapping::TitleType::TRANSLATED_TITLE)
+            else
+              ::Datacite::Mapping::Title.new(value: title.title, type: ::Datacite::Mapping::TitleType.find_by_value(title.title_type))
             end
           end.compact
         end


### PR DESCRIPTION
- Fix #807

Small change in behavior: If an unexpected value were encountered, it would error instead of falling through.