### PR TITLE
Allowing vite javascript to not be minifed in the Development environment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,21 @@
 import { defineConfig } from 'vite'
 import RubyPlugin from 'vite-plugin-ruby'
 
-export default defineConfig({
-  plugins: [
-    RubyPlugin(),
-  ],
-})
+export default ({ command, mode }) => {
+  let minifySetting
+
+  if (mode === "development") {
+    minifySetting = false
+  } else {
+    minifySetting = "esbuild" 
+  }
+
+  return {
+    build: {
+      minify: minifySetting
+    },
+    plugins: [
+      RubyPlugin(),
+    ],
+  }
+}


### PR DESCRIPTION
Grabbed this technique from Jeff Knox here: https://www.jeffreyknox.dev/blog/dropping-webpack-for-vite-part-2/

On staging we are still minified:
![Screenshot 2023-02-03 at 10 48 42 AM](https://user-images.githubusercontent.com/1599081/216646650-79d0ad1a-71c4-4d92-a51d-7a950ec178a9.png)

On Development we are not minified:
![Screenshot 2023-02-03 at 10 49 57 AM](https://user-images.githubusercontent.com/1599081/216647007-35bae958-fbee-45bc-9a63-7eedb0b6f823.png)
