### PR TITLE
Show funder changes in log, and refactor `ResourceCompareService` so it will pick up new properties by default

### DIFF
--- a/app/models/pdc_metadata/rights.rb
+++ b/app/models/pdc_metadata/rights.rb
@@ -9,6 +9,10 @@ module PDCMetadata
       @name = name
     end
 
+    def compare_value
+      @name
+    end
+
     def self.all
       @all ||= [
         Rights.new(identifier: "MIT", uri: "https://mit-license.org/", name: "MIT License"),

--- a/app/services/resource_compare_service.rb
+++ b/app/services/resource_compare_service.rb
@@ -54,32 +54,24 @@ class ResourceCompareService
     end
 
     def compare_values(method_sym)
-      before_value = @before.send(method_sym)
-      after_value = @after.send(method_sym)
-      if before_value != after_value
-        @differences[method_sym] = [{ action: :changed, from: before_value, to: after_value }]
-      end
+      compare(method_sym) { |value| value }
     end
 
     def compare_objects(method_sym)
-      before_value = @before.send(method_sym).compare_value
-      after_value = @after.send(method_sym).compare_value
-      if before_value != after_value
-        @differences[method_sym] = [{ action: :changed, from: before_value, to: after_value }]
-      end
+      compare(method_sym) { |value| value.compare_value }
     end
 
     def compare_value_arrays(method_sym)
-      before_value = @before.send(method_sym).join("\n")
-      after_value = @after.send(method_sym).join("\n")
-      if before_value != after_value
-        @differences[method_sym] = [{ action: :changed, from: before_value, to: after_value }]
-      end
+      compare(method_sym) { |values| values.join("\n") }
     end
 
     def compare_object_arrays(method_sym)
-      before_value = @before.send(method_sym).map(&:compare_value).join("\n")
-      after_value = @after.send(method_sym).map(&:compare_value).join("\n")
+      compare(method_sym) { |values| values.map(&:compare_value).join("\n") }
+    end
+
+    def compare(method_sym)
+      before_value = yield(@before.send(method_sym))
+      after_value = yield(@after.send(method_sym))
       if before_value != after_value
         @differences[method_sym] = [{ action: :changed, from: before_value, to: after_value }]
       end

--- a/app/services/resource_compare_service.rb
+++ b/app/services/resource_compare_service.rb
@@ -38,7 +38,7 @@ class ResourceCompareService
           after_value = @after.send(method_sym)
           next if before_value.empty? && after_value.empty?
           compare_arrays(method_sym, before_value, after_value)
-        elsif before_value.respond_to?(:compare_value) or after_value.respond_to?(:compare_value)
+        elsif before_value.respond_to?(:compare_value) || after_value.respond_to?(:compare_value)
           compare_objects(method_sym)
         else
           compare_values(method_sym)

--- a/app/services/resource_compare_service.rb
+++ b/app/services/resource_compare_service.rb
@@ -32,13 +32,13 @@ class ResourceCompareService
   private
 
     def compare_resources
-      # loop through an objects json structure and compare the values from the before and after objects
-      #  Note: This assumes the before and after objects have the same json structure
+      # Loop through an object's json keys and compare the values from the before and after objects.
+      # Note: This assumes the before and after objects have the same json keys.
       @before.as_json.keys.map(&:to_sym).each do |method_sym|
         before_value = @before.send(method_sym)
         after_value = @after.send(method_sym)
+        next if before_value.to_json == after_value.to_json
         if before_value.is_a?(Array)
-          next if before_value.empty? && after_value.empty?
           compare_arrays(method_sym, before_value, after_value)
         elsif before_value.respond_to?(:compare_value) || after_value.respond_to?(:compare_value)
           # If either value is nil, we still want to get the compare_value for the other.

--- a/app/services/resource_compare_service.rb
+++ b/app/services/resource_compare_service.rb
@@ -32,6 +32,8 @@ class ResourceCompareService
   private
 
     def compare_resources
+      # loop through an objects json structure and compare the values from the before and after objects
+      #  Note: This assumes the before and after objects have the same json structure
       @before.as_json.keys.map(&:to_sym).each do |method_sym|
         before_value = @before.send(method_sym)
         after_value = @after.send(method_sym)

--- a/app/services/resource_compare_service.rb
+++ b/app/services/resource_compare_service.rb
@@ -32,7 +32,7 @@ class ResourceCompareService
   private
 
     def compare_resources
-      [:titles, :creators, :contributors, :related_objects].each do |field|
+      [:titles, :creators, :contributors, :related_objects, :funders].each do |field|
         compare_objects(field)
       end
       [:description, :publisher, :publication_year,

--- a/app/services/resource_compare_service.rb
+++ b/app/services/resource_compare_service.rb
@@ -36,18 +36,22 @@ class ResourceCompareService
         before_value = @before.send(method_sym)
         if before_value.is_a?(Array)
           after_value = @after.send(method_sym)
-          next if before_value.empty? && after_value.empty?
-          inside_value = (before_value + after_value).first
-          if inside_value.respond_to?(:compare_value)
-            compare_object_arrays(method_sym)
-          else
-            compare_value_arrays(method_sym)
-          end
+          compare_arrays(before_value, after_value)
         elsif before_value.respond_to?(:compare_value)
           compare_objects(method_sym)
         else
           compare_values(method_sym)
         end
+      end
+    end
+
+    def compare_arrays(before_array, after_array)
+      return if before_array.empty? && after_array.empty?
+      inside_value = (before_array + after_array).first
+      if inside_value.respond_to?(:compare_value)
+        compare_object_arrays(method_sym)
+      else
+        compare_value_arrays(method_sym)
       end
     end
 

--- a/app/services/resource_compare_service.rb
+++ b/app/services/resource_compare_service.rb
@@ -34,7 +34,7 @@ class ResourceCompareService
     def compare_resources
       @before.as_json.keys.map(&:to_sym).each do |method_sym|
         before_value = @before.send(method_sym)
-        if before_value.kind_of?(Array)
+        if before_value.is_a?(Array)
           after_value = @after.send(method_sym)
           next if before_value.empty? && after_value.empty?
           inside_value = (before_value + after_value).first
@@ -43,12 +43,10 @@ class ResourceCompareService
           else
             compare_value_arrays(method_sym)
           end
+        elsif before_value.respond_to?(:compare_value)
+          compare_objects(method_sym)
         else
-          if before_value.respond_to?(:compare_value)
-            compare_objects(method_sym)
-          else
-            compare_values(method_sym)
-          end
+          compare_values(method_sym)
         end
       end
     end
@@ -58,7 +56,7 @@ class ResourceCompareService
     end
 
     def compare_objects(method_sym)
-      compare(method_sym) { |value| value.compare_value }
+      compare(method_sym, &:compare_value)
     end
 
     def compare_value_arrays(method_sym)

--- a/app/services/resource_compare_service.rb
+++ b/app/services/resource_compare_service.rb
@@ -57,7 +57,7 @@ class ResourceCompareService
     end
 
     def compare_values(method_sym)
-      compare(method_sym) { |value| value }
+      compare(method_sym, &:to_s)
     end
 
     def compare_objects(method_sym)

--- a/app/services/resource_compare_service.rb
+++ b/app/services/resource_compare_service.rb
@@ -34,11 +34,12 @@ class ResourceCompareService
     def compare_resources
       @before.as_json.keys.map(&:to_sym).each do |method_sym|
         before_value = @before.send(method_sym)
+        after_value = @after.send(method_sym)
         if before_value.is_a?(Array)
-          after_value = @after.send(method_sym)
           next if before_value.empty? && after_value.empty?
           compare_arrays(method_sym, before_value, after_value)
         elsif before_value.respond_to?(:compare_value) || after_value.respond_to?(:compare_value)
+          # If either value is nil, we still want to get the compare_value for the other.
           compare_objects(method_sym)
         else
           compare_values(method_sym)
@@ -60,8 +61,6 @@ class ResourceCompareService
     end
 
     def compare_objects(method_sym)
-      # We encounter nil values in tests,
-      # but I'm not sure if they are possible in production.
       compare(method_sym) { |value| value.nil? ? "" : value.compare_value }
     end
 

--- a/spec/services/resource_compare_service_spec.rb
+++ b/spec/services/resource_compare_service_spec.rb
@@ -56,64 +56,66 @@ describe ResourceCompareService do
                                  to: "Smith, Robert | 2 | " }]
   end
 
-  class MockResource < OpenStruct
-    # We want to confirm that the compare service still works with new unexpected attributes.
-    # This lets us treat a hash as if it were a resource.
-    def as_json
-      to_h
-    end
-  end
-
-  class MockComparable < OpenStruct
-    def compare_value
-      to_h.to_yaml.sub("---\n", "")
-    end
-  end
-
-  describe "value comparison" do
-    it "does not flag integer->string as change" do
-      compare = described_class.new(MockResource.new({ fake_year: 2000 }), MockResource.new({ fake_year: "2000" }))
-      differences = compare.differences[:fake_year]
-      expect(differences).to eq nil
+  describe "generic comparisons" do
+    class MockResource < OpenStruct
+      # We want to confirm that the compare service still works with new unexpected attributes.
+      # This lets us treat a hash as if it were a resource.
+      def as_json
+        to_h
+      end
     end
 
-    it "does flag integer->string+1 as change" do
-      compare = described_class.new(MockResource.new({ fake_year: 2000 }), MockResource.new({ fake_year: "2001" }))
-      differences = compare.differences[:fake_year]
-      expect(differences).to eq [{ action: :changed, from: "2000", to: "2001" }]
+    class MockComparable < OpenStruct
+      def compare_value
+        to_h.to_yaml.sub("---\n", "")
+      end
     end
 
-    it "does flag nil->string as change" do
-      compare = described_class.new(MockResource.new({ fake_year: "2000" }), MockResource.new({ fake_year: nil }))
-      differences = compare.differences[:fake_year]
-      expect(differences).to eq [{ action: :changed, from: "2000", to: "" }]
+    describe "value comparison" do
+      it "does not flag integer->string as change" do
+        compare = described_class.new(MockResource.new({ fake_year: 2000 }), MockResource.new({ fake_year: "2000" }))
+        differences = compare.differences[:fake_year]
+        expect(differences).to eq nil
+      end
+
+      it "does flag integer->string+1 as change" do
+        compare = described_class.new(MockResource.new({ fake_year: 2000 }), MockResource.new({ fake_year: "2001" }))
+        differences = compare.differences[:fake_year]
+        expect(differences).to eq [{ action: :changed, from: "2000", to: "2001" }]
+      end
+
+      it "does flag nil->string as change" do
+        compare = described_class.new(MockResource.new({ fake_year: "2000" }), MockResource.new({ fake_year: nil }))
+        differences = compare.differences[:fake_year]
+        expect(differences).to eq [{ action: :changed, from: "2000", to: "" }]
+      end
+
+      it "does flag string->nil as change" do
+        compare = described_class.new(MockResource.new({ fake_year: nil }), MockResource.new({ fake_year: "2000" }))
+        differences = compare.differences[:fake_year]
+        expect(differences).to eq([{ action: :changed, from: "", to: "2000" }])
+      end
     end
 
-    it "does flag string->nil as change" do
-      compare = described_class.new(MockResource.new({ fake_year: nil }), MockResource.new({ fake_year: "2000" }))
-      differences = compare.differences[:fake_year]
-      expect(differences).to eq([{ action: :changed, from: "", to: "2000" }])
+    describe "value array comparison" do
+      it "flags change" do
+        compare = described_class.new(MockResource.new({ fake_array: ["old"] }), MockResource.new({ fake_array: ["new"] }))
+        expect(compare.differences).to eq({ fake_array: [{ action: :changed, from: "old", to: "new" }] })
+      end
     end
-  end
 
-  describe "value array comparison" do
-    it "flags change" do
-      compare = described_class.new(MockResource.new({ fake_array: ["old"] }), MockResource.new({ fake_array: ["new"] }))
-      expect(compare.differences).to eq({ fake_array: [{ action: :changed, from: "old", to: "new" }] })
+    describe "object comparison" do
+      it "flags change" do
+        compare = described_class.new(MockResource.new({ fake_object: MockComparable.new({ field: "old" }) }), MockResource.new({ fake_object: MockComparable.new({ field: "new" }) }))
+        expect(compare.differences).to eq({ fake_object: [{ action: :changed, from: ":field: old\n", to: ":field: new\n" }] })
+      end
     end
-  end
 
-  describe "object comparison" do
-    it "flags change" do
-      compare = described_class.new(MockResource.new({ fake_object: MockComparable.new({ field: "old" }) }), MockResource.new({ fake_object: MockComparable.new({ field: "new" }) }))
-      expect(compare.differences).to eq({ fake_object: [{ action: :changed, from: ":field: old\n", to: ":field: new\n" }] })
-    end
-  end
-
-  describe "object array comparison" do
-    it "flags change" do
-      compare = described_class.new(MockResource.new({ fake_object_array: [MockComparable.new({ field: "old" })] }), MockResource.new({ fake_object_array: [MockComparable.new({ field: "new" })] }))
-      expect(compare.differences).to eq({ fake_object_array: [{ action: :changed, from: ":field: old\n", to: ":field: new\n" }] })
+    describe "object array comparison" do
+      it "flags change" do
+        compare = described_class.new(MockResource.new({ fake_object_array: [MockComparable.new({ field: "old" })] }), MockResource.new({ fake_object_array: [MockComparable.new({ field: "new" })] }))
+        expect(compare.differences).to eq({ fake_object_array: [{ action: :changed, from: ":field: old\n", to: ":field: new\n" }] })
+      end
     end
   end
 end

--- a/spec/services/resource_compare_service_spec.rb
+++ b/spec/services/resource_compare_service_spec.rb
@@ -71,20 +71,19 @@ describe ResourceCompareService do
       creators: []
     }
     expected_diff = {
-      doi: [{:action=>:changed, :from=>"10.34770/pe9w-x904", :to=>""}],
-      ark: [{:action=>:changed, :from=>"ark:/88435/dsp01zc77st047", :to=>""}],
-      description: [{:action=>:changed,
-       :from=>
-       "All data is related to the Shakespeare and Company bookshop and lending library opened and operated by Sylvia Beach in Paris, 1919–1962.",
-       :to=>"new description"}],
-      publication_year: [{:action=>:changed, :from=>"2020", :to=>""}],
-      version_number: [{:action=>:changed, :from=>"1", :to=>""}],
-      publisher: [{:action=>:changed, :from=>"Princeton University", :to=>""}],
-      resource_type: [{:action=>:changed, :from=>"Dataset", :to=>""}],
-      rights: [{:action=>:changed, :from=>"Creative Commons Attribution 4.0 International", :to=>""}],
-      titles: [{:action=>:changed, :from=>"Shakespeare and Company Project Dataset: Lending Library Members, Books, Events ()", :to=>"new title ()"}],
-      collection_tags: [{:action=>:changed, :from=>"", :to=>"fake"}],
-      creators: [{:action=>:changed, :from=>"Kotin, Joshua | 1 | ", :to=>""}]
+      doi: [{ action: :changed, from: "10.34770/pe9w-x904", to: "" }],
+      ark: [{ action: :changed, from: "ark:/88435/dsp01zc77st047", to: "" }],
+      description: [{ action: :changed,
+                      from: "All data is related to the Shakespeare and Company bookshop and lending library opened and operated by Sylvia Beach in Paris, 1919–1962.",
+                      to: "new description" }],
+      publication_year: [{ action: :changed, from: "2020", to: "" }],
+      version_number: [{ action: :changed, from: "1", to: "" }],
+      publisher: [{ action: :changed, from: "Princeton University", to: "" }],
+      resource_type: [{ action: :changed, from: "Dataset", to: "" }],
+      rights: [{ action: :changed, from: "Creative Commons Attribution 4.0 International", to: "" }],
+      titles: [{ action: :changed, from: "Shakespeare and Company Project Dataset: Lending Library Members, Books, Events ()", to: "new title ()" }],
+      collection_tags: [{ action: :changed, from: "", to: "fake" }],
+      creators: [{ action: :changed, from: "Kotin, Joshua | 1 | ", to: "" }]
     }
     resource1 = FactoryBot.create(:shakespeare_and_company_work).resource
     keys = resource1.as_json.keys.sort

--- a/spec/services/resource_compare_service_spec.rb
+++ b/spec/services/resource_compare_service_spec.rb
@@ -129,13 +129,13 @@ describe ResourceCompareService do
         expect(differences).to eq [{ action: :changed, from: "2000", to: "2001" }]
       end
 
-      it "does flag nil->string as change" do
+      it "does flag string->nil as change" do
         compare = described_class.new(MockResource.new({ fake_year: "2000" }), MockResource.new({ fake_year: nil }))
         differences = compare.differences[:fake_year]
         expect(differences).to eq [{ action: :changed, from: "2000", to: "" }]
       end
 
-      it "does flag string->nil as change" do
+      it "does flag nil->string as change" do
         compare = described_class.new(MockResource.new({ fake_year: nil }), MockResource.new({ fake_year: "2000" }))
         differences = compare.differences[:fake_year]
         expect(differences).to eq([{ action: :changed, from: "", to: "2000" }])

--- a/spec/services/resource_compare_service_spec.rb
+++ b/spec/services/resource_compare_service_spec.rb
@@ -57,7 +57,7 @@ describe ResourceCompareService do
   end
 
   class MockResource < OpenStruct
-    # We want to confirm that the compare service still works with unexpected, new, attributes.
+    # We want to confirm that the compare service still works with new unexpected attributes.
     # This lets us treat a hash as if it were a resource.
     def as_json
       to_h
@@ -74,5 +74,17 @@ describe ResourceCompareService do
     compare = described_class.new(MockResource.new({fake_year: 2000}), MockResource.new({fake_year: "2001"}))
     differences = compare.differences[:fake_year]
     expect(differences).to eq [{:action=>:changed, :from=>"2000", :to=>"2001"}]
+  end
+
+  it "does flag nil->string as change" do
+    compare = described_class.new(MockResource.new({fake_year: "2000"}), MockResource.new({fake_year: nil}))
+    differences = compare.differences[:fake_year]
+    expect(differences).to eq [{:action=>:changed, :from=>"2000", :to=>""}]
+  end
+
+  it "does flag string->nil as change" do
+    compare = described_class.new(MockResource.new({fake_year: nil}), MockResource.new({fake_year: "2000"}))
+    differences = compare.differences[:fake_year]
+    expect(differences).to eq [{:action=>:changed, :from=>"", :to=>"2000"}]
   end
 end


### PR DESCRIPTION
- fix #867
- fix #874 

One caveat: There are form fields that don't populate the resource, ie, notes to curator. I don't think they are in scope, but I could be wrong.