### PR TITLE
Fix CircleCI caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ commands:
       - run: gem install bundler -v '2.3.11'
       - run: cp Gemfile.lock Gemfile.lock.bak
       - restore_cache:
-          keys: &gem_key rails_template-cimg-{{ checksum "Gemfile.lock.bak" }}
+          key: &gem_key rails_template-cimg-{{ checksum "Gemfile.lock.bak" }}
       - run: bundle install --path ./vendor/bundle
       - save_cache:
           key: *gem_key


### PR DESCRIPTION
- Fix #776

There was a typo in the yaml: ["keys" should be a list; "key" if a string](https://circleci.com/docs/caching/#restoring-cache).

It now [finds the cache](https://app.circleci.com/pipelines/github/pulibrary/pdc_describe/2446/workflows/c835e779-a1ce-4b17-951c-bbe2d140927f/jobs/7773?invite=true#step-105-1):
```
Found a cache from build 7263 at rails_template-cimg-WNPdhkVXsHhraGXcvTTqCdESo9kJ_5f1tcmi+sF_L5k=
Size: 63 MiB
Cached paths:
  * /home/circleci/rails_template/vendor/bundle

Downloading cache archive...
Validating cache...

Unarchiving cache...
```
and the bundle install in the next step runs in less than a second, instead of [1:49](https://app.circleci.com/pipelines/github/pulibrary/pdc_describe/2439/workflows/7716e5a5-a2ae-4812-8edf-0f9aa070a8e2/jobs/7745) or [1:42](https://app.circleci.com/pipelines/github/pulibrary/pdc_describe/2437/workflows/62fbbe24-c465-4865-bc13-42ef9e944fcf/jobs/7737).