### PR TITLE
Find "comment" replace with "message"

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -126,7 +126,7 @@ input[readonly] {
   background: #f4f4f4;
 }
 
-.activity-history-item .comment-html {
+.activity-history-item .message-html {
   // For all fields we just do a string diff;
   // For arrays, we join the values with "\n",
   // but we need to make sure this is preserved when rendered.

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -67,7 +67,7 @@ class WorksController < ApplicationController
     # check if anything was added in S3 since we last viewed this object
     @work.attach_s3_resources
     @changes = @work.changes
-    @comments = @work.comments
+    @messages = @work.messages
 
     respond_to do |format|
       format.html do
@@ -222,13 +222,13 @@ class WorksController < ApplicationController
     render json: { errors: ["Cannot save dataset"] }, status: :bad_request
   end
 
-  def add_comment
+  def add_message
     work = Work.find(params[:id])
-    if params["new-comment"].present?
-      new_comment_param = params["new-comment"]
-      sanitized_new_comment = html_escape(new_comment_param)
+    if params["new-message"].present?
+      new_message_param = params["new-message"]
+      sanitized_new_message = html_escape(new_message_param)
 
-      work.add_comment(sanitized_new_comment, current_user.id)
+      work.add_message(sanitized_new_message, current_user.id)
     end
     redirect_to work_path(id: params[:id])
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -143,7 +143,7 @@ class User < ApplicationRecord
   end
 
   # Returns a string with the UID (netid) for all the users.
-  # We use this string to power the JavaScript @mention functionality when adding comments to works.
+  # We use this string to power the JavaScript @mention functionality when adding messages to works.
   def self.all_uids_string
     User.all.map { |user| '"' + user.uid + '"' }.join(", ")
   end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -302,8 +302,8 @@ class Work < ApplicationRecord
     persisted.uid
   end
 
-  def add_comment(comment, current_user_id)
-    WorkActivity.add_system_activity(id, comment, current_user_id, activity_type: WorkActivity::COMMENT)
+  def add_message(message, current_user_id)
+    WorkActivity.add_system_activity(id, message, current_user_id, activity_type: WorkActivity::MESSAGE)
   end
 
   def log_changes(resource_compare, current_user_id)
@@ -324,8 +324,8 @@ class Work < ApplicationRecord
     activities.select(&:log_event_type?)
   end
 
-  def comments
-    activities.select(&:comment_event_type?)
+  def messages
+    activities.select(&:message_event_type?)
   end
 
   def new_notification_count_for_user(user_id)

--- a/app/models/work_activity.rb
+++ b/app/models/work_activity.rb
@@ -91,7 +91,6 @@ class WorkActivity < ApplicationRecord
       message_html
     end
   end
-  alias message_html to_html
 
   private
 

--- a/app/models/work_activity.rb
+++ b/app/models/work_activity.rb
@@ -5,7 +5,7 @@ require_relative "../lib/diff_tools"
 # rubocop:disable Metrics/ClassLength
 class WorkActivity < ApplicationRecord
   CHANGES = "CHANGES"
-  MESSAGE = "COMMENT" # TODO: Migrate existing records to "MESSAGE"
+  MESSAGE = "COMMENT" # TODO: Migrate existing records to "MESSAGE"; then close #825.
   FILE_CHANGES = "FILE-CHANGES"
   SYSTEM = "SYSTEM"
   USER_REFERENCE = /@[\w]*/.freeze # e.g. @xy123

--- a/app/models/work_activity.rb
+++ b/app/models/work_activity.rb
@@ -5,7 +5,7 @@ require_relative "../lib/diff_tools"
 # rubocop:disable Metrics/ClassLength
 class WorkActivity < ApplicationRecord
   CHANGES = "CHANGES"
-  COMMENT = "COMMENT"
+  MESSAGE = "COMMENT" # TODO: Migrate existing records to "MESSAGE"
   FILE_CHANGES = "FILE-CHANGES"
   SYSTEM = "SYSTEM"
   USER_REFERENCE = /@[\w]*/.freeze # e.g. @xy123
@@ -54,8 +54,8 @@ class WorkActivity < ApplicationRecord
     "Unknown user outside the system"
   end
 
-  def comment_event_type?
-    activity_type == COMMENT
+  def message_event_type?
+    activity_type == MESSAGE
   end
 
   def changes_event_type?
@@ -75,8 +75,8 @@ class WorkActivity < ApplicationRecord
   end
 
   def event_type
-    if comment_event_type?
-      "comment"
+    if message_event_type?
+      "message"
     else
       "log"
     end
@@ -88,7 +88,7 @@ class WorkActivity < ApplicationRecord
     elsif file_changes_event_type?
       file_changes_html
     else
-      comment_html
+      message_html
     end
   end
   alias message_html to_html
@@ -108,8 +108,8 @@ class WorkActivity < ApplicationRecord
     end
 
     # This is working
-    def comment_timestamp_html
-      "at #{event_timestamp}" if comment_event_type?
+    def message_timestamp_html
+      "at #{event_timestamp}" if message_event_type?
     end
 
     def title_html
@@ -117,13 +117,13 @@ class WorkActivity < ApplicationRecord
 <span class="activity-history-title">
   #{event_timestamp_html}
   #{created_by_user_html}
-  #{comment_timestamp_html}
+  #{message_timestamp_html}
 </span>
       HTML
     end
 
     def event_html(children:)
-      title_html + "<span class='comment-html'>#{children.chomp}</span>"
+      title_html + "<span class='message-html'>#{children.chomp}</span>"
     end
 
     # Returns the message formatted to display _file_ changes that were logged as an activity
@@ -151,14 +151,14 @@ class WorkActivity < ApplicationRecord
         change = changes[field]
         mapped = change.map { |value| change_value_html(value) }
         values = mapped.join
-        html += "<details class='comment-html'><summary class='show-changes'>#{field}</summary>#{values}</details>"
+        html += "<details class='message-html'><summary class='show-changes'>#{field}</summary>#{values}</details>"
       end
 
       html
     end
 
     # rubocop:disable Metrics/MethodLength
-    def comment_html
+    def message_html
       # convert user references to user links
       text = message.gsub(USER_REFERENCE) do |at_uid|
         uid = at_uid[1..-1]
@@ -173,7 +173,7 @@ class WorkActivity < ApplicationRecord
                       end
         end
 
-        "<a class='comment-user-link' title='#{user_info}' href='#{users_path}/#{uid}'>#{at_uid}</a>"
+        "<a class='message-user-link' title='#{user_info}' href='#{users_path}/#{uid}'>#{at_uid}</a>"
       end
 
       # allow ``` for code blocks (Kramdown only supports ~~~)

--- a/app/views/works/_work_activity_history.html.erb
+++ b/app/views/works/_work_activity_history.html.erb
@@ -1,10 +1,10 @@
 <div>
   <h2>Messages</h2>
-  <% if @comments.size == 0 && !@work.submission_notes.present? %>
+  <% if @messages.size == 0 && !@work.submission_notes.present? %>
     No messages
   <% end %>
   <ul class="no-beads">
-    <% @comments.each do |activity| %>
+    <% @messages.each do |activity| %>
       <%= render partial: 'work_activity', locals: {
         activity: activity,
         event_type: activity.event_type
@@ -22,12 +22,12 @@
     <% end %>
   </ul>
 
-  <div id="new-comment-section">
-    <%= form_with url: add_comment_work_path(@work) do |f| %>
-      <textarea id="new-comment" name="new-comment" class="new-comment" placeholder="leave a message" rows="5" cols="100"></textarea>
+  <div id="new-message-section">
+    <%= form_with url: add_message_work_path(@work) do |f| %>
+      <textarea id="new-message" name="new-message" class="new-message" placeholder="leave a message" rows="5" cols="100"></textarea>
       <br/>
       <%= f.submit("Message", class: "btn btn-secondary") %>
-      <span class="new-comment-help">
+      <span class="new-message-help">
         Simple Markdown is accepted, e.g. *italics*, **bold**, # Header 1, ## Header 2, ```code```. Use @netid to refer to others.
       </span>
     <% end %>

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -3,11 +3,11 @@
     display: inline;
   }
 
-  .new-comment {
+  .new-message {
     margin-bottom: 5px;
   }
 
-  .new-comment-help {
+  .new-message-help {
     color: #aca9a9;
     font-size: 12px;
   }
@@ -16,11 +16,11 @@
     font-weight: bold;
   }
 
-  .comment-html > p {
+  .message-html > p {
     margin-bottom: 0px;
   }
 
-  .comment-html h1, .comment-html h2, .comment-html h3, .comment-html h4, .comment-html h5, .comment-html h6 {
+  .message-html h1, .message-html h2, .message-html h3, .message-html h4, .message-html h5, .message-html h6 {
     font-weight: bold;
     font-size: 100%;
     display: table;
@@ -28,39 +28,39 @@
     padding: 1px;
   }
 
-  .comment-html h1 {
+  .message-html h1 {
     padding-bottom: 2px;
     border-bottom: 4px solid gray;
   }
 
-  .comment-html h2 {
+  .message-html h2 {
     padding-bottom: 1.5px;
     border-bottom: 2px solid gray;
   }
 
-  .comment-html h3 {
+  .message-html h3 {
     border-bottom: 1px solid gray;
   }
 
-  .comment-html h4 {
+  .message-html h4 {
     border: 1px solid gray;
     padding: 1px 4px;
   }
 
-  .comment-html h5 {
+  .message-html h5 {
     font-weight: normal;
     border: 1px solid gray;
     padding: 1px 4px;
   }
 
-  .comment-html h6 {
+  .message-html h6 {
     font-weight: normal;
     font-size: small;
     border: 1px solid gray;
     padding: 1px 4px;
   }
 
-  .comment-user-link {
+  .message-user-link {
     color: rgb(36, 41, 47);
     background-color: rgb(255, 248, 197);
     text-decoration-color: rgb(36, 41, 47);
@@ -275,13 +275,13 @@
 
     // triggeredAutocomplete (https://github.com/Hawkers/triggeredAutocomplete) is a plug-in
     // that sits on top of jQuery UI autocomplete and provides the @mention functionaly to
-    // reference other users via their netid in a message/comment.
+    // reference other users via their netid in a message.
     //
     // Notice that https://github.com/Hawkers/triggeredAutocomplete also supports passing an
     // array of objects with structure {value: x, label: y} to display a more user friendly
     // label rather than the netid, but this approach carries another set of complications
     // (e.g. how to handle spaces, how to edit)
-    $('#new-comment').triggeredAutocomplete({
+    $('#new-message').triggeredAutocomplete({
       hidden: '#hidden_inputbox',
       source: userList,
       trigger: "@"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,7 @@ Rails.application.routes.draw do
   post "work/:id/approve", to: "works#approve", as: :approve_work
   post "work/:id/withdraw", to: "works#withdraw", as: :withdraw_work
   post "work/:id/resubmit", to: "works#resubmit", as: :resubmit_work
-  post "work/:id/add-comment", to: "works#add_comment", as: :add_comment_work
+  post "work/:id/add-message", to: "works#add_message", as: :add_message_work
   put "works/:id/assign-curator/:uid", to: "works#assign_curator", as: :work_assign_curator
   get "works/:id/datacite", to: "works#datacite", as: :datacite_work
   get "works/:id/datacite/validate", to: "works#datacite_validate", as: :datacite_validate_work

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -1014,19 +1014,19 @@ RSpec.describe WorksController do
       expect(response.body).to eq '{"errors":["Cannot save dataset"]}'
     end
 
-    it "posts a comment/message" do
+    it "posts a message" do
       sign_in user
-      post :add_comment, params: { id: work.id, "new-comment" => "hello world" }
+      post :add_message, params: { id: work.id, "new-message" => "hello world" }
       expect(response.status).to be 302
       expect(response.location).to eq "http://test.host/works/#{work.id}"
     end
 
-    context "when posting a comment/message containing HTML" do
+    context "when posting a message containing HTML" do
       render_views
 
-      it "posts a comment/message with sanitized HTML" do
+      it "posts a message with sanitized HTML" do
         sign_in user
-        post :add_comment, params: { id: work.id, "new-comment" => "<div>hello world</div>" }
+        post :add_message, params: { id: work.id, "new-message" => "<div>hello world</div>" }
         expect(response.status).to be 302
         expect(response.location).to eq "http://test.host/works/#{work.id}"
         stub_s3

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -381,8 +381,8 @@ RSpec.describe Work, type: :model do
       message = "taggging @#{curator_user.uid} and @#{user_other.uid}"
       work.add_message(message, user.id)
       activity = work.activities.find { |a| a.message.include?(message) }
-      expect(activity.message_html.include?("#{curator_user.uid}</a>")).to be true
-      expect(activity.message_html.include?("#{user_other.uid}</a>")).to be true
+      expect(activity.to_html.include?("#{curator_user.uid}</a>")).to be true
+      expect(activity.to_html.include?("#{user_other.uid}</a>")).to be true
     end
   end
 

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -356,20 +356,20 @@ RSpec.describe Work, type: :model do
     end
   end
 
-  describe "#add_comment" do
-    it "adds a comment/message" do
-      work.add_comment("hello world", user.id)
+  describe "#add_message" do
+    it "adds a message" do
+      work.add_message("hello world", user.id)
       activity = work.activities.find { |a| a.message.include?("hello world") }
       expect(activity.created_by_user.id).to eq user.id
-      expect(activity.activity_type).to eq "COMMENT"
+      expect(activity.activity_type).to eq WorkActivity::MESSAGE
     end
 
     it "logs notifications" do
       expect(work.new_notification_count_for_user(user.id)).to eq 0
       expect(work.new_notification_count_for_user(curator_user.id)).to eq 0
 
-      work.add_comment("taggging @#{curator_user.uid}", user.id)
-      work2.add_comment("taggging @#{curator_user.uid}", user.id)
+      work.add_message("taggging @#{curator_user.uid}", user.id)
+      work2.add_message("taggging @#{curator_user.uid}", user.id)
       expect(work.new_notification_count_for_user(user.id)).to eq 0
       expect(work.new_notification_count_for_user(curator_user.id)).to eq 1
 
@@ -379,7 +379,7 @@ RSpec.describe Work, type: :model do
 
     it "parses tagged users correctly" do
       message = "taggging @#{curator_user.uid} and @#{user_other.uid}"
-      work.add_comment(message, user.id)
+      work.add_message(message, user.id)
       activity = work.activities.find { |a| a.message.include?(message) }
       expect(activity.message_html.include?("#{curator_user.uid}</a>")).to be true
       expect(activity.message_html.include?("#{user_other.uid}</a>")).to be true

--- a/spec/requests/works_spec.rb
+++ b/spec/requests/works_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "/works", type: :request do
         before do
           allow(work).to receive(:id).and_return("test-id")
           allow(work).to receive(:changes).and_return([])
-          allow(work).to receive(:comments).and_return([])
+          allow(work).to receive(:messages).and_return([])
           allow(work).to receive(:collection).and_return(nil)
           allow(work).to receive(:attach_s3_resources)
 


### PR DESCRIPTION
- Towards #825

"Towards" rather than "Fixes" because of this one line:
```diff
class WorkActivity < ApplicationRecord
  ...
-  COMMENT = "COMMENT"
+  MESSAGE = "COMMENT" # TODO: Migrate existing records to "MESSAGE"; then close #825.
```
Seems a little bit safer to separate the db migration work from the bulk of the renaming.

There was one odd alias:
```diff
-  alias message_html to_html
```
The `message_html` alias wasn't referenced except for a couple tests, but it would now conflict with the private former `comment_html`, so I got rid of it.

Everything else was just search and replace.