### PR TITLE
Test flash messages

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -98,7 +98,7 @@ class WorksController < ApplicationController
     if current_user && @work.editable_by?(current_user)
       if @work.approved? && !@work.administered_by?(current_user)
         Honeybadger.notify("Can not edit work: #{@work.id} is approved but #{current_user} is not admin")
-        redirect_to root_path, notice: I18n.t("works.approved.uneditable")
+        redirect_to root_path, notice: I18n.t("works.uneditable.approved")
       else
         @uploads = @work.uploads
         @wizard_mode = wizard_mode?
@@ -106,7 +106,7 @@ class WorksController < ApplicationController
       end
     else
       Honeybadger.notify("Can not edit work: #{@work.id} is not editable by #{current_user}")
-      redirect_to root_path, notice: I18n.t("works.approved.uneditable")
+      redirect_to root_path, notice: I18n.t("works.uneditable.privs")
     end
   end
 
@@ -114,10 +114,10 @@ class WorksController < ApplicationController
     @work = Work.find(params[:id])
     if current_user.blank? || !@work.editable_by?(current_user)
       Honeybadger.notify("Can not update work: #{@work.id} is not editable by #{current_user}")
-      redirect_to root_path, notice: I18n.t("works.approved.uneditable")
+      redirect_to root_path, notice: I18n.t("works.uneditable.approved")
     elsif !@work.editable_in_current_state?(current_user)
       Honeybadger.notify("Can not update work: #{@work.id} is not editable in current state by #{current_user}")
-      redirect_to root_path, notice: I18n.t("works.approved.uneditable")
+      redirect_to root_path, notice: I18n.t("works.uneditable.privs")
     else
       update_work
     end

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -114,10 +114,10 @@ class WorksController < ApplicationController
     @work = Work.find(params[:id])
     if current_user.blank? || !@work.editable_by?(current_user)
       Honeybadger.notify("Can not update work: #{@work.id} is not editable by #{current_user}")
-      redirect_to root_path, notice: I18n.t("works.uneditable.approved")
+      redirect_to root_path, notice: I18n.t("works.uneditable.privs")
     elsif !@work.editable_in_current_state?(current_user)
       Honeybadger.notify("Can not update work: #{@work.id} is not editable in current state by #{current_user}")
-      redirect_to root_path, notice: I18n.t("works.uneditable.privs")
+      redirect_to root_path, notice: I18n.t("works.uneditable.approved")
     else
       update_work
     end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,6 +36,13 @@
   <body>
     <%= render partial: 'shared/header' %>
     <div class="container">
+      <% if flash[:notice] %>
+        <div class="row">
+          <div class="col">
+            <div class="alert alert-warning" role="alert" ><%= flash[:notice] %></div>
+          </div>
+        </div>
+      <% end %>
       <div class="row">
         <%= yield %>
       </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,7 +1,3 @@
-<% if notice.present? %>
-  <p id="notice"><%= notice %></p>
-<% end %>
-
 <div class="search-bar">
   <div class="search-form">
     <%= form_with(url: user_path(@user.uid), method: "get") do %>

--- a/app/views/works/file_upload.html.erb
+++ b/app/views/works/file_upload.html.erb
@@ -1,8 +1,4 @@
 <div class="wizard-area">
-  <% if flash[:notice] %>
-    <div class="alert alert-warning" role="alert" ><%= flash[:notice] %></div>
-  <% end %>
-
   <h1><%= t('works.form.file_upload.heading', work_title: @work.title) %></h1>
   <%= render "wizard_progress", wizard_step: 2 %>
   <%= form_with(model: @work, scope: :patch, url: work_file_uploaded_path(id: @work.id)) do |f| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,5 +60,6 @@ en:
         heading: "Uncurated Files"
       post_curation_uploads:
         heading: "Curated Files"
-    approved:
-      uneditable: "This work has been approved.  Edits are no longer available."
+    uneditable:
+      approved: "This work has been approved.  Edits are no longer available."
+      privs: "You do not have permission to edit this work."

--- a/spec/system/authz_admin_spec.rb
+++ b/spec/system/authz_admin_spec.rb
@@ -75,7 +75,9 @@ RSpec.describe "Authz for curators", type: :system, js: true do
         # And so, research_data_moderator can NOT edit the work
         login_as research_data_moderator
         visit edit_work_path(work)
+        expect(current_path).to eq root_path
         expect(page).not_to have_content("Editing Dataset")
+        expect(page).to have_content("You do not have permission to edit this work")
       end
 
       context "with submitter rights" do

--- a/spec/system/authz_submitter_spec.rb
+++ b/spec/system/authz_submitter_spec.rb
@@ -53,6 +53,8 @@ RSpec.describe "Authz for submitters", type: :system, js: true do
       visit edit_work_path(work)
       expect(page).not_to have_content "Save Work"
       expect(current_path).to eq root_path
+      expect(page).to have_content "This work has been approved. Edits are no longer available"
+      # TODO: This error isn't actually appropriate: Fix it.
     end
 
     it "should not be able to edit a collection to add curators and submitters" do

--- a/spec/system/authz_submitter_spec.rb
+++ b/spec/system/authz_submitter_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe "Authz for submitters", type: :system, js: true do
       # But other users cannot edit this work. If they try, they are redirected.
       sign_in submitter2
       visit edit_work_path(work)
-      expect(page).not_to have_content "Save Work"
       expect(current_path).to eq root_path
+      expect(page).not_to have_content "Save Work"
       expect(page).to have_content "You do not have permission to edit this work"
     end
 

--- a/spec/system/authz_submitter_spec.rb
+++ b/spec/system/authz_submitter_spec.rb
@@ -53,8 +53,7 @@ RSpec.describe "Authz for submitters", type: :system, js: true do
       visit edit_work_path(work)
       expect(page).not_to have_content "Save Work"
       expect(current_path).to eq root_path
-      expect(page).to have_content "This work has been approved. Edits are no longer available"
-      # TODO: This error isn't actually appropriate: Fix it.
+      expect(page).to have_content "You do not have permission to edit this work"
     end
 
     it "should not be able to edit a collection to add curators and submitters" do


### PR DESCRIPTION
- Fix #943
- Add system tests for flash messages. (Previously, the only tests of flash messages were controller tests... so they didn't fail, even if they didn't make it to the screen.) (Tried for a bit to make a lower-level view test, but never got the wiring sorted out... and view tests aren't our default, in any case.)
- In two cases, we weren't actually sending the right message: fix it.
- Remove redundant rendering of flash messages: It should only be done in one place.