### PR TITLE
Remove redundant help text on Related Identifier

### DIFF
--- a/app/assets/javascripts/edit_work_utils.js
+++ b/app/assets/javascripts/edit_work_utils.js
@@ -86,7 +86,7 @@ $(() => {
 
     const rowHtml = `<tr id="${rowId}" class="related-objects-table-row">
       <td>
-        <input type="text" id="${relatedIdentifierId}" name="${relatedIdentifierId}" value="${related_identifier}" data-num="${num}" placeholder="The URL web address for a related publication or other resource" />
+        <input type="text" id="${relatedIdentifierId}" name="${relatedIdentifierId}" value="${related_identifier}" data-num="${num}"/>
       </td>
       <td>
         ${relatedIdentifierTypeHtml}

--- a/app/views/works/_related_objects_table.html.erb
+++ b/app/views/works/_related_objects_table.html.erb
@@ -7,7 +7,7 @@
   <table>
     <thead>
       <tr class="header-row">
-        <th>Related Identifier (Example: URI for a related publication or resource)</th>
+        <th>Related Identifier</th>
         <th>Related Identifier Type</th>
         <th>Relation Type</th>
       </tr>


### PR DESCRIPTION
The current placeholder can't actually be read to the end, and we don't include explanatory text in other column headers.

I think the current help text is sufficient, but this is subjective.

after changes, and before:
<img width="634" alt="Screen Shot 2023-01-06 at 4 53 34 PM" src="https://user-images.githubusercontent.com/730388/211106892-8c39dc22-dc0f-4e39-8cb2-7aa559cfd278.png">
