### PR TITLE
Send just one notification if creator is also admin

### DIFF
--- a/app/models/work_state_transition_notification.rb
+++ b/app/models/work_state_transition_notification.rb
@@ -13,7 +13,7 @@ class WorkStateTransitionNotification
     @collection_administrators = work.collection.administrators.to_a
     @work_url = Rails.application.routes.url_helpers.work_url(work)
     @work_title = work.title
-    @users = @collection_administrators + [@depositor]
+    @users = @collection_administrators | [@depositor] # Depositor may also be an admin, but should only be listed once.
     @notification = notification_for_transition
     @id = work.id
     @current_user_id = current_user_id

--- a/spec/models/work_state_spec.rb
+++ b/spec/models/work_state_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Work state transions", type: :model do
     context "a #{fixture}" do
       let(:work) { FactoryBot.create(fixture) }
 
-      it "Creates a work activity notification for the curator & the user after #{method_sym}" do
+      it "Creates work activity notifications for the curator & the creator after #{method_sym}" do
         curator_user # make sure the curator exists
         if method_sym == :approve!
           allow(work).to receive(:publish)
@@ -24,6 +24,20 @@ RSpec.describe "Work state transions", type: :model do
           work.send(method_sym, user)
         end.to change { WorkActivity.count }.by(2)
           .and change { WorkActivityNotification.count }.by(2)
+      end
+
+      it "Creates a single work activity notification for the curator = creator after #{method_sym}" do
+        work.created_by_user.add_role(:collection_admin, work.collection)
+        if method_sym == :approve!
+          allow(work).to receive(:publish)
+          user = curator_user
+        else
+          user = work.created_by_user
+        end
+        expect do
+          work.send(method_sym, user)
+        end.to change { WorkActivity.count }.by(2)
+          .and change { WorkActivityNotification.count }.by(1)
       end
     end
   end  

--- a/spec/models/work_state_spec.rb
+++ b/spec/models/work_state_spec.rb
@@ -4,39 +4,22 @@ require "rails_helper"
 RSpec.describe "Work state transions", type: :model do
   let(:curator_user) { FactoryBot.create :user, collections_to_admin: [work.collection] }
 
-  context "a none work" do
-    let(:work) { FactoryBot.create(:none_work) }
+  {
+    none_work: :draft!,
+    draft_work: :complete_submission!,
+    awaiting_approval_work: :approve!
+  }.each do |fixture, method_sym|
+    context "a #{fixture}" do
+      let(:work) { FactoryBot.create(fixture) }
 
-    it "Creates a work activity notification for the curator & the user when drafted" do
-      curator_user # make sure the curator exists
-      expect do
-        work.draft!(work.created_by_user)
-      end.to change { WorkActivity.count }.by(2)
-        .and change { WorkActivityNotification.count }.by(2)
+      it "Creates a work activity notification for the curator & the user after #{method_sym}" do
+        curator_user # make sure the curator exists
+        allow(work).to receive(:publish) # Only relevant for approve.
+        expect do
+          work.send(method_sym, method_sym == :approve! ? curator_user : work.created_by_user)
+        end.to change { WorkActivity.count }.by(2)
+          .and change { WorkActivityNotification.count }.by(2)
+      end
     end
-  end
-
-  context "a draft work" do
-    let(:work) { FactoryBot.create(:draft_work) }
-
-    it "Creates a work activity notification for the curator & the user when completed" do
-      curator_user # make sure the curator exists
-      expect do
-        work.complete_submission!(work.created_by_user)
-      end.to change { WorkActivity.count }.by(2)
-         .and change { WorkActivityNotification.count }.by(2)
-    end
-  end
-
-  context "a completed work" do
-    let(:work) { FactoryBot.create(:awaiting_approval_work) }
-
-    it "Creates a work activity notification for the curator & the user when approved" do
-      allow(work).to receive(:publish)
-      expect do
-        work.approve!(curator_user)
-      end.to change { WorkActivity.count }.by(2)
-         .and change { WorkActivityNotification.count }.by(2)
-    end
-  end
+  end  
 end

--- a/spec/models/work_state_spec.rb
+++ b/spec/models/work_state_spec.rb
@@ -14,14 +14,14 @@ RSpec.describe "Work state transions", type: :model do
         it "Creates work activity notifications for the curator & the creator after #{method_sym}" do
           user = work.created_by_user
           if creator_is_admin
-            user.add_role(:collection_admin, work.collection)  
+            user.add_role(:collection_admin, work.collection)
           else
             curator_user # make sure the curator exists
           end
           expect do
             work.send(method_sym, user)
           end.to change { WorkActivity.count }.by(2)
-            .and change { WorkActivityNotification.count }.by(creator_is_admin ? 1 : 2)
+                                              .and change { WorkActivityNotification.count }.by(creator_is_admin ? 1 : 2)
         end
       end
     end

--- a/spec/models/work_state_spec.rb
+++ b/spec/models/work_state_spec.rb
@@ -2,16 +2,18 @@
 require "rails_helper"
 
 RSpec.describe "Work state transions", type: :model do
-  let(:work) { FactoryBot.create(:none_work) }
-
   let(:curator_user) { FactoryBot.create :user, collections_to_admin: [work.collection] }
 
-  it "Creates a work activity notification for the curator & the user when drafted" do
-    curator_user # make sure the curator exists
-    expect do
-      work.draft!(work.created_by_user)
-    end.to change { WorkActivity.count }.by(2)
-       .and change { WorkActivityNotification.count }.by(2)
+  context "a none work" do
+    let(:work) { FactoryBot.create(:none_work) }
+
+    it "Creates a work activity notification for the curator & the user when drafted" do
+      curator_user # make sure the curator exists
+      expect do
+        work.draft!(work.created_by_user)
+      end.to change { WorkActivity.count }.by(2)
+        .and change { WorkActivityNotification.count }.by(2)
+    end
   end
 
   context "a draft work" do

--- a/spec/models/work_state_spec.rb
+++ b/spec/models/work_state_spec.rb
@@ -14,9 +14,14 @@ RSpec.describe "Work state transions", type: :model do
 
       it "Creates a work activity notification for the curator & the user after #{method_sym}" do
         curator_user # make sure the curator exists
-        allow(work).to receive(:publish) # Only relevant for approve.
+        if method_sym == :approve!
+          allow(work).to receive(:publish)
+          user = curator_user
+        else
+          user = work.created_by_user
+        end
         expect do
-          work.send(method_sym, method_sym == :approve! ? curator_user : work.created_by_user)
+          work.send(method_sym, user)
         end.to change { WorkActivity.count }.by(2)
           .and change { WorkActivityNotification.count }.by(2)
       end

--- a/spec/models/work_state_spec.rb
+++ b/spec/models/work_state_spec.rb
@@ -8,25 +8,21 @@ RSpec.describe "Work state transions", type: :model do
     none_work: :draft!,
     draft_work: :complete_submission!
   }.each do |fixture, method_sym|
-    context "a #{fixture}" do
-      let(:work) { FactoryBot.create(fixture) }
-
-      it "Creates work activity notifications for the curator & the creator after #{method_sym}" do
-        curator_user # make sure the curator exists
-        user = work.created_by_user
-        expect do
-          work.send(method_sym, user)
-        end.to change { WorkActivity.count }.by(2)
-          .and change { WorkActivityNotification.count }.by(2)
-      end
-
-      it "Creates a single work activity notification for the curator = creator after #{method_sym}" do
-        work.created_by_user.add_role(:collection_admin, work.collection)
-        user = work.created_by_user
-        expect do
-          work.send(method_sym, user)
-        end.to change { WorkActivity.count }.by(2)
-          .and change { WorkActivityNotification.count }.by(1)
+    [true, false].each do |creator_is_admin|
+      context "a #{fixture} and creator #{creator_is_admin ? 'is' : 'not'} admin" do
+        let(:work) { FactoryBot.create(fixture) }
+        it "Creates work activity notifications for the curator & the creator after #{method_sym}" do
+          user = work.created_by_user
+          if creator_is_admin
+            user.add_role(:collection_admin, work.collection)  
+          else
+            curator_user # make sure the curator exists
+          end
+          expect do
+            work.send(method_sym, user)
+          end.to change { WorkActivity.count }.by(2)
+            .and change { WorkActivityNotification.count }.by(creator_is_admin ? 1 : 2)
+        end
       end
     end
   end


### PR DESCRIPTION
- Fix #855
- Refactor test to cover four cases: 2 work states (associated with a particular transition method to call) times 2 admin conditions (creator is or is not admin)