### PR TITLE
Updating the Ark validation to only be called when needed

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -541,7 +541,10 @@ class Work < ApplicationRecord
     end
 
     def validate_ark
-      if ark.present?
+      return if ark.blank?
+      first_save = id.blank?
+      changed_value = metadata["ark"] != ark
+      if first_save || changed_value
         errors.add(:base, "Invalid ARK provided for the Work: #{ark}") unless Ark.valid?(ark)
       end
     end

--- a/spec/factories/work.rb
+++ b/spec/factories/work.rb
@@ -15,11 +15,12 @@ FactoryBot.define do
     factory :draft_work do
       transient do
         doi { "10.34770/123-abc" }
+        ark { nil }
       end
       collection { Collection.research_data }
       state { "draft" }
       created_by_user_id { FactoryBot.create(:user).id }
-      resource { FactoryBot.build :resource, doi: doi }
+      resource { FactoryBot.build :resource, doi: doi, ark: ark }
     end
 
     factory :awaiting_approval_work do

--- a/spec/models/work_validation_spec.rb
+++ b/spec/models/work_validation_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe Work, type: :model do
+  describe "#validate_ark" do
+    let(:work) { FactoryBot.build(:draft_work, ark: "ark:/88435/dsp01zc77st047") }
+    before do
+      allow(Ark).to receive(:valid?).and_return(true)
+    end
+
+    it "validates the ark" do
+      work.save
+      expect(Ark).to have_received(:valid?).once
+    end
+
+    context "when the ark does not change" do
+      before do
+        work.save
+      end
+      it "does not validate the ark" do
+        expect(work.save).to be_truthy
+        expect(Ark).to have_received(:valid?).once
+      end
+    end
+
+    context "when the ark changes" do
+      before do
+        work.save
+        work.resource.ark = "ark:/88435/changed999"
+      end
+      it "validates the ark" do
+        expect(work.save).to be_truthy
+        expect(Ark).to have_received(:valid?).twice
+      end
+    end
+
+    context "when the ark is not set" do
+      let(:work) { FactoryBot.build(:draft_work) }
+
+      it "does not validate the ark" do
+        expect(work.save).to be_truthy
+        expect(Ark).not_to have_received(:valid?)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Validation is needed when the record is new, or when the metadata is changed Put the validation into it's own spec file as I would love to move the validation out from the work model and into a spearate class in the future.  Also the work spec files is just too big...

fixes #926