### PR TITLE
Simplify handling of related objects

### DIFF
--- a/app/assets/javascripts/edit_work_utils.js
+++ b/app/assets/javascripts/edit_work_utils.js
@@ -66,39 +66,6 @@ $(() => {
   }
 
   // ************************************************ //
-  // Related Objects
-  // related_identifier:, related_identifier_type:, relation_type
-  function addRelatedObjectHtml(num, related_identifier, related_identifier_type, relation_type) {
-    const rowId = `related_object_row_${num}`;
-    const relatedIdentifierId = `related_identifier_${num}`;
-    const relatedIdentifierTypeId = `related_identifier_type_${num}`;
-    const relationTypeId = `relation_type_${num}`;
-    const relatedIdentifierTypeHtml = makeSelectHtml(
-      relatedIdentifierTypeId,
-      related_identifier_type,
-      pdc.datacite.RelatedIdentifierType,
-    );
-    const relationTypeHtml = makeSelectHtml(
-      relationTypeId,
-      relation_type,
-      pdc.datacite.RelationType,
-    );
-
-    const rowHtml = `<tr id="${rowId}" class="related-objects-table-row">
-      <td>
-        <input type="text" id="${relatedIdentifierId}" name="${relatedIdentifierId}" value="${related_identifier}" data-num="${num}" placeholder="The URL web address for a related publication or other resource" />
-      </td>
-      <td>
-        ${relatedIdentifierTypeHtml}
-      </td>
-      <td>
-        ${relationTypeHtml}
-      </td>
-    </tr>`;
-    $('#related-objects-table').append(rowHtml);
-  }
-
-  // ************************************************ //
 
   function addContributorHtml(num, orcid, givenName, familyName, role, sequence) {
     const rowId = `contributor_row_${num}`;
@@ -311,12 +278,6 @@ $(() => {
     return false;
   });
 
-  $('#btn-add-related-object').on('click', (el) => {
-    const num = incrementCounter('#related_object_count');
-    addRelatedObjectHtml(num, '', '', '');
-    return false;
-  });
-
   $('#btn-add-me-creator').on('click', (el) => {
     const num = incrementCounter('#creator_count');
     const orcid = $('#user_orcid').val();
@@ -411,22 +372,6 @@ $(() => {
         creator.familyName,
         creator.sequence,
       );
-    }
-  }
-
-  // Load any existing related objects into the edit form.
-  // If there are any related objects they should appear in hidden <span> tags.
-  if ($('.related-object-data').length == 0) {
-    // Add an empty related object for the user to fill it out
-    const num = incrementCounter('#related_object_count');
-    addRelatedObjectHtml(num, '', '', '');
-  } else {
-    // Add existing related objects for editing
-    for (const related_object of $('.related-object-data')) {
-      const {
-        num, relatedIdentifier, relatedIdentifierType, relationType,
-      } = related_object.dataset;
-      addRelatedObjectHtml(num, relatedIdentifier, relatedIdentifierType, relationType);
     }
   }
 

--- a/app/services/form_to_resource_service.rb
+++ b/app/services/form_to_resource_service.rb
@@ -73,11 +73,8 @@ class FormToResourceService
       # Related Objects:
 
       def add_related_objects(params, resource)
-        resource.related_objects = (1..params["related_object_count"].to_i).filter_map do |i|
-          related_identifier = params["related_identifier_#{i}"]
-          related_identifier_type = params["related_identifier_type_#{i}"]
-          relation_type = params["relation_type_#{i}"]
-          new_related_object(related_identifier, related_identifier_type, relation_type)
+        resource.related_objects = (params[:related_objects] || []).filter_map do |related_object|
+          new_related_object(related_object[:related_identifier], related_object[:related_identifier_type], related_object[:relation_type])
         end
       end
 
@@ -124,7 +121,6 @@ class FormToResourceService
       # Funders:
 
       def add_funders(params, resource)
-        # (New pattern: Use rails param name conventions rather than numbering fields.)
         resource.funders = (params[:funders] || []).filter_map do |funder|
           new_funder(funder[:funder_name], funder[:award_number], funder[:award_uri])
         end

--- a/app/views/works/_form_hidden_fields.html.erb
+++ b/app/views/works/_form_hidden_fields.html.erb
@@ -8,7 +8,6 @@
   <input type="text" id="new_title_count" name="new_title_count" value="0" class="hidden" />
   <input type="text" id="creator_count" name="creator_count" value="<%= @work&.resource&.creators&.count || 0%>" class="hidden" />
   <input type="text" id="contributor_count" name="contributor_count" value="<%= @work&.resource&.contributors&.count || 0%>" class="hidden" />
-  <input type="text" id="related_object_count" name="related_object_count" value="<%= @work&.resource&.related_objects&.count || 0%>" class="hidden" />
   
   <% if @wizard_mode || ( @work&.doi&.present? &&  @work.persisted?) %>
     <input type="text" id="doi" name="doi" value="<%= @work&.resource&.doi %>" class="hidden" />

--- a/app/views/works/_related_objects_table.html.erb
+++ b/app/views/works/_related_objects_table.html.erb
@@ -12,7 +12,37 @@
         <th>Relation Type</th>
       </tr>
     </thead>
-    <tbody id="related-objects-table"></tbody>
+    <tbody id="related-objects-table">
+      <% (@work.resource.related_objects + [nil]).each do |related_object| %>
+        <tr>
+          <td>
+            <input name="related_object[][related_identifier]" value="<%= related_object&.related_identifier %>" />
+          </td>
+          <td>
+            <select name="related_object[][related_identifier_type]">
+              <option value="" ></option>
+              <% ::Datacite::Mapping::RelatedIdentifierType.map(&:value).each do |type| %>
+                <option
+                  value="<%= type %>"
+                  <%= related_object&.related_identifier_type == type ? "selected" : "" %>
+                ><%= type %></option>
+              <% end %>
+            </select>
+          </td>
+          <td>
+            <select name="related_object[][relation_type]">
+              <option value="" ></option>
+              <% ::Datacite::Mapping::RelationType.map(&:value).each do |type| %>
+                <option
+                  value="<%= type %>"
+                  <%= related_object&.relation_type == type ? "selected" : "" %>
+                ><%= type %></option>
+              <% end %>
+            </select>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
     <tfoot>
       <tr>
         <td colspan="3">
@@ -22,14 +52,3 @@
     </tfoot>
   </table>
 </div>
-
-<% if @work %>
-  <% @work.resource.related_objects.each_with_index do |related_object, i| %>
-  <span class="hidden related-object-data"
-    data-num="<%= i + 1 %>"
-    data-related-identifier="<%= related_object.related_identifier %>"
-    data-related-identifier-type="<%= related_object.related_identifier_type %>"
-    data-relation-type="<%= related_object.relation_type %>"
-    ></span>
-  <% end %>
-<% end %>

--- a/spec/services/form_to_resource_service_spec.rb
+++ b/spec/services/form_to_resource_service_spec.rb
@@ -25,10 +25,9 @@ describe FormToResourceService do
         new_creator_count: "1",
         resource_type: "Dataset",
         resource_type_general: "AUDIOVISUAL",
-        related_identifier_1: "",
-        related_identifier_type_1: "",
-        relation_type_1: "",
-        related_object_count: "1"
+        "related_object[][related_identifier]" => "",
+        "related_object[][related_identifier_type]" => "",
+        "related_object[][relation_type]" => "",
       }.with_indifferent_access
     end
     let(:current_user) { FactoryBot.create(:user) }

--- a/spec/system/work_create_spec.rb
+++ b/spec/system/work_create_spec.rb
@@ -43,7 +43,6 @@ RSpec.describe "Form submission for a legacy dataset", type: :system do
       sign_in user
       visit new_work_path(params: { wizard: true })
       fill_in "title_main", with: title
-      expect(find("#related_object_count", visible: false).value).to eq("1")
 
       fill_in "given_name_1", with: "Samantha"
       fill_in "family_name_1", with: "Abrams"
@@ -72,7 +71,6 @@ RSpec.describe "Form submission for a legacy dataset", type: :system do
       find("#rights_identifier").find(:xpath, "option[2]").select_option
       click_on "Curator Controlled"
       fill_in "publication_year", with: issue_date
-      expect(find("#related_object_count", visible: false).value).to eq("1")
       click_on "Additional Metadata"
       fill_in "related_identifier_1", with: "https://related.example.com"
       click_on "Save Work"


### PR DESCRIPTION
Towards
- #760
- #761

This code uses the Datacite enum values, rather than the keys. This PR should be merged first: 
- #798

Tests will break because of inconsistency in the values. Filing as draft until that is resolved.