### PR TITLE
No longer redirect if ARK or DOI is only a partial match (except for the prefix, which is optional)

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -89,13 +89,13 @@ class Work < ApplicationRecord
     def find_by_doi(doi)
       prefix = "10.34770/"
       doi = "#{prefix}#{doi}" unless doi.start_with?(prefix)
-      Work.find_by!('metadata @> ?', JSON.dump(doi: doi))
+      Work.find_by!("metadata @> ?", JSON.dump(doi: doi))
     end
 
     def find_by_ark(ark)
       prefix = "ark:/"
       ark = "#{prefix}#{ark}" unless ark.start_with?(prefix)
-      Work.find_by!('metadata @> ?', JSON.dump(ark: ark))
+      Work.find_by!("metadata @> ?", JSON.dump(ark: ark))
     end
 
     delegate :resource_type_general_values, to: PDCMetadata::Resource

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -87,11 +87,15 @@ class Work < ApplicationRecord
 
   class << self
     def find_by_doi(doi)
+      prefix = "10.34770/"
+      doi = "#{prefix}#{doi}" unless doi.start_with?(prefix)
       Work.find_by!('metadata @> ?', JSON.dump(doi: doi))
     end
 
     def find_by_ark(ark)
-      Work.find_by!('metadata @> ?', JSON.dump(ark: doi))
+      prefix = "ark:/"
+      ark = "#{prefix}#{ark}" unless ark.start_with?(prefix)
+      Work.find_by!('metadata @> ?', JSON.dump(ark: ark))
     end
 
     delegate :resource_type_general_values, to: PDCMetadata::Resource

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -87,19 +87,11 @@ class Work < ApplicationRecord
 
   class << self
     def find_by_doi(doi)
-      # This does a string compare to allow for partial matches
-      # I'm not entirely sure why we are allowing partial matches in a find by
-      Work.find_by!("metadata->>'doi' like ? ", "%#{doi}")
-      # I think we should be doing the following instead, which matches exactly
-      # Work.find_by!('metadata @> ?', "{\"doi\":\"#{doi}\"}")
+      Work.find_by!('metadata @> ?', JSON.dump(doi: doi))
     end
 
     def find_by_ark(ark)
-      # This does a string compare to allow for partial matches
-      # I'm not entirely sure why we are allowing partial matches in a find by
-      Work.find_by!("metadata->>'ark' like ? ", "%#{ark}")
-      # I think we should be doing the following instead, which matches exactly
-      # Work.find_by!('metadata @> ?', "{\"ark\":\"#{ark}\"}")
+      Work.find_by!('metadata @> ?', JSON.dump(ark: doi))
     end
 
     delegate :resource_type_general_values, to: PDCMetadata::Resource

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -829,9 +829,9 @@ RSpec.describe WorksController do
 
           it "does not redirect to the Work show view if not exact (missing slash)" do
             stub_s3
-            expect { 
+            expect do
               get :resolve_doi, params: { doi: work.doi.gsub("10.34770", "") }
-            }.to raise_error(ActiveRecord::RecordNotFound)
+            end.to raise_error(ActiveRecord::RecordNotFound)
           end
         end
       end
@@ -862,9 +862,9 @@ RSpec.describe WorksController do
 
           it "does not redirect to the Work show view if not exact (missing slash)" do
             stub_s3
-            expect { 
+            expect do
               get :resolve_ark, params: { ark: work.ark.gsub("ark:", "") }
-            }.to raise_error(ActiveRecord::RecordNotFound)
+            end.to raise_error(ActiveRecord::RecordNotFound)
           end
         end
       end


### PR DESCRIPTION
- Fix #827

I've implemented one exception as suggested in that issue: either ID can be provided without the prefix. I don't know how this feature is being used, so I'm not confident that is the right course.

The test is repetitive: I've tried making it more DRY... but that also makes it harder to read. Whatever the reviewer thinks best: Either approve the current state, or request changes and I could paste it in.

<details><summary>More DRY</summary>

```ruby
    describe "ID redirection" do
      {
        doi: "10.34770/",
        ark: "ark:/"
      }.each do |method_sym, prefix|
        resolve_method_sym = "resolve_#{method_sym}"
        describe resolve_method_sym do
          before do
            sign_in user
            stub_s3 data: data
          end

          let(:data) { [] }
          let(:work) { FactoryBot.create(:shakespeare_and_company_work) }

          it "redirects to the Work show view" do
            stub_s3
            get resolve_method_sym, params: { method_sym => work.send(method_sym) }
            expect(response).to redirect_to(work_path(work))
          end

          context "when passing only a segment of the #{method_sym}" do
            it "redirects to the Work show view if missing prefix" do
              stub_s3
              expect(work.send(method_sym)).to start_with(prefix)
              get resolve_method_sym, params: { method_sym => work.send(method_sym).gsub(prefix, "") }
              expect(response).to redirect_to(work_path(work))
            end

            it "does not redirect to the Work show view if not exact (missing slash)" do
              stub_s3
              expect do
                get resolve_method_sym, params: { method_sym => work.send(method_sym).gsub(prefix[0...-1], "") }
              end.to raise_error(ActiveRecord::RecordNotFound)
            end
          end
        end
      end
    end
```

`rspec spec/controllers/works_controller_spec.rb:805 -f d`
```
WorksController
  valid user login
    ID redirection
      resolve_ark
        redirects to the Work show view
        when passing only a segment of the ark
          redirects to the Work show view if missing prefix
          does not redirect to the Work show view if not exact (missing slash)
      resolve_doi
        redirects to the Work show view
        when passing only a segment of the doi
          does not redirect to the Work show view if not exact (missing slash)
          redirects to the Work show view if missing prefix
```

</details>