### PR TITLE
Sending a notification to the Depositor and the Collection Administrators when state changes occur

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -32,7 +32,7 @@ class Work < ApplicationRecord
     end
 
     event :complete_submission do
-      transitions from: :draft, to: :awaiting_approval, guard: :valid_to_submit, after: :notify_collection_curators
+      transitions from: :draft, to: :awaiting_approval, guard: :valid_to_submit
     end
 
     event :request_changes do
@@ -505,6 +505,7 @@ class Work < ApplicationRecord
       uw = UserWork.new(user_id: user.id, work_id: id, state: state)
       uw.save!
       WorkActivity.add_system_activity(id, "marked as #{state.to_s.titleize}", user.id)
+      WorkStateTransitionNotification.new(self, user.id).send
     end
 
     def data_cite_connection
@@ -660,12 +661,6 @@ class Work < ApplicationRecord
       # ...and delete them from the pre-curation bucket.
       transferred_files.each(&:purge)
       delete_pre_curation_s3_dir
-    end
-
-    def notify_collection_curators(current_user)
-      curators = collection.administrators.map { |admin| "@#{admin.uid}" }.join(", ")
-      notification = "#{curators} The [work](#{work_url(self)}) is ready for review."
-      WorkActivity.add_system_activity(id, notification, current_user.id)
     end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/models/work_state_transition_notification.rb
+++ b/app/models/work_state_transition_notification.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# Connect with the curators of a work when an activity occurs
+#
+class WorkStateTransitionNotification
+  attr_accessor :collection_administrators, :depositor, :to_state, :from_state,
+                :work_url, :notification, :users, :id, :current_user_id
+
+  def initialize(work, current_user_id)
+    @to_state = work.aasm.to_state
+    @from_state = work.aasm.from_state
+    @depositor = work.created_by_user
+    @collection_administrators = work.collection.administrators.to_a
+    @work_url = Rails.application.routes.url_helpers.work_url(work)
+    @users = @collection_administrators + [@depositor]
+    @notification = notification_for_transition
+    @id = work.id
+    @current_user_id = current_user_id
+  end
+
+  def send
+    return if notification.nil?
+
+    WorkActivity.add_system_activity(id, notification, current_user_id, activity_type: WorkActivity::SYSTEM)
+  end
+
+    private
+
+      def notification_for_transition
+        case to_state
+        when :awaiting_approval
+          "#{user_tags} The [work](#{work_url}) is ready for review."
+        when :draft
+          "#{user_tags} The [work](#{work_url}) has been created."
+        when :approved
+          "#{user_tags} The [work](#{work_url}) has been approved."
+        end
+      end
+
+      def user_tags
+        users.map { |admin| "@#{admin.uid}" }.join(", ")
+      end
+end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -48,6 +48,7 @@ Rails.application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
+  config.active_job.queue_adapter = :test
 
   config.action_mailer.default_options = {
     from: "noreply@example.com"

--- a/spec/factories/work.rb
+++ b/spec/factories/work.rb
@@ -2,6 +2,16 @@
 
 FactoryBot.define do
   factory :work do
+    factory :none_work do
+      transient do
+        doi { "10.34770/123-abc" }
+      end
+      collection { Collection.research_data }
+      state { "none" }
+      created_by_user_id { FactoryBot.create(:user).id }
+      resource { FactoryBot.build :resource, doi: doi }
+    end
+
     factory :draft_work do
       transient do
         doi { "10.34770/123-abc" }

--- a/spec/models/work_state_spec.rb
+++ b/spec/models/work_state_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe "Work state transions", type: :model do
+  let(:work) { FactoryBot.create(:none_work) }
+
+  let(:curator_user) { FactoryBot.create :user, collections_to_admin: [work.collection] }
+
+  it "Creates a work activity notification for the curator & the user when drafted" do
+    curator_user # make sure the curator exists
+    expect do
+      work.draft!(work.created_by_user)
+    end.to change { WorkActivity.count }.by(2)
+       .and change { WorkActivityNotification.count }.by(2)
+  end
+
+  context "a draft work" do
+    let(:work) { FactoryBot.create(:draft_work) }
+
+    it "Creates a work activity notification for the curator & the user when completed" do
+      curator_user # make sure the curator exists
+      expect do
+        work.complete_submission!(work.created_by_user)
+      end.to change { WorkActivity.count }.by(2)
+         .and change { WorkActivityNotification.count }.by(2)
+    end
+  end
+
+  context "a completed work" do
+    let(:work) { FactoryBot.create(:awaiting_approval_work) }
+
+    it "Creates a work activity notification for the curator & the user when approved" do
+      allow(work).to receive(:publish)
+      expect do
+        work.approve!(curator_user)
+      end.to change { WorkActivity.count }.by(2)
+         .and change { WorkActivityNotification.count }.by(2)
+    end
+  end
+end

--- a/spec/system/work_create_spec.rb
+++ b/spec/system/work_create_spec.rb
@@ -91,15 +91,22 @@ RSpec.describe "Form submission for a legacy dataset", type: :system do
 
       expect(page).to have_content "awaiting_approval"
 
+      visit(user_path(user))
+      # This is the blue badge on the work that should show up for a submitter
+      #  when a work is started and marked completed by a submitter
+      within("#unfinished_datasets span.badge.rounded-pill.bg-primary") do
+        expect(page).to have_content "2"
+      end
+
       # Now sign is as the collection curator and see the notification on your dashboard
       sign_out user
       sign_in curator
       visit(user_path(curator))
       expect(page).to have_content curator.display_name
       # This is the blue badge on the work that should show up for a curator
-      #  when a work is marked completed by a submitter
+      #  when a work is startend and marked completed by a submitter
       within("#unfinished_datasets span.badge.rounded-pill.bg-primary") do
-        expect(page).to have_content "1"
+        expect(page).to have_content "2"
       end
     end
   end


### PR DESCRIPTION
Moves the code from the Work Model to it's own class WorkStateTransitionNotification

refs #675 

This is related to #831, but it leaves the notification as SYSTEM messages, which means they will show up in the comments/messages section of the work.

This is the smallest change to advance #675 without implementing a Notification screen we do not know if the curators will want.

The only unfortunate part of this change is that the Depositor and the Curators receive the same note. If we sent two different ones then the comments/message section would grow even more.  This may be good enough.  I could see that it would be nice to tell the depositor that this is just a receipt and that no action is required on their part for any of the notifications.