### PR TITLE
Remove trailing whitespace from message

### DIFF
--- a/app/models/work_activity.rb
+++ b/app/models/work_activity.rb
@@ -119,7 +119,7 @@ class WorkActivity < ApplicationRecord
   #{created_by_user_html}
   #{comment_timestamp_html}
 </div>
-<span class="comment-html">#{children}</span>
+<span class="comment-html">#{children.chomp}</span>
     HTML
     end
 


### PR DESCRIPTION
This CSS:
```
.activity-history-item .comment-html {
  white-space: pre-wrap;
}
```
means that whitespace is preserved when rendering, including trailing whitespace, which is not what we want.

Before this PR:
<img width="204" alt="Screen Shot 2023-01-05 at 1 57 48 PM" src="https://user-images.githubusercontent.com/730388/210859167-5df2dec2-536b-46d2-88aa-99940b59b9a2.png">

After this PR:
<img width="179" alt="Screen Shot 2023-01-05 at 1 52 03 PM" src="https://user-images.githubusercontent.com/730388/210859039-b5d8b4a2-7fb5-42f1-be97-d29726db59db.png">

