### PR TITLE
Add coding style section to readme and update JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,15 @@ Sample data available here: https://docs.google.com/document/d/18ZkBldqWxIIR1UA6
 ## Notes on migration process from DataSpace
 
 Datasets are re-described in order to migrate its metadata from modified Dublin Core to modified DataCite, and to migrate location from Princeton's legacy DataSpace repository to the DataCite compliant Princeton Data Commons suite of applications.
+
+## Coding style
+
+### Ruby
+We run Rubocop in CI, in particular the defaults provided by [Bixby](https://github.com/samvera/bixby).
+We've increased some of the limits, so if you run into a warning about method length, for example,
+consider refactoring your code for readability instead of just adding an ignore. 
+
+### Javascript
+We run ESLint in CI, in particular the defaults provided by AirBNB. We are moving towards ESM bundled by
+[Vite](https://vitejs.dev/). To keep things simple, we're just using jQuery, and will not be using React or Vue.
+Variables containing jQuery objects should be prefixed with `$`.

--- a/app/assets/javascripts/edit_collection_utils.js
+++ b/app/assets/javascripts/edit_collection_utils.js
@@ -86,32 +86,32 @@ $(() => {
   if ($('#data-loaded').text() != 'true') {
     // Displays the initial list of submitters.
     $('.submitter-data').each((ix, el) => {
-      var elList = $('#submitter-list');
+      var $elList = $('#submitter-list');
       var uid = $(el).data('uid');
       var collectionId = $(el).data('collectionId');
       var canDelete = $(el).data('canDelete');
       var isYou = $(el).data('you') == true;
       var is_super_admin = false;
-      addUserHtml(elList, uid, collectionId, 'submit', canDelete, isYou, is_super_admin);
+      addUserHtml($elList, uid, collectionId, 'submit', canDelete, isYou, is_super_admin);
     });
 
     // Displays the initial list of curators.
     $('.curator-data').each((ix, el) => {
-      var elList = $('#curator-list');
+      var $elList = $('#curator-list');
       var uid = $(el).data('uid');
       var collectionId = $(el).data('collectionId');
       var canDelete = $(el).data('canDelete');
       var isYou = $(el).data('you') == true;
-      addUserHtml(elList, uid, collectionId, 'admin', canDelete, isYou, false);
+      addUserHtml($elList, uid, collectionId, 'admin', canDelete, isYou, false);
     });
 
     // Displays the list of system administrators.
     $('.sysadmin-data').each((ix, el) => {
-      var elList = $('#sysadmin-list');
+      var $elList = $('#sysadmin-list');
       var uid = $(el).data('uid');
       var collectionId = $(el).data('collectionId');
       var isYou = $(el).data('you') == true;
-      addUserHtml(elList, uid, collectionId, 'admin', false, isYou, true);
+      addUserHtml($elList, uid, collectionId, 'admin', false, isYou, true);
     });
 
     // Track that we have displayed this information. This prevents re-display when

--- a/app/assets/javascripts/edit_work_utils.js
+++ b/app/assets/javascripts/edit_work_utils.js
@@ -169,12 +169,12 @@ $(() => {
 
   function deletePerson(rowToDelete, type) {
     const rowExists = $(rowToDelete).length > 0;
-    const rowData = $(`${rowToDelete} input:not(.hidden)`);
+    const $rowData = $(`${rowToDelete} input:not(.hidden)`);
     let i; let
       token;
     let rowText = '';
-    for (i = 0; i < rowData.length; i++) {
-      token = $(rowData[i]).val();
+    for (i = 0; i < $rowData.length; i++) {
+      token = $($rowData[i]).val();
       if (token.trim().length > 0) {
         rowText += `${token} `;
       }
@@ -239,14 +239,14 @@ $(() => {
     const creatorSpans = $(selector);
     const creators = [];
     for (i = 0; i < creatorSpans.length; i++) {
-      el = $(creatorSpans[i]);
+      $el = $(creatorSpans[i]);
       creator = {
-        num: el.data('num'),
-        orcid: el.data('orcid'),
-        givenName: el.data('given-name'),
-        familyName: el.data('family-name'),
-        sequence: el.data('sequence'),
-        role: el.data('role'),
+        num: $el.data('num'),
+        orcid: $el.data('orcid'),
+        givenName: $el.data('given-name'),
+        familyName: $el.data('family-name'),
+        sequence: $el.data('sequence'),
+        role: $el.data('role'),
       };
       creators.push(creator);
     }
@@ -259,9 +259,9 @@ $(() => {
     let selector; let textboxes; let i; let textboxId; let
       value;
     selector = `#${rowId} > td > input`;
-    textboxes = $(selector);
-    for (i = 0; i < textboxes.length; i++) {
-      textboxId = textboxes[i].id;
+    $textboxes = $(selector);
+    for (i = 0; i < $textboxes.length; i++) {
+      textboxId = $textboxes[i].id;
       if (textboxId.startsWith('orcid_') || textboxId.startsWith('given_name_') || textboxId.startsWith('family_name_')) {
         value = $(`#${textboxId}`).val().trim();
         if (value != '') {
@@ -275,10 +275,10 @@ $(() => {
   // Returns the ID of the first row that has an empty creator (if any)
   function findEmptyCreator() {
     let i;
-    const rows = $('.creators-table-row');
-    for (i = 0; i < rows.length; i++) {
-      if (isEmptyRow(rows[i].id)) {
-        return rows[i].id;
+    const $rows = $('.creators-table-row');
+    for (i = 0; i < $rows.length; i++) {
+      if (isEmptyRow($rows[i].id)) {
+        return $rows[i].id;
       }
     }
     return null;
@@ -287,9 +287,9 @@ $(() => {
   // Returns true if there is at least one creator with information
   function hasCreators() {
     let i;
-    const rows = $('.creators-table-row');
+    const $rows = $('.creators-table-row');
     for (i = 0; i < rows.length; i++) {
-      if (!isEmptyRow(rows[i].id)) {
+      if (!isEmptyRow($rows[i].id)) {
         return true;
       }
     }

--- a/app/javascript/entrypoints/pdc/maximum_file_upload.es6
+++ b/app/javascript/entrypoints/pdc/maximum_file_upload.es6
@@ -1,7 +1,7 @@
 export default class MaximumFileUpload {
 
     constructor(upload_id, save_id, error_id = "file-error") {
-      this.upload_element = $("#"+upload_id);
+      this.$upload_element = $("#"+upload_id);
       this.save_element = document.getElementById(save_id);
       this.error_element = document.getElementById(error_id)
       this.attach_validation();
@@ -9,11 +9,11 @@ export default class MaximumFileUpload {
   
     attach_validation() {
         console.log("attaching validation")
-        this.upload_element.on("change", this.validate.bind(this));
+        this.$upload_element.on("change", this.validate.bind(this));
     }
 
     validate() {
-        if (this.upload_element[0].files.length > 20) {
+        if (this.$upload_element[0].files.length > 20) {
             this.save_element.disabled = true;
             this.error_element.innerText = "You can select a maximum of 20 files";
         } else {


### PR DESCRIPTION
- Fix #948

Failing on CI, but passing locally:
```
  1) Creating and updating works Prevents empty title
     Failure/Error: work.draft!(current_user)
     
     AASM::InvalidTransition:
       Event 'draft' cannot transition from 'none'. Failed callback(s): [:valid_to_draft].
     
     [Screenshot Image]: /home/circleci/rails_template/tmp/screenshots/failures_r_spec_example_groups_creating_and_updating_works_3_prevents_empty_title_521.png

     
     # ./app/controllers/works_controller.rb:58:in `new_submission'
     # ------------------
     # --- Caused by: ---
     # Capybara::ExpectationNotMet:
     #   expected to find text "Must provide a title" in "Puma caught this error: Event 'draft' cannot transition from 'none'. Failed callback(s): [:valid_to_draft]. (AASM::InvalidTransition)...
     #   ./spec/system/work_spec.rb:33:in `block (2 levels) in <top (required)>'
```

Draft for now: Will try rerunning on CI. There may be a flaky test.

... Same failure on CI. Possible that I've introduced a bug, but there's some kind of stale JS cache problem locally. Or, possible that this test really is flakey, and I'm just getting lucky now?