### PR TITLE
Add a note to README explaining DataSpace migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,7 @@ An early stages Entity-Relationship Diagram (ERD) is available in [this Google D
 
 ### Sample Data
 Sample data available here: https://docs.google.com/document/d/18ZkBldqWxIIR1UA6qMY87RnGFTKU9HG3EJzodzzFf2A/edit
+
+## Notes on migration process from DataSpace
+
+Datasets are re-described in order to migrate its metadata from modified Dublin Core to modified DataCite, and to migrate location from Princeton's legacy DataSpace repository to the DataCite compliant Princeton Data Commons suite of applications.


### PR DESCRIPTION
From the conversation in:
- #718

... we identified one necessary piece as the work now in: 
- #839

... but @hhkitsune also [wrote](https://github.com/pulibrary/pdc_describe/issues/718#issuecomment-1348832476)
> I like this statement though and want to see it in our documentation for the repository. It belongs with further detailed description of the migration, rather than in the provenance log.

I don't think an issue was filed for this task, but adding it to the README seems reasonable. Phrasing changed slightly to address the process in general instead of one particular item.