### PR TITLE
Adds support for domains

### DIFF
--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Domain
+  def self.all
+    # Values taken from PDC Discovery
+    # https://github.com/pulibrary/pdc_discovery/blob/main/lib/traject/domain.rb
+    domains = []
+    domains << "Engineering"
+    domains << "Humanities"
+    domains << "Natural Sciences"
+    domains << "Social Sciences"
+    domains
+  end
+end

--- a/app/models/pdc_metadata/resource.rb
+++ b/app/models/pdc_metadata/resource.rb
@@ -10,7 +10,7 @@ module PDCMetadata
   class Resource
     attr_accessor :creators, :titles, :publisher, :publication_year, :resource_type, :resource_type_general,
       :description, :doi, :ark, :rights, :version_number, :collection_tags, :keywords, :contributors, :related_objects,
-      :funders
+      :funders, :domains
 
     # rubocop:disable Metrics/MethodLength
     def initialize(doi: nil, title: nil, resource_type: nil, resource_type_general: nil, creators: [], description: nil)
@@ -31,6 +31,7 @@ module PDCMetadata
       @keywords = []
       @contributors = []
       @funders = []
+      @domains = []
     end
     # rubocop:enable Metrics/MethodLength
 
@@ -96,6 +97,7 @@ module PDCMetadata
           resource.publisher = hash["publisher"]
           resource.publication_year = hash["publication_year"]
           resource.rights = rights(hash["rights"])
+          resource.domains = hash["domains"] || []
         end
 
         def set_curator_controlled_metadata(resource, hash)

--- a/app/services/form_to_resource_service.rb
+++ b/app/services/form_to_resource_service.rb
@@ -15,6 +15,7 @@ class FormToResourceService
       resource.publication_year = params["publication_year"] if params["publication_year"].present?
       resource.rights = PDCMetadata::Rights.find(params["rights_identifier"])
       resource.keywords = (params["keywords"] || "").split(",").map(&:strip)
+      resource.domains = params["domains"] || []
 
       add_curator_controlled(params, resource)
       add_titles(params, resource)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,6 +22,13 @@
     <!-- Provides https://jqueryui.com/sortable/ and /autocomplete/-->
     <script src="https://code.jquery.com/ui/1.13.1/jquery-ui.js"></script>
 
+    <!-- Reference bootstrap-select for the modern looking multi-select dropdown list
+      Notice that we are using a beta version of this component since that's the one
+      supported with Bootstrap 5 (https://stackoverflow.com/a/67949799/446681).
+    -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.14.0-beta2/css/bootstrap-select.min.css" integrity="sha512-mR/b5Y7FRsKqrYZou7uysnOdCIJib/7r5QeJMFvLNHNhtye3xJp1TdJVPLtetkukFn227nKpXD9OjUc09lx97Q==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.14.0-beta2/js/bootstrap-select.min.js" integrity="sha512-FHZVRMUW9FsXobt+ONiix6Z0tIkxvQfxtCSirkKc5Sb4TKHmqq1dZa8DphF0XqKb3ldLu/wgMa8mT6uXiLlRlw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.11.3/css/jquery.dataTables.min.css"/>
     <script type="text/javascript" src="https://cdn.datatables.net/1.11.3/js/jquery.dataTables.min.js"></script>
     <%= favicon_link_tag asset_path('favicon.png') %>
@@ -50,9 +57,9 @@
       datacite: <%= raw(
         ['ContributorType', 'RelationType', 'RelatedIdentifierType'].map { |name|
           [
-            name, 
+            name,
             Datacite::Mapping.const_get(name).to_a.map(&:value)
-          ] 
+          ]
         }.to_h.to_json
       ) %>,
     };

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,13 +22,6 @@
     <!-- Provides https://jqueryui.com/sortable/ and /autocomplete/-->
     <script src="https://code.jquery.com/ui/1.13.1/jquery-ui.js"></script>
 
-    <!-- Reference bootstrap-select for the modern looking multi-select dropdown list
-      Notice that we are using a beta version of this component since that's the one
-      supported with Bootstrap 5 (https://stackoverflow.com/a/67949799/446681).
-    -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.14.0-beta2/css/bootstrap-select.min.css" integrity="sha512-mR/b5Y7FRsKqrYZou7uysnOdCIJib/7r5QeJMFvLNHNhtye3xJp1TdJVPLtetkukFn227nKpXD9OjUc09lx97Q==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.14.0-beta2/js/bootstrap-select.min.js" integrity="sha512-FHZVRMUW9FsXobt+ONiix6Z0tIkxvQfxtCSirkKc5Sb4TKHmqq1dZa8DphF0XqKb3ldLu/wgMa8mT6uXiLlRlw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.11.3/css/jquery.dataTables.min.css"/>
     <script type="text/javascript" src="https://cdn.datatables.net/1.11.3/js/jquery.dataTables.min.js"></script>
     <%= favicon_link_tag asset_path('favicon.png') %>

--- a/app/views/works/_additional_form.html.erb
+++ b/app/views/works/_additional_form.html.erb
@@ -8,9 +8,10 @@
   value="<%= @work.resource.keywords.join(', ') %>"
 />
 
-
 <%= render(partial: 'works/funder_table') %>
 
 <%= render(partial: 'works/related_objects_table') %>
 
 <%= render(partial: 'works/contributors_table') %>
+
+<%= render(partial: 'works/domains') %>

--- a/app/views/works/_domains.html.erb
+++ b/app/views/works/_domains.html.erb
@@ -1,0 +1,24 @@
+<div class="section-title">
+  <details>
+    <summary>Domains</summary>
+    Select one or more domains that apply to this dataset.
+  </details>
+
+  <!-- https://developer.snapappointments.com/bootstrap-select/options/ -->
+  <select id="domains" name="domains[]" class="selectpicker" size="3" multiple data-none-selected-text="No domains selected" data-width="600px">
+    <% Domain.all.each do |domain| %>
+      <% if @work.resource.domains.include?(domain) %>
+        <option selected><%= domain %></option>
+      <% else %>
+        <option><%= domain %></option>
+      <% end %>
+    <% end %>
+  </select>
+</div>
+
+<script>
+  $(function() {
+    /* Enable the domain multi-select dropdown */
+    $("#domains").selectpicker();
+  });
+</script>

--- a/app/views/works/_domains.html.erb
+++ b/app/views/works/_domains.html.erb
@@ -4,8 +4,8 @@
     Select one or more domains that apply to this dataset.
   </details>
 
-  <!-- https://developer.snapappointments.com/bootstrap-select/options/ -->
-  <select id="domains" name="domains[]" class="selectpicker" size="3" multiple data-none-selected-text="No domains selected" data-width="600px">
+  <!-- https://getbootstrap.com/docs/5.0/forms/select/ -->
+  <select id="domains" name="domains[]" class="form-select" multiple >
     <% Domain.all.each do |domain| %>
       <% if @work.resource.domains.include?(domain) %>
         <option selected><%= domain %></option>
@@ -16,9 +16,3 @@
   </select>
 </div>
 
-<script>
-  $(function() {
-    /* Enable the domain multi-select dropdown */
-    $("#domains").selectpicker();
-  });
-</script>

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -154,6 +154,15 @@
         </dd>
       <% end %>
 
+      <% if @work.resource.domains.count > 0 %>
+        <dt>Domains</dt>
+        <dd>
+          <% @work.resource.domains.each do |domain| %>
+            <span class="badge bg-dark"><%= domain %></span>
+          <% end %>
+        </dd>
+      <% end %>
+
       <% if @work.resource.rights.present? %>
         <dt>Rights</dt>
         <dd><%= @work.resource.rights.name %> (<%= link_to(@work.resource.rights.identifier, @work.resource.rights.uri, {target: "_blank"}) %>)</dd>
@@ -174,7 +183,7 @@
         <dt>Resource Type</dt>
         <dd><%= @work.resource_type %></dd>
       <% end %>
-        
+
       <% if @work.resource_type_general %>
         <dt>General Type</dt>
         <dd><%= @work.resource_type_general %></dd>
@@ -215,7 +224,7 @@
             <%= funder.award_uri %>
           </dd>
         <% end %>
-      <% end %> 
+      <% end %>
 
       <dt>Location</dt>
       <dd>

--- a/spec/models/pdc_metadata/resource_spec.rb
+++ b/spec/models/pdc_metadata/resource_spec.rb
@@ -119,6 +119,14 @@ RSpec.describe PDCMetadata::Resource, type: :model do
     expect(ds.to_json).to include("green")
   end
 
+  it "allows for domains" do
+    ds.domains << "Humanities"
+    ds.domains << "Social Sciences"
+    expect(ds.domains).to eq(["Humanities", "Social Sciences"])
+    expect(ds.to_json).to include("Humanities")
+    expect(ds.to_json).to include("Social Sciences")
+  end
+
   describe "##new_from_jsonb" do
     let(:jsonb) do
       {
@@ -148,7 +156,8 @@ RSpec.describe PDCMetadata::Resource, type: :model do
           "funder_name" => nil,
           "award_number" => nil,
           "award_uri" => nil
-        }]
+        }],
+        "domains" => ["Humanities"]
       }
     end
     it "parses the json" do
@@ -157,6 +166,7 @@ RSpec.describe PDCMetadata::Resource, type: :model do
       expect(resource.collection_tags).to eq(["ABC", "123"])
       expect(resource.keywords).to eq(["red", "yellow", "green"])
       expect(resource.description).to eq("All data is related to the Shakespeare and Company bookshop and lending library opened and operated by Sylvia Beach in Paris, 1919–1962.")
+      expect(resource.domains).to eq(["Humanities"])
       expect(JSON.parse(resource.to_json)).to eq(jsonb)
     end
   end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -54,7 +54,8 @@ RSpec.describe Work, type: :model do
             "related_objects" => [],
             "keywords" => [],
             "contributors" => [],
-            "funders" => []
+            "funders" => [],
+            "domains"=>[]
           },
           "files" => [],
           "collection" => {
@@ -999,7 +1000,8 @@ RSpec.describe Work, type: :model do
             "award_number": "nsf-123",
             "award_uri": "http://nsg.gov/award/123"
           }
-        ]
+        ],
+        "domains":[]
       }'
     end
     it "can change the entire resource" do

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Work, type: :model do
             "keywords" => [],
             "contributors" => [],
             "funders" => [],
-            "domains"=>[]
+            "domains" => []
           },
           "files" => [],
           "collection" => {

--- a/spec/services/resource_compare_service_spec.rb
+++ b/spec/services/resource_compare_service_spec.rb
@@ -58,7 +58,7 @@ describe ResourceCompareService do
 
   describe "checking every field" do
     new_values = {
-      # These could be filled in with represenatative values, but since this
+      # These could be filled in with representative values, but since this
       # really just checking the coverage of the ResouceCompareService,
       # that isn't critical.
       related_objects: [],
@@ -68,7 +68,8 @@ describe ResourceCompareService do
       funders: [],
       keywords: [],
       contributors: [],
-      creators: []
+      creators: [],
+      domains: ["Humanities"]
     }
     expected_diff = {
       doi: [{ action: :changed, from: "10.34770/pe9w-x904", to: "" }],
@@ -83,7 +84,8 @@ describe ResourceCompareService do
       rights: [{ action: :changed, from: "Creative Commons Attribution 4.0 International", to: "" }],
       titles: [{ action: :changed, from: "Shakespeare and Company Project Dataset: Lending Library Members, Books, Events ()", to: "new title ()" }],
       collection_tags: [{ action: :changed, from: "", to: "fake" }],
-      creators: [{ action: :changed, from: "Kotin, Joshua | 1 | ", to: "" }]
+      creators: [{ action: :changed, from: "Kotin, Joshua | 1 | ", to: "" }],
+      domains:[{ action: :changed, from: "", to: "Humanities" }]
     }
     resource1 = FactoryBot.create(:shakespeare_and_company_work).resource
     keys = resource1.as_json.keys.sort

--- a/spec/services/resource_compare_service_spec.rb
+++ b/spec/services/resource_compare_service_spec.rb
@@ -85,7 +85,7 @@ describe ResourceCompareService do
       titles: [{ action: :changed, from: "Shakespeare and Company Project Dataset: Lending Library Members, Books, Events ()", to: "new title ()" }],
       collection_tags: [{ action: :changed, from: "", to: "fake" }],
       creators: [{ action: :changed, from: "Kotin, Joshua | 1 | ", to: "" }],
-      domains:[{ action: :changed, from: "", to: "Humanities" }]
+      domains: [{ action: :changed, from: "", to: "Humanities" }]
     }
     resource1 = FactoryBot.create(:shakespeare_and_company_work).resource
     keys = resource1.as_json.keys.sort


### PR DESCRIPTION
Adds support for a multi-value domain field with a controlled vocabulary in the Additional Metadata section of the Work. 

The current values in the controlled vocabulary were copied from what were using for DataSpace records in PDC Discovery but we could easily expand that list in a future PR once we get the official list from RDOS.

![Screenshot 2023-01-26 at 4 49 51 PM](https://user-images.githubusercontent.com/568286/214958481-78f23345-e049-45d5-ae1a-0c2d83073b8c.png)


Closes #905 