### PR TITLE
Add license text to the last page of the wizard workflow

### DIFF
--- a/app/views/works/review.html.erb
+++ b/app/views/works/review.html.erb
@@ -1,9 +1,58 @@
 <div class="wizard-area">
   <h1>New Submission (<%= @work.title %>)</h1>
   <%= render "wizard_progress", wizard_step: 3 %>
-  <p>Thanks so much!</p>
+  <p>
+    In order for Princeton University's Princeton Data Commons to reproduce, translate, and distribute
+    your submission for worldwide public access your agreement to the following terms is necessary.
+    Please take a moment to read the terms of this license.
+  </p>
 
-  <p>Data curators are carefully reviewing the submission for accuracy and completeness to make
+  <blockquote style="border: 1px solid; padding: 1em;">
+    <p>
+      By clicking through this license, you (the author(s) or creator(s) or copyright owner(s)) grant to Princeton University the non-exclusive right to reproduce, translate (as defined below), and/or distribute your submission (including the abstract) worldwide in electronic format.
+    </p>
+    <p>
+      You represent that the submission is your original work, and/or that you have
+      the right to grant the rights contained in this license.  You represent that
+      your submission does not, to the best of your knowledge, infringe upon anyone's copyright.
+    </p>
+    <p>
+      Because Princeton University owns the copyright in any work that any member of
+      the University staff (not faculty) creates in the course of his or her assigned duties at the University ("University Work Product"), University Work Products may not be deposited in Princeton Data Commons without first securing the consent of the University supervisor who is responsible for the creation and dissemination the University Work Product.  Such consent must include acknowledgement by the supervisor that the University Work Product can, and will, be made available to the general public.
+    </p>
+    <p>
+      You also represent, to the best of your knowledge, that public distribution of
+      your submission will not violate the personal privacy rights of any group or
+      individual.  You agree that Princeton University may translate the submission to any medium or format for the purpose of preservation.
+    </p>
+    <p>
+      You also agree that Princeton University may keep more than one copy of this
+      submission for purposes of security, back-up, and preservation.
+    </p>
+    <p>
+      If the submission contains material for which you do not hold copyright, you
+      represent that you have obtained the unrestricted permission of the copyright
+      owner to grant Princeton University the rights required by this license, and
+      that such third-party owned material is clearly identified and acknowledged
+      within the text or content of the submission.
+    </p>
+    <p>
+      If the submission is based upon work that has been sponsored or supported by an agency or organization other than Princeton University, you represent that you have fulfilled any right of review or other obligations required by such
+      contract or agreement.
+    </p>
+    <p>
+      Princeton University will not make any alteration, other than as allowed by this license, to your submission.
+    </p>
+    <p>
+      Princeton University reserves the right to make unavailable any content which it deems to be in violation of this agreement, or of applicable local, state or federal law.  Princeton also reserves the right to make content unavailable for limited periods of time so as to perform maintenance on the repository or its contents.
+    </p>
+    <p>
+      Princeton will endeavor to maintain this repository and make its contents
+      available indefinitely.  However, the University reserves the right to terminate this repository and its services should circumstances warrant.  In such a case, Princeton's sole responsibility will be to make a best-faith effort to transfer the content to another repository and/or return the content to its original owner.
+    </p>
+  </blockquote>
+
+  <p>Data curators will review the submission for accuracy and completeness to make
     it more discoverable and reusable. Recommendations will be available in the "unfinished submissions"
     section of this form within 2-5 business days.</p>
 
@@ -12,7 +61,7 @@
       placeholder="(optional) Type here to leave a message for the curators"><%= @work.submission_notes %></textarea>
     <div class="actions">
       <%= link_to "Go Back", work_attachment_select_url(@work, wizard: true), class: "btn btn-secondary" %>
-      <%= submit_tag "Complete", class: "btn btn-primary wizard-next-button" %>
+      <%= submit_tag "Grant License and Complete", class: "btn btn-primary wizard-next-button" %>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
- Fix #764

<img width="410" alt="Screen Shot 2023-01-05 at 12 22 50 PM" src="https://user-images.githubusercontent.com/730388/210842209-cef05335-519f-4bf4-8ecd-e46dc47f03d6.png">


I believe this is a simple way to do what is needed, though it might not be exactly what was envisioned. Some points to consider:
- It does not add a separate page to the wizard: The provided screenshot has "License" as a step preceding "Complete".
- It does not use a fixed-width font for the license-text, nor does it wrap the license text in a scrollable div, both of which are common in license UIs.
- It does not add license-approval as an extra bit of state in the model: Instead I've just added "Grant License" to the button.
- It also does not give an option to proceed without granting the license, which is an option in the DataSpace screenshot.
- ... so there is no need for this text "Not granting the license will not delete your submission..."
- It only has this sentence once, instead of repeating it in the text of the license: "In order for Princeton University's Princeton Data Commons to reproduce, translate, and distribute..."

Finally, it makes one change to the existing text on the page:
```diff
- Data curators are carefully reviewing the submission ...
+ Data curators will review the submission ...
```
This has seemed a little out of place, even with the current workflow, but with the addition of the license approval, it feels less confusing to put the review in the future.

Some of these would be trivial to change, but making license approval an explicit part of work state would be a bit of work.