### PR TITLE
Let admins add free-text, back-dated messages to change-history

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -237,7 +237,7 @@ class WorksController < ApplicationController
     work = Work.find(params[:id])
     if params["new-provenance-note"].present?
       new_date = params["new-provenance-date"]
-      new_note = params["new-provenance-note"]
+      new_note = html_escape(params["new-provenance-note"])
 
       work.add_provenance_note(new_date, new_note, current_user.id)
     end

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -233,6 +233,17 @@ class WorksController < ApplicationController
     redirect_to work_path(id: params[:id])
   end
 
+  def add_provenance_note
+    work = Work.find(params[:id])
+    if params["new-provenance-note"].present?
+      new_date = params["new-provenance-date"]
+      new_note = params["new-provenance-note"]
+
+      work.add_provenance_note(new_date, new_note, current_user.id)
+    end
+    redirect_to work_path(id: params[:id])
+  end
+
   # Outputs the Datacite XML representation of the work
   def datacite
     work = Work.find(params[:id])

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -307,7 +307,7 @@ class Work < ApplicationRecord
   end
 
   def add_provenance_note(date, note, current_user_id)
-    WorkActivity.add_system_activity(id, note, current_user_id, activity_type: WorkActivity::PROVENANCE_NOTES)
+    WorkActivity.add_system_activity(id, note, current_user_id, activity_type: WorkActivity::PROVENANCE_NOTES, date: date)
   end
 
   def log_changes(resource_compare, current_user_id)

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -306,6 +306,10 @@ class Work < ApplicationRecord
     WorkActivity.add_system_activity(id, message, current_user_id, activity_type: WorkActivity::MESSAGE)
   end
 
+  def add_provenance_note(date, note, current_user_id)
+    WorkActivity.add_system_activity(id, note, current_user_id, activity_type: WorkActivity::PROVENANCE_NOTES)
+  end
+
   def log_changes(resource_compare, current_user_id)
     return if resource_compare.identical?
     WorkActivity.add_system_activity(id, resource_compare.differences.to_json, current_user_id, activity_type: WorkActivity::CHANGES)

--- a/app/models/work_activity.rb
+++ b/app/models/work_activity.rb
@@ -16,13 +16,13 @@ class WorkActivity < ApplicationRecord
   belongs_to :work
   has_many :work_activity_notifications, dependent: :destroy
 
-  def self.add_system_activity(work_id, message, user_id, activity_type: "SYSTEM")
+  def self.add_system_activity(work_id, message, user_id, activity_type: "SYSTEM", date: nil)
     activity = WorkActivity.new(
       work_id: work_id,
       activity_type: activity_type,
       message: message,
       created_by_user_id: user_id,
-      created_at: "2012-02-27 00:00:00"
+      created_at: date # If nil, will be set by activerecord at save.
     )
     activity.save!
     activity.notify_users

--- a/app/models/work_activity.rb
+++ b/app/models/work_activity.rb
@@ -8,6 +8,7 @@ class WorkActivity < ApplicationRecord
   MESSAGE = "COMMENT" # TODO: Migrate existing records to "MESSAGE"; then close #825.
   FILE_CHANGES = "FILE-CHANGES"
   SYSTEM = "SYSTEM"
+  PROVENANCE_NOTES = "PROVENANCE-NOTES"
   USER_REFERENCE = /@[\w]*/.freeze # e.g. @xy123
 
   include Rails.application.routes.url_helpers
@@ -20,7 +21,8 @@ class WorkActivity < ApplicationRecord
       work_id: work_id,
       activity_type: activity_type,
       message: message,
-      created_by_user_id: user_id
+      created_by_user_id: user_id,
+      created_at: "2012-02-27 00:00:00"
     )
     activity.save!
     activity.notify_users
@@ -70,8 +72,12 @@ class WorkActivity < ApplicationRecord
     activity_type == SYSTEM
   end
 
+  def provenance_notes_type?
+    activity_type == PROVENANCE_NOTES
+  end
+
   def log_event_type?
-    system_event_type? || file_changes_event_type? || changes_event_type?
+    system_event_type? || file_changes_event_type? || changes_event_type? || provenance_notes_type?
   end
 
   def event_type

--- a/app/views/works/_work_activity_history.html.erb
+++ b/app/views/works/_work_activity_history.html.erb
@@ -40,7 +40,7 @@
     No activity
   <% end %>
   <ul class="beads">
-    <% @changes.each do |activity| %>
+    <% @changes.sort_by(&:created_at).reverse.each do |activity| %>
       <%= render partial: 'work_activity', locals: {
         activity: activity,
         event_type: activity.event_type
@@ -52,7 +52,8 @@
     <div class="field">
       <details>
         <summary>Date</summary>
-        The date in the change history your note should be given.
+        The date in the change history your note should be given. Format as "YYY-MM-DD".
+        Leave blank to use the current date and time.
       </details>
       <input id="new-provenance-date" name="new-provenance-date" ></textarea>
     </div>
@@ -60,7 +61,7 @@
     <div class="field">
       <details>
         <summary>Note</summary>
-        The note to add to the change history.
+        The note to add to the change history. Markdown can be used.
       </details>
       <input id="new-provenance-note" name="new-provenance-note" ></textarea>
     </div>

--- a/app/views/works/_work_activity_history.html.erb
+++ b/app/views/works/_work_activity_history.html.erb
@@ -48,24 +48,26 @@
     <% end %>
   </ul>
 
-  <%= form_with url: add_provenance_note_path(@work) do |f| %>
-    <div class="field">
-      <details>
-        <summary>Date</summary>
-        The date in the change history your note should be given. Format as "YYY-MM-DD".
-        Leave blank to use the current date and time.
-      </details>
-      <input id="new-provenance-date" name="new-provenance-date" ></textarea>
-    </div>
-    
-    <div class="field">
-      <details>
-        <summary>Note</summary>
-        The note to add to the change history. Markdown can be used.
-      </details>
-      <input id="new-provenance-note" name="new-provenance-note" ></textarea>
-    </div>
+  <% if ["cm7575"].include? current_user.uid %>
+    <%= form_with url: add_provenance_note_path(@work) do |f| %>
+      <div class="field">
+        <details>
+          <summary>Date</summary>
+          The date in the change history your note should be given. Format as "YYY-MM-DD".
+          Leave blank to use the current date and time.
+        </details>
+        <input id="new-provenance-date" name="new-provenance-date" ></textarea>
+      </div>
+      
+      <div class="field">
+        <details>
+          <summary>Note</summary>
+          The note to add to the change history. Markdown can be used.
+        </details>
+        <input id="new-provenance-note" name="new-provenance-note" ></textarea>
+      </div>
 
-    <%= f.submit("Add Provenance Note", class: "btn btn-secondary") %>
+      <%= f.submit("Add Provenance Note", class: "btn btn-secondary") %>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/works/_work_activity_history.html.erb
+++ b/app/views/works/_work_activity_history.html.erb
@@ -47,4 +47,24 @@
       } %>
     <% end %>
   </ul>
+
+  <%= form_with url: add_provenance_note_path(@work) do |f| %>
+    <div class="field">
+      <details>
+        <summary>Date</summary>
+        The date in the change history your note should be given.
+      </details>
+      <input id="new-provenance-date" name="new-provenance-date" ></textarea>
+    </div>
+    
+    <div class="field">
+      <details>
+        <summary>Note</summary>
+        The note to add to the change history.
+      </details>
+      <input id="new-provenance-note" name="new-provenance-note" ></textarea>
+    </div>
+
+    <%= f.submit("Add Provenance Note", class: "btn btn-secondary") %>
+  <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
   post "work/:id/withdraw", to: "works#withdraw", as: :withdraw_work
   post "work/:id/resubmit", to: "works#resubmit", as: :resubmit_work
   post "work/:id/add-message", to: "works#add_message", as: :add_message_work
+  post "work/:id/add-provenance-note", to: "works#add_provenance_note", as: :add_provenance_note
   put "works/:id/assign-curator/:uid", to: "works#assign_curator", as: :work_assign_curator
   get "works/:id/datacite", to: "works#datacite", as: :datacite_work
   get "works/:id/datacite/validate", to: "works#datacite_validate", as: :datacite_validate_work

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -1021,6 +1021,13 @@ RSpec.describe WorksController do
       expect(response.location).to eq "http://test.host/works/#{work.id}"
     end
 
+    it "posts a message" do
+      sign_in user
+      post :add_provenance_note, params: { id: work.id, "new-provenance-note" => "hello world", "new-provenance-date" => "2000-01-01" }
+      expect(response.status).to be 302
+      expect(response.location).to eq "http://test.host/works/#{work.id}"
+    end
+
     context "when posting a message containing HTML" do
       render_views
 

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -1021,15 +1021,18 @@ RSpec.describe WorksController do
       expect(response.location).to eq "http://test.host/works/#{work.id}"
     end
 
-    it "posts a message" do
-      sign_in user
-      post :add_provenance_note, params: { id: work.id, "new-provenance-note" => "hello world", "new-provenance-date" => "2000-01-01" }
-      expect(response.status).to be 302
-      expect(response.location).to eq "http://test.host/works/#{work.id}"
-    end
-
     context "when posting a message containing HTML" do
       render_views
+
+      it "adds to change history with a date and markdown" do
+        sign_in user
+        post :add_provenance_note, params: { id: work.id, "new-provenance-note" => "<span>hello</span> _world_", "new-provenance-date" => "2000-01-01" }
+        expect(response.status).to be 302
+        expect(response.location).to eq "http://test.host/works/#{work.id}"
+        get :show, params: { id: work.id }
+        expect(response.body).to include("&lt;span&gt;hello&lt;/span&gt; <em>world</em>")
+        expect(response.body).to include("January 01, 2000")
+      end
 
       it "posts a message with sanitized HTML" do
         sign_in user


### PR DESCRIPTION
- Replace #839
- Fix #720

Notes: 
- User list is hard-coded, as indicated in the issue: I'm the only one on it for now: please add netIDs as needed.
- On the screen we're calling this the "Change History", but I also hear "Provenance" -- It looks like the name "provenance" hasn't really be used in the code before, so I would changes this to "change-history"... unless we should be moving existing references to "provenance"?
- There's no validation of the date string; there could be. The Rails date parsing has some strange behavior:

```
January 12, 2023 00:00 by Chuck
Date was "12"

January 11, 2023 16:35 by Chuck
Date was "1234"

January 11, 2023 00:00 by Chuck
Date was "123"

January 01, 0012 00:00 by Chuck
Date was "12345"
```

<img width="646" alt="Screen Shot 2023-01-11 at 4 27 52 PM" src="https://user-images.githubusercontent.com/730388/211922509-987e9989-9bdf-482f-9c34-d18b7b6f3934.png">
