### PR TITLE
Allow collection depositors to receive emails

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -59,7 +59,7 @@ class UsersController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def user_params
-      @user_params ||= params.require(:user).permit([:display_name, :full_name, :family_name, :orcid, :email_messages_enabled, { collections_with_messaging: {} }])
+      @user_params ||= params.require(:user).permit([:display_name, :full_name, :family_name, :orcid, :email_messages_enabled, collections_with_messaging: {}])
     end
 
     def can_edit?

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -9,20 +9,18 @@
         </div>
       </fieldset>
 
-      <% if @user.moderator? %>
-        <section class="card container">
-          <h2>Collections</h2>
-          <fieldset>
-            <% @user.admin_collections.each do |admin_collection| %>
-              <legend><%= admin_collection.title %></legend>
-              <div class="form-check">
-                <%= check_box_tag("user[collections_with_messaging][#{admin_collection.id}]", "1", user.messages_enabled_from?(collection: admin_collection), { class: ["form-check-input"] }) %>
-                <%= label_tag("user[collections_with_messaging][#{admin_collection.id}]", t("users.form.email_messages_enabled"), class: ["form-check-label"]) %>
-              </div>
-            <% end %>
-          </fieldset>
-        </section>
-      <% end %>
+      <section class="card container collections"> 
+        <h2>Collections</h2>
+        <fieldset>
+          <% @user.submitter_or_admin_collections.each do |collection| %>
+            <legend><%= collection.title %></legend>
+            <div class="form-check">
+              <%= form.check_box("[collections_with_messaging][#{collection.id}]", { id: "collection_messaging_#{collection.id}", checked: user.messages_enabled_from?(collection: collection), class: ["form-check-input"] }) %>
+              <%= form.label("[collections_with_messaging][#{collection.id}]", t("users.form.email_messages_enabled"), class: ["form-check-label"]) %>
+            </div>
+          <% end %>
+        </fieldset>
+      </section>
 
       <button type="submit" class="btn btn-primary"><%= t("users.form.email_messages_submit") %></button>
     <% end %>

--- a/spec/models/work_activity_notification_spec.rb
+++ b/spec/models/work_activity_notification_spec.rb
@@ -16,23 +16,19 @@ describe WorkActivityNotification, type: :model do
       allow(NotificationMailer).to receive(:with).and_return(notification_mailer)
     end
 
-    it "does not enqueue an e-mail message to be delivered for the notification" do
+    it "enqueues an e-mail message to be delivered for the notification" do
       described_class.create(user: user, work_activity: work_activity)
-      expect(message_delivery).not_to have_received(:deliver_later)
+      expect(message_delivery).to have_received(:deliver_later)
     end
 
-    context "when e-mail notifications are enabled for the Collection" do
-      let(:user) { FactoryBot.create :user }
+    context "when e-mail notifications are disabled for the Collection" do
       before do
-        user.add_role(:collection_admin, collection)
-        user.enable_messages_from(collection: collection)
-        user.save!
-        user.reload
+        user.disable_messages_from(collection: collection)
       end
 
-      it "enqueues an e-mail message to be delivered for the notification" do
+      it "does not enqueue an e-mail message to be delivered for the notification" do
         described_class.create(user: user, work_activity: work_activity)
-        expect(message_delivery).to have_received(:deliver_later)
+        expect(message_delivery).not_to have_received(:deliver_later)
       end
     end
 

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -468,17 +468,12 @@ RSpec.describe Work, type: :model do
     end
 
     it "Notifies Curators and Depositor" do
-      # enable emails
-      user.email_messages_enabled = true
-      # Can not enable message for a depositor, but we will not send them without the messages being enabled
-      # user.enable_messages_from(collection: collection)
-      curator_user.email_messages_enabled = true
-      curator_user.enable_messages_from(collection: collection)
+      curator_user
       expect { draft_work }
         .to change { WorkActivity.where(activity_type: WorkActivity::SYSTEM).count }.by(1)
         .and change { WorkActivity.where(activity_type: WorkActivity::NOTIFICATION).count }.by(1)
-        .and have_enqueued_job(ActionMailer::MailDeliveryJob).once # this would be twice if the user could enable messages
-      expect(WorkActivity.where(activity_type: WorkActivity::SYSTEM).first.message).to eq("marked as Draft")
+        .and have_enqueued_job(ActionMailer::MailDeliveryJob).twice
+      expect(WorkActivity.where(activity_type: "SYSTEM").first.message).to eq("marked as Draft")
       user_notification = WorkActivity.where(activity_type: WorkActivity::NOTIFICATION).last.message
       expect(user_notification).to include("@#{curator_user.uid}")
       expect(user_notification).to include("@#{user.uid}")
@@ -583,16 +578,10 @@ RSpec.describe Work, type: :model do
 
     it "notifies the curator and depositor it is ready for review" do
       curator = FactoryBot.create(:research_data_moderator)
-      # enable emails
-      user.email_messages_enabled = true
-      # Can not enable message for a depositor, but we will not send them without the messages being enabled
-      # user.enable_messages_from(collection: collection)
-      curator.email_messages_enabled = true
-      curator.enable_messages_from(collection: collection)
       expect { awaiting_approval_work }
         .to change { WorkActivity.where(activity_type: WorkActivity::SYSTEM).count }.by(1)
         .and change { WorkActivity.where(activity_type: WorkActivity::NOTIFICATION).count }.by(1)
-        .and have_enqueued_job(ActionMailer::MailDeliveryJob).once # this would be twice if the user could enable messages
+        .and have_enqueued_job(ActionMailer::MailDeliveryJob).twice
       expect(WorkActivity.where(activity_type: WorkActivity::SYSTEM).first.message).to eq("marked as Awaiting Approval")
       curator_notification = WorkActivity.where(activity_type: WorkActivity::NOTIFICATION).last.message
       expect(curator_notification).to include("@#{curator.uid}")
@@ -656,16 +645,10 @@ RSpec.describe Work, type: :model do
 
     it "Notifies Curators and Depositor" do
       stub_datacite_doi
-      # enable emails
-      user.email_messages_enabled = true
-      # Can not enable message for a depositor, but we will not send them without the messages being enabled
-      # user.enable_messages_from(collection: collection)
-      curator_user.email_messages_enabled = true
-      curator_user.enable_messages_from(collection: collection)
       expect { approved_work }
         .to change { WorkActivity.where(activity_type: WorkActivity::SYSTEM).count }.by(1)
         .and change { WorkActivity.where(activity_type: WorkActivity::NOTIFICATION).count }.by(1)
-        .and have_enqueued_job(ActionMailer::MailDeliveryJob).once # this would be twice if the user could enable messages
+        .and have_enqueued_job(ActionMailer::MailDeliveryJob).twice
       expect(WorkActivity.where(activity_type: WorkActivity::SYSTEM).first.message).to eq("marked as Approved")
       user_notification = WorkActivity.where(activity_type: WorkActivity::NOTIFICATION).last.message
       expect(user_notification).to include("@#{curator_user.uid}")

--- a/spec/system/user_edit_spec.rb
+++ b/spec/system/user_edit_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require "rails_helper"
-RSpec.describe "Editing users" do
+RSpec.describe "Editing users", type: :system do
   describe "Admin users can edit other users data" do
     before { sign_in user_admin }
 
@@ -29,6 +29,52 @@ RSpec.describe "Editing users" do
       visit user_path(user_other)
       expect(page).to have_content user_other.display_name
       expect(page).to_not have_content "Edit"
+    end
+  end
+
+  describe "Allows a user to edit which collections send emails", js: true do
+    let(:user) { FactoryBot.create :princeton_submitter }
+    let(:pppl_collection) { Collection.plasma_laboratory }
+    let(:rd_collection) { Collection.research_data }
+    let(:random_collection) { FactoryBot.create(:collection) }
+
+    before do
+      sign_in user
+      user.add_role(:submitter, pppl_collection)
+      random_collection # ensure the collection exists
+    end
+
+    it "shows the form" do
+      visit edit_user_path(user)
+      expect(page).to have_field("user_display_name", with: user.display_name)
+      expect(page).to have_content "My Profile Settings"
+      expect(page).to have_unchecked_field "collection_messaging_#{pppl_collection.id}"
+      expect(page).to have_checked_field "collection_messaging_#{rd_collection.id}"
+      expect(page).not_to have_field "collection_messaging_#{random_collection.id}"
+      check "collection_messaging_#{pppl_collection.id}"
+      click_on "Update"
+      visit edit_user_path(user)
+      expect(page).to have_checked_field "collection_messaging_#{pppl_collection.id}"
+      expect(page).to have_checked_field "collection_messaging_#{rd_collection.id}"
+    end
+
+    context "User is super admin" do
+      let(:user) { FactoryBot.create :super_admin_user }
+
+      it "shows the form with all the collections and only the default collection is checked" do
+        visit edit_user_path(user)
+        expect(page).to have_field("user_display_name", with: user.display_name)
+        expect(page).to have_content "My Profile Settings"
+        expect(page).to have_unchecked_field "collection_messaging_#{pppl_collection.id}"
+        expect(page).to have_checked_field "collection_messaging_#{rd_collection.id}"
+        expect(page).to have_unchecked_field "collection_messaging_#{random_collection.id}"
+        uncheck "collection_messaging_#{rd_collection.id}"
+        click_on "Update"
+        visit edit_user_path(user)
+        expect(page).to have_unchecked_field "collection_messaging_#{pppl_collection.id}"
+        expect(page).to have_unchecked_field "collection_messaging_#{rd_collection.id}"
+        expect(page).to have_unchecked_field "collection_messaging_#{random_collection.id}"
+      end
     end
   end
 end

--- a/spec/system/work_comment_spec.rb
+++ b/spec/system/work_comment_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "Commenting on works sends emails or not", type: :system, js: tru
   let(:work) { FactoryBot.create(:draft_work) }
   let(:user) { work.created_by_user }
   let(:user2) { FactoryBot.create(:princeton_submitter) }
+  let(:message) { "@#{user2.uid} Look at this work!" }
 
   before do
     page.driver.browser.manage.window.resize_to(2000, 2000)
@@ -12,13 +13,26 @@ RSpec.describe "Commenting on works sends emails or not", type: :system, js: tru
     visit work_path(work)
   end
 
-  it "Allows the user to comment and tag another user but will not send an email" do
-    message = "@#{user2.uid} Look at this work!"
+  it "Allows the user to comment and tag another user and will send an email" do
     fill_in "new-message", with: message
     expect { click_on "Message" }
       .to change { WorkActivity.where(activity_type: WorkActivity::MESSAGE).count }.by(1)
-      .and have_enqueued_job(ActionMailer::MailDeliveryJob).exactly(0).times
+      .and have_enqueued_job(ActionMailer::MailDeliveryJob).exactly(1).times
     expect(page).to have_content message
+  end
+
+  context "when the user has emails disabled" do
+    before do
+      user2.disable_messages_from(collection: work.collection)
+    end
+
+    it "Allows the user to comment and tag a curator and not send an email" do
+      fill_in "new-message", with: message
+      expect { click_on "Message" }
+        .to change { WorkActivity.where(activity_type: WorkActivity::MESSAGE).count }.by(1)
+        .and have_enqueued_job(ActionMailer::MailDeliveryJob).exactly(0).times
+      expect(page).to have_content message
+    end
   end
 
   context "the user is a curator" do
@@ -29,20 +43,20 @@ RSpec.describe "Commenting on works sends emails or not", type: :system, js: tru
       fill_in "new-message", with: message
       expect { click_on "Message" }
         .to change { WorkActivity.where(activity_type: WorkActivity::MESSAGE).count }.by(1)
-        .and have_enqueued_job(ActionMailer::MailDeliveryJob).exactly(0).times
+        .and have_enqueued_job(ActionMailer::MailDeliveryJob).exactly(1).times
       expect(page).to have_content message
     end
 
-    context "when the curator has emails enabled" do
+    context "when the curator has emails disabled" do
       before do
-        user2.enable_messages_from(collection: work.collection)
+        user2.disable_messages_from(collection: work.collection)
       end
 
       it "Allows the user to comment and tag a curator and send an email" do
         fill_in "new-message", with: message
         expect { click_on "Message" }
           .to change { WorkActivity.where(activity_type: WorkActivity::MESSAGE).count }.by(1)
-          .and have_enqueued_job(ActionMailer::MailDeliveryJob).exactly(1).times
+          .and have_enqueued_job(ActionMailer::MailDeliveryJob).exactly(0).times
         expect(page).to have_content message
       end
     end


### PR DESCRIPTION
Allow Users to recieve emails by default for collection they have deposit rights to Allow users to configure thier emails even when they are not collection administrators Fix bug so that you can uncheck email for specific collections by utilizing the form.check_box instead of the check_box_tag

fixs #762