### PR TITLE
Allow a curator who deposited a work the ability to edit the work after it has been approved

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -114,7 +114,7 @@ class WorksController < ApplicationController
     if current_user.blank? || !@work.editable_by?(current_user)
       Rails.logger.warn("Unauthorized attempt to update work #{@work.id} by user #{current_user.uid}")
       redirect_to root_path
-    elsif @work.approved? && @work.submitted_by?(current_user)
+    elsif !@work.editable_in_current_state?(current_user)
       redirect_to root_path, notice: I18n.t("works.approved.uneditable")
     else
       update_work

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -77,6 +77,14 @@ class Work < ApplicationRecord
     submitted_by?(user) || administered_by?(user)
   end
 
+  def editable_in_current_state?(user)
+    # anyone with edit privleges can edit a work while it is in draft or awaiting approval
+    return editable_by?(user) if draft? || awaiting_approval?
+
+    # Only admisitrators can edit a work in other states
+    administered_by?(user)
+  end
+
   def submitted_by?(user)
     created_by_user_id == user.id
   end

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -72,7 +72,7 @@
 
 <div class="row">
   <div class="col-8">
-    <% if @work.draft?  || @work.awaiting_approval? || current_user.has_role?(:collection_admin, @collection) %>
+    <% if @work.editable_in_current_state?(current_user)  %>
       <%= link_to("Edit", edit_work_path(@work, wizard: @work.draft?), class: "btn btn-primary") %>
     <% end %>
     <% if @work.awaiting_approval? && current_user.has_role?(:collection_admin, @collection) %>

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -1216,7 +1216,7 @@ RSpec.describe WorksController do
 
     context "the work is approved" do
       let(:work) { FactoryBot.create :approved_work }
-      let(:new_params) { params.merge(doi: "new-doi").merge(ark: "new-ark").merge(collection_tags: "new-colletion-tag1, new-collection-tag2") }
+      let(:new_params) { params.merge(doi: "new-doi").merge(ark: "ark:/99999/new-ark").merge(collection_tags: "new-colletion-tag1, new-collection-tag2") }
 
       context "the submitter" do
         let(:user) { work.created_by_user }
@@ -1243,7 +1243,19 @@ RSpec.describe WorksController do
           sign_in user
           patch :update, params: new_params
           expect(work.reload.doi).to eq("new-doi")
-          expect(work.ark).to eq("new-ark")
+          expect(work.ark).to eq("ark:/99999/new-ark")
+          expect(work.resource.collection_tags).to eq(["new-colletion-tag1", "new-collection-tag2"])
+        end
+      end
+
+      context "the submitter is the curator" do
+        let(:work) { FactoryBot.create(:approved_work, created_by_user_id: curator.id) }
+
+        it "renders the edit page on edit" do
+          sign_in curator
+          patch :update, params: new_params
+          expect(work.reload.doi).to eq("new-doi")
+          expect(work.ark).to eq("ark:/99999/new-ark")
           expect(work.resource.collection_tags).to eq(["new-colletion-tag1", "new-collection-tag2"])
         end
       end
@@ -1254,7 +1266,7 @@ RSpec.describe WorksController do
           sign_in user
           patch :update, params: new_params
           expect(work.reload.doi).to eq("new-doi")
-          expect(work.ark).to eq("new-ark")
+          expect(work.ark).to eq("ark:/99999/new-ark")
           expect(work.resource.collection_tags).to eq(["new-colletion-tag1", "new-collection-tag2"])
         end
       end

--- a/spec/factories/work.rb
+++ b/spec/factories/work.rb
@@ -103,6 +103,7 @@ FactoryBot.define do
         json_from_spec = File.read(Rails.root.join("spec", "fixtures", "cytoskeletal_metadata.json"))
         PDCMetadata::Resource.new_from_jsonb(JSON.parse(json_from_spec))
       end
+      state { "draft" }
       created_by_user_id { FactoryBot.create(:user).id }
     end
 

--- a/spec/system/work_spec.rb
+++ b/spec/system/work_spec.rb
@@ -145,10 +145,15 @@ RSpec.describe "Creating and updating works", type: :system do
       expect(page.html.include?("/works/#{draft_work.id}/edit?wizard=true")).to be true
     end
 
-    it "does not use the wizard if the work once the work is not in draft" do
-      sign_in user
-      visit work_path(awaiting_approval_work)
-      expect(page.html.include?("/works/#{awaiting_approval_work.id}/edit")).to be true
+    context "work is awaiting approval" do
+      let(:awaiting_approval_work) { FactoryBot.create(:awaiting_approval_work) }
+      let(:user) { awaiting_approval_work.created_by_user }
+
+      it "does not use the wizard if the work once the work is not in draft" do
+        sign_in user
+        visit work_path(awaiting_approval_work)
+        expect(page.html.include?("/works/#{awaiting_approval_work.id}/edit")).to be true
+      end
     end
 
     it "allows users to modify the order of the creators", js: true do


### PR DESCRIPTION

Moved logic for edit button to the work, so it can be utilized in the controller and the view.  The view logic and the controller logic was not quite complete.  The view logic did not care if the user had edit rights for the item.  The controller logic did not allow administrators to edit the work if they submitted the work.

fixes #833