### PR TITLE
Moving Notification  on State Change out of the System ActivityType

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -66,8 +66,8 @@ class WorksController < ApplicationController
     @work = Work.find(params[:id])
     # check if anything was added in S3 since we last viewed this object
     @work.attach_s3_resources
-    @changes = @work.changes
-    @messages = @work.messages
+    @changes =  WorkActivity.changes_for_work(@work.id)
+    @messages = WorkActivity.messages_for_work(@work.id)
 
     respond_to do |format|
       format.html do

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -322,15 +322,7 @@ class Work < ApplicationRecord
   end
 
   def activities
-    WorkActivity.where(work_id: id).sort_by(&:updated_at).reverse
-  end
-
-  def changes
-    activities.select(&:log_event_type?)
-  end
-
-  def messages
-    activities.select(&:message_event_type?)
+    WorkActivity.activities_for_work(id)
   end
 
   def new_notification_count_for_user(user_id)

--- a/app/models/work_state_transition_notification.rb
+++ b/app/models/work_state_transition_notification.rb
@@ -4,7 +4,7 @@
 #
 class WorkStateTransitionNotification
   attr_accessor :collection_administrators, :depositor, :to_state, :from_state,
-                :work_url, :notification, :users, :id, :current_user_id
+                :work_url, :notification, :users, :id, :current_user_id, :work_title
 
   def initialize(work, current_user_id)
     @to_state = work.aasm.to_state
@@ -12,6 +12,7 @@ class WorkStateTransitionNotification
     @depositor = work.created_by_user
     @collection_administrators = work.collection.administrators.to_a
     @work_url = Rails.application.routes.url_helpers.work_url(work)
+    @work_title = work.title
     @users = @collection_administrators + [@depositor]
     @notification = notification_for_transition
     @id = work.id
@@ -21,7 +22,7 @@ class WorkStateTransitionNotification
   def send
     return if notification.nil?
 
-    WorkActivity.add_system_activity(id, notification, current_user_id, activity_type: WorkActivity::SYSTEM)
+    WorkActivity.add_system_activity(id, notification, current_user_id, activity_type: WorkActivity::NOTIFICATION)
   end
 
     private
@@ -29,11 +30,11 @@ class WorkStateTransitionNotification
       def notification_for_transition
         case to_state
         when :awaiting_approval
-          "#{user_tags} The [work](#{work_url}) is ready for review."
+          "#{user_tags} [#{work_title}](#{work_url}) is ready for review."
         when :draft
-          "#{user_tags} The [work](#{work_url}) has been created."
+          "#{user_tags} [#{work_title}](#{work_url}) has been created."
         when :approved
-          "#{user_tags} The [work](#{work_url}) has been approved."
+          "#{user_tags} [#{work_title}](#{work_url}) has been approved."
         end
       end
 

--- a/app/views/works/_work_activity_history.html.erb
+++ b/app/views/works/_work_activity_history.html.erb
@@ -3,7 +3,7 @@
   <% if @messages.size == 0 && !@work.submission_notes.present? %>
     No messages
   <% end %>
-  <ul class="no-beads">
+  <ul class="no-beads work-messages">
     <% @messages.each do |activity| %>
       <%= render partial: 'work_activity', locals: {
         activity: activity,

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -777,9 +777,24 @@ RSpec.describe WorksController do
       let(:data) { [] }
 
       it "renders the workshow page" do
-        stub_s3
         get :show, params: { id: work.id }
         expect(response).to render_template("show")
+        expect(assigns[:changes]).to eq([])
+        expect(assigns[:messages]).to eq([])
+      end
+
+      context "when the work has changes and messages" do
+        before do
+          WorkActivity.add_system_activity(work.id, "Hello System", user.id)
+          work.add_message("Hello World", user.id)
+        end
+
+        it "renders the workshow page" do
+          get :show, params: { id: work.id }
+          expect(response).to render_template("show")
+          expect(assigns[:changes].map(&:message)).to eq(["Hello System"])
+          expect(assigns[:messages].map(&:message)).to eq(["Hello World"])
+        end
       end
     end
 

--- a/spec/models/work_activity_spec.rb
+++ b/spec/models/work_activity_spec.rb
@@ -45,4 +45,41 @@ describe WorkActivity, type: :model do
       expect(WorkActivityNotification.where(work_activity_id: work_activity.id)).to be_empty
     end
   end
+
+  context "many work Activities have been sent" do
+    let(:notification) { described_class.add_system_activity(work.id, message, user.id, activity_type: WorkActivity::NOTIFICATION) }
+    before do
+      work_activity
+      notification
+      work2 = FactoryBot.create(:draft_work)
+      described_class.add_system_activity(work2.id, message, user.id, activity_type: WorkActivity::NOTIFICATION)
+    end
+
+    describe "#activities_for_work" do
+      it "finds all the activities for the work" do
+        expect(described_class.activities_for_work(work)).to eq([notification, work_activity])
+      end
+
+      it "finds all the activities for the work and type" do
+        expect(described_class.activities_for_work(work, [WorkActivity::SYSTEM])).to eq([work_activity])
+        expect(described_class.activities_for_work(work, [WorkActivity::NOTIFICATION])).to eq([notification])
+        expect(described_class.activities_for_work(work, [WorkActivity::SYSTEM, WorkActivity::NOTIFICATION])).to eq([notification, work_activity])
+      end
+    end
+
+    describe "#messages_for_work" do
+      it "finds all the messages for the work" do
+        activity_message = described_class.add_system_activity(work.id, message, user.id, activity_type: WorkActivity::MESSAGE)
+        expect(described_class.messages_for_work(work.id)).to eq([activity_message, notification])
+      end
+    end
+
+    describe "#changes_for_work" do
+      it "finds all the changes for the work" do
+        change_file = described_class.add_system_activity(work.id, message, user.id, activity_type: WorkActivity::FILE_CHANGES)
+        changes = described_class.add_system_activity(work.id, message, user.id, activity_type: WorkActivity::CHANGES)
+        expect(described_class.changes_for_work(work.id)).to eq([changes, change_file, work_activity])
+      end
+    end
+  end
 end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -340,17 +340,20 @@ RSpec.describe Work, type: :model do
       expect(work.curator).to be nil
 
       work.change_curator(curator_user.id, user)
-      activity = work.activities.find { |a| a.message.include?("Set curator to @#{curator_user.uid}") }
+      activity = WorkActivity.changes_for_work(work.id).first
+      expect(activity.message).to eq("Set curator to @#{curator_user.uid}")
       expect(work.curator.id).to be curator_user.id
       expect(activity.created_by_user.id).to eq user.id
 
       work.change_curator(user.id, user)
-      activity = work.activities.find { |a| a.message.include?("Self-assigned as curator") }
+      activity = WorkActivity.changes_for_work(work.id).first
+      expect(activity.message).to eq("Self-assigned as curator")
       expect(work.curator.id).to be user.id
       expect(activity.created_by_user.id).to eq user.id
 
       work.clear_curator(user)
-      activity = work.activities.find { |a| a.message.include?("Unassigned existing curator") }
+      activity = WorkActivity.changes_for_work(work.id).first
+      expect(activity.message).to eq("Unassigned existing curator")
       expect(work.curator).to be nil
       expect(activity.created_by_user.id).to eq user.id
     end
@@ -359,7 +362,8 @@ RSpec.describe Work, type: :model do
   describe "#add_message" do
     it "adds a message" do
       work.add_message("hello world", user.id)
-      activity = work.activities.find { |a| a.message.include?("hello world") }
+      activity = WorkActivity.messages_for_work(work.id).first
+      expect(activity.message).to eq("hello world")
       expect(activity.created_by_user.id).to eq user.id
       expect(activity.activity_type).to eq WorkActivity::MESSAGE
     end
@@ -380,7 +384,8 @@ RSpec.describe Work, type: :model do
     it "parses tagged users correctly" do
       message = "taggging @#{curator_user.uid} and @#{user_other.uid}"
       work.add_message(message, user.id)
-      activity = work.activities.find { |a| a.message.include?(message) }
+      activity = WorkActivity.messages_for_work(work.id).first
+      expect(activity.message).to eq(message)
       expect(activity.to_html.include?("#{curator_user.uid}</a>")).to be true
       expect(activity.to_html.include?("#{user_other.uid}</a>")).to be true
     end
@@ -431,10 +436,11 @@ RSpec.describe Work, type: :model do
       curator_user.email_messages_enabled = true
       curator_user.enable_messages_from(collection: collection)
       expect { draft_work }
-        .to change { WorkActivity.where(activity_type: "SYSTEM").count }.by(2)
+        .to change { WorkActivity.where(activity_type: WorkActivity::SYSTEM).count }.by(1)
+        .and change { WorkActivity.where(activity_type: WorkActivity::NOTIFICATION).count }.by(1)
         .and have_enqueued_job(ActionMailer::MailDeliveryJob).once # this would be twice if the user could enable messages
-      expect(WorkActivity.where(activity_type: "SYSTEM").first.message).to eq("marked as Draft")
-      user_notification = WorkActivity.where(activity_type: "SYSTEM").last.message
+      expect(WorkActivity.where(activity_type: WorkActivity::SYSTEM).first.message).to eq("marked as Draft")
+      user_notification = WorkActivity.where(activity_type: WorkActivity::NOTIFICATION).last.message
       expect(user_notification).to include("@#{curator_user.uid}")
       expect(user_notification).to include("@#{user.uid}")
       expect(user_notification). to include(Rails.application.routes.url_helpers.work_url(draft_work))
@@ -545,10 +551,11 @@ RSpec.describe Work, type: :model do
       curator.email_messages_enabled = true
       curator.enable_messages_from(collection: collection)
       expect { awaiting_approval_work }
-        .to change { WorkActivity.where(activity_type: "SYSTEM").count }.by(2)
+        .to change { WorkActivity.where(activity_type: WorkActivity::SYSTEM).count }.by(1)
+        .and change { WorkActivity.where(activity_type: WorkActivity::NOTIFICATION).count }.by(1)
         .and have_enqueued_job(ActionMailer::MailDeliveryJob).once # this would be twice if the user could enable messages
-      expect(WorkActivity.where(activity_type: "SYSTEM").first.message).to eq("marked as Awaiting Approval")
-      curator_notification = WorkActivity.where(activity_type: "SYSTEM").last.message
+      expect(WorkActivity.where(activity_type: WorkActivity::SYSTEM).first.message).to eq("marked as Awaiting Approval")
+      curator_notification = WorkActivity.where(activity_type: WorkActivity::NOTIFICATION).last.message
       expect(curator_notification).to include("@#{curator.uid}")
       expect(curator_notification). to include(Rails.application.routes.url_helpers.work_url(awaiting_approval_work))
     end
@@ -617,10 +624,11 @@ RSpec.describe Work, type: :model do
       curator_user.email_messages_enabled = true
       curator_user.enable_messages_from(collection: collection)
       expect { approved_work }
-        .to change { WorkActivity.where(activity_type: "SYSTEM").count }.by(2)
+        .to change { WorkActivity.where(activity_type: WorkActivity::SYSTEM).count }.by(1)
+        .and change { WorkActivity.where(activity_type: WorkActivity::NOTIFICATION).count }.by(1)
         .and have_enqueued_job(ActionMailer::MailDeliveryJob).once # this would be twice if the user could enable messages
-      expect(WorkActivity.where(activity_type: "SYSTEM").first.message).to eq("marked as Approved")
-      user_notification = WorkActivity.where(activity_type: "SYSTEM").last.message
+      expect(WorkActivity.where(activity_type: WorkActivity::SYSTEM).first.message).to eq("marked as Approved")
+      user_notification = WorkActivity.where(activity_type: WorkActivity::NOTIFICATION).last.message
       expect(user_notification).to include("@#{curator_user.uid}")
       expect(user_notification).to include("@#{approved_work.created_by_user.uid}")
       expect(user_notification). to include(Rails.application.routes.url_helpers.work_url(approved_work))
@@ -821,12 +829,12 @@ RSpec.describe Work, type: :model do
         expect(work.pre_curation_uploads.first.key).to eq("#{work.doi}/#{work.id}/SCoData_combined_v1_2020-07_README.txt")
         expect(work.pre_curation_uploads.last).to be_a(ActiveStorage::Attachment)
         expect(work.pre_curation_uploads.last.key).to eq("#{work.doi}/#{work.id}/SCoData_combined_v1_2020-07_datapackage.json")
-        expect(work.activities.count { |a| a.activity_type == "FILE-CHANGES" }).to eq(1)
+        expect(WorkActivity.activities_for_work(work.id, ["FILE-CHANGES"]).count).to eq(1)
 
         # call the s3 reload and make sure no more files get added to the model
         work.attach_s3_resources
         expect(work.pre_curation_uploads.length).to eq(2)
-        expect(work.activities.count { |a| a.activity_type == "FILE-CHANGES" }).to eq(1)
+        expect(WorkActivity.activities_for_work(work.id, ["FILE-CHANGES"]).count).to eq(1)
       end
 
       context "a blob already exists for one of the files" do

--- a/spec/requests/works_spec.rb
+++ b/spec/requests/works_spec.rb
@@ -41,8 +41,6 @@ RSpec.describe "/works", type: :request do
 
         before do
           allow(work).to receive(:id).and_return("test-id")
-          allow(work).to receive(:changes).and_return([])
-          allow(work).to receive(:messages).and_return([])
           allow(work).to receive(:collection).and_return(nil)
           allow(work).to receive(:attach_s3_resources)
 

--- a/spec/system/work_create_spec.rb
+++ b/spec/system/work_create_spec.rb
@@ -104,6 +104,13 @@ RSpec.describe "Form submission for a legacy dataset", type: :system do
         expect(page).to have_content "2"
       end
 
+      visit(work_path(Work.last))
+
+      within("ul.work-messages") do
+        expect(page).to have_content("#{title} has been created")
+        expect(page).to have_content("#{title} is ready for review")
+      end
+
       # Now sign is as the collection curator and see the notification on your dashboard
       sign_out user
       sign_in curator


### PR DESCRIPTION
Additionally moving logic for finding the different types of messages into WorkActivity in an effort to make the Work Model smaller.
Also included the title of the work in notifications as I though that would make the emails nicer.

fixes #847