### PR TITLE
Mccalluc group message UI

### DIFF
--- a/app/views/works/_work_activity_history.html.erb
+++ b/app/views/works/_work_activity_history.html.erb
@@ -10,6 +10,19 @@
     } %>
   <% end %>
 
+  <div id="new-comment-section">
+    <%= form_with url: add_comment_work_path(@work) do |f| %>
+      <textarea id="new-comment" name="new-comment" class="new-comment" placeholder="leave a message" rows="5" cols="100"></textarea>
+      <br/>
+      <%= f.submit("Message", class: "btn btn-secondary") %>
+      <span class="new-comment-help">
+        Simple Markdown is accepted, e.g. *italics*, **bold**, # Header 1, ## Header 2, ```code```. Use @netid to refer to others.
+      </span>
+    <% end %>
+  </div>
+</div>
+
+<div>
   <h2>Change History</h2>
   <% if @changes.size == 0 %>
     No activity

--- a/app/views/works/_work_activity_history.html.erb
+++ b/app/views/works/_work_activity_history.html.erb
@@ -1,7 +1,7 @@
 <div>
-  <h2>Comments</h2>
+  <h2>Messages</h2>
   <% if @comments.size == 0 %>
-    No comments
+    No messages
   <% end %>
   <% @comments.each do |activity| %>
     <%= render partial: 'work_activity', locals: {

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -267,9 +267,9 @@
 
 <div id="new-comment-section">
   <%= form_with url: add_comment_work_path(@work) do |f| %>
-    <textarea id="new-comment" name="new-comment" class="new-comment" placeholder="leave a comment" rows="5" cols="100"></textarea>
+    <textarea id="new-comment" name="new-comment" class="new-comment" placeholder="leave a message" rows="5" cols="100"></textarea>
     <br/>
-    <%= f.submit("Comment", class: "btn btn-secondary") %>
+    <%= f.submit("Message", class: "btn btn-secondary") %>
     <span class="new-comment-help">
       Simple Markdown is accepted, e.g. *italics*, **bold**, # Header 1, ## Header 2, ```code```. Use @netid to refer to others.
     </span>
@@ -304,7 +304,7 @@
 
     // triggeredAutocomplete (https://github.com/Hawkers/triggeredAutocomplete) is a plug-in
     // that sits on top of jQuery UI autocomplete and provides the @mention functionaly to
-    // reference other users via their netid in a comments.
+    // reference other users via their netid in a message/comment.
     //
     // Notice that https://github.com/Hawkers/triggeredAutocomplete also supports passing an
     // array of objects with structure {value: x, label: y} to display a more user friendly

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -265,17 +265,6 @@
 
 <%= render 'work_activity_history' %>
 
-<div id="new-comment-section">
-  <%= form_with url: add_comment_work_path(@work) do |f| %>
-    <textarea id="new-comment" name="new-comment" class="new-comment" placeholder="leave a message" rows="5" cols="100"></textarea>
-    <br/>
-    <%= f.submit("Message", class: "btn btn-secondary") %>
-    <span class="new-comment-help">
-      Simple Markdown is accepted, e.g. *italics*, **bold**, # Header 1, ## Header 2, ```code```. Use @netid to refer to others.
-    </span>
-  <% end %>
-</div>
-
 <%= javascript_include_tag 'show_work_utils' %>
 
 <script>

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -1014,17 +1014,17 @@ RSpec.describe WorksController do
       expect(response.body).to eq '{"errors":["Cannot save dataset"]}'
     end
 
-    it "posts a comment" do
+    it "posts a comment/message" do
       sign_in user
       post :add_comment, params: { id: work.id, "new-comment" => "hello world" }
       expect(response.status).to be 302
       expect(response.location).to eq "http://test.host/works/#{work.id}"
     end
 
-    context "when posting a comment containing HTML" do
+    context "when posting a comment/message containing HTML" do
       render_views
 
-      it "posts a comment with sanitized HTML" do
+      it "posts a comment/message with sanitized HTML" do
         sign_in user
         post :add_comment, params: { id: work.id, "new-comment" => "<div>hello world</div>" }
         expect(response.status).to be 302

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -357,7 +357,7 @@ RSpec.describe Work, type: :model do
   end
 
   describe "#add_comment" do
-    it "adds a comment" do
+    it "adds a comment/message" do
       work.add_comment("hello world", user.id)
       activity = work.activities.find { |a| a.message.include?("hello world") }
       expect(activity.created_by_user.id).to eq user.id


### PR DESCRIPTION
- Fix #810: In the meeting, there was discussion about a larger change to the UI, but this seems sufficient for this particular issue.
- Also, find "comment" and replace with "message", but only in the UI: I don't think it's worth the trouble to change all the names internally, but that could be the wrong call.