### PR TITLE
Add a placeholder and client-side validation to provenance notes

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -233,3 +233,7 @@ ul.no-beads {
     padding: 5px;
   }
 }
+
+input:invalid {
+  box-shadow: 0 0 10px red;
+}

--- a/app/views/works/_work_activity_history.html.erb
+++ b/app/views/works/_work_activity_history.html.erb
@@ -56,7 +56,9 @@
           The date in the change history your note should be given. Format as "YYY-MM-DD".
           Leave blank to use the current date and time.
         </details>
-        <input id="new-provenance-date" name="new-provenance-date" ></textarea>
+        <input id="new-provenance-date" name="new-provenance-date"
+          placeholder="YYYY-MM-DD"
+          pattern="\d{4}-\d{2}-\d{2}">
       </div>
       
       <div class="field">
@@ -64,7 +66,7 @@
           <summary>Note</summary>
           The note to add to the change history. Markdown can be used.
         </details>
-        <input id="new-provenance-note" name="new-provenance-note" ></textarea>
+        <input id="new-provenance-note" name="new-provenance-note">
       </div>
 
       <%= f.submit("Add Provenance Note", class: "btn btn-secondary") %>

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -1036,6 +1036,10 @@ RSpec.describe WorksController do
 
       it "posts a message with sanitized HTML" do
         sign_in user
+        # The ERB only shows the form to a subset of users,
+        # but the endpoint has no such restriction: Anyone can POST.
+        # In some contexts, a hole like this would be a security problem,
+        # but this is low-stakes.
         post :add_message, params: { id: work.id, "new-message" => "<div>hello world</div>" }
         expect(response.status).to be 302
         expect(response.location).to eq "http://test.host/works/#{work.id}"


### PR DESCRIPTION
Clean up
- #848 

I don't think we've used client side validation before: I thought this could be a little bit helpful, but it's not essential.