### PR TITLE
Upgrading browser-tools orb version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ commands:
           paths:
             - ~/.cache/yarn
 orbs:
-  browser-tools: circleci/browser-tools@1.2
+  browser-tools: circleci/browser-tools@1.4.1
 jobs:
   build:
     working_directory: ~/rails_template


### PR DESCRIPTION
Fixes `curl: (22) The requested URL returned error: 404` https://app.circleci.com/pipelines/github/pulibrary/pdc_describe/2644/workflows/f4740255-fb88-48d8-b62a-9bd457992896/jobs/8554

Not sure if we entirely need this.  Rerunning the job caused it to pass.  If CI passes, there does not seem to be any harm in upgrading the ORB though...