### PR TITLE
Moving S3 blob generation into the S3 File to make the work model smaller

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -457,20 +457,6 @@ class Work < ApplicationRecord
 
   private
 
-    def s3_file_to_blob(s3_file)
-      existing_blob = ActiveStorage::Blob.find_by(key: s3_file.filename)
-
-      if existing_blob.present?
-        Rails.logger.warn("There is a blob existing for #{s3_file.filename}, which we are not expecting!  It will be reattached #{existing_blob.inspect}")
-        return existing_blob
-      end
-
-      params = { filename: s3_file.filename, content_type: "", byte_size: s3_file.size, checksum: s3_file.checksum }
-      blob = ActiveStorage::Blob.create_before_direct_upload!(**params)
-      blob.key = s3_file.filename
-      blob
-    end
-
     def publish(user)
       publish_doi(user)
       update_ark_information
@@ -647,7 +633,7 @@ class Work < ApplicationRecord
     def add_pre_curation_s3_object(s3_file)
       return if s3_object_persisted?(s3_file)
 
-      persisted = s3_file_to_blob(s3_file)
+      persisted = s3_file.to_blob
       pre_curation_uploads.attach(persisted)
     end
 

--- a/spec/models/s3_file_spec.rb
+++ b/spec/models/s3_file_spec.rb
@@ -39,4 +39,37 @@ RSpec.describe S3File, type: :model do
       expect(CGI.unescape(url_file)).to eq(filename.split("/").last)
     end
   end
+
+  describe "#to_blob" do
+    let(:file) do
+      S3File.new(
+        filename: "abc123/111/SCoData_combined_v1_2020-07_README.txt",
+        last_modified: Time.parse("2022-04-21T18:30:07.000Z"),
+        size: 12_739,
+        checksum: "abc567"
+      )
+    end
+
+    it "persists S3 Bucket resources as ActiveStorage::Blob" do
+      # call the s3 reload and make sure no more files get added to the model
+      blob = nil
+      expect { blob = file.to_blob }.to change { ActiveStorage::Blob.count }.by(1)
+
+      expect(blob.key).to eq("abc123/111/SCoData_combined_v1_2020-07_README.txt")
+    end
+
+    context "a blob already exists for one of the files" do
+      before do
+        persisted = ActiveStorage::Blob.create_before_direct_upload!(
+          filename: file.filename, content_type: "", byte_size: file.size, checksum: ""
+        )
+        persisted.key = file.filename
+        persisted.save
+      end
+
+      it "finds the blob" do
+        expect { file.to_blob }.to change { ActiveStorage::Blob.count }.by(0)
+      end
+    end
+  end
 end

--- a/spec/models/s3_file_spec.rb
+++ b/spec/models/s3_file_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe S3File, type: :model do
       end
 
       it "finds the blob" do
-        expect { file.to_blob }.to change { ActiveStorage::Blob.count }.by(0)
+        expect { file.to_blob }.not_to change { ActiveStorage::Blob.count }
       end
     end
   end


### PR DESCRIPTION
This just moves the code out of the work into the S3 file, which is where I believe it belongs.