### PR TITLE
Counting the number of files stored in amazon to allow the user to see system processing progress

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -466,6 +466,10 @@ class Work < ApplicationRecord
     }
   end
 
+  def pre_curation_uploads_count
+    s3_query_service.file_count
+  end
+
   delegate :ark, :doi, :resource_type, :resource_type=, :resource_type_general, :resource_type_general=,
            :to_xml, to: :resource
 
@@ -634,7 +638,7 @@ class Work < ApplicationRecord
     # S3QueryService object associated with this Work
     # @return [S3QueryService]
     def s3_query_service
-      @s3_query_service = S3QueryService.new(self, !approved?)
+      @s3_query_service ||= S3QueryService.new(self, !approved?)
     end
 
     # Request S3 Bucket Objects associated with this Work

--- a/app/views/works/uploads/_pre_curation_s3_resources.html.erb
+++ b/app/views/works/uploads/_pre_curation_s3_resources.html.erb
@@ -3,6 +3,8 @@
     <div class="card">
       <div class="files card-body">
         <!-- Only render file download table if there are files in S3 -->
+        <h3><%= "#{@work.pre_curation_uploads.count} #{'File'.pluralize(@work.pre_curation_uploads.count)}" %>  processed by the system </h3>
+        <h3><%= "#{@work.pre_curation_uploads_count} #{'File'.pluralize(@work.pre_curation_uploads_count)}"%> in precuration storage  </h3>
         <table id="files-table" class="table">
           <thead>
             <tr>

--- a/spec/models/s3_file_spec.rb
+++ b/spec/models/s3_file_spec.rb
@@ -9,13 +9,6 @@ RSpec.describe S3File, type: :model do
   let(:checksum) { "abc123" }
   let(:query_service) { instance_double(S3QueryService, class: S3QueryService, bucket_name: bucket_name) }
   let(:bucket_name) { "test-bucket" }
-  let(:url_protocol) { "https" }
-  let(:s3_host) { "s3.amazon.com" }
-
-  before do
-    allow(S3QueryService).to receive(:url_protocol).and_return(url_protocol)
-    allow(S3QueryService).to receive(:s3_host).and_return(s3_host)
-  end
 
   it "can take S3 file data at creation time" do
     expect(s3_file.filename).to eq filename

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -1027,4 +1027,18 @@ RSpec.describe Work, type: :model do
                                                                                     .and change { WorkActivity.count }.by(-2)
     end
   end
+
+  describe "pre_curation_uploads_count" do
+    let(:s3_query_service_double) { instance_double(S3QueryService, file_count: 3) }
+
+    it "gets the count of the files on Amazon" do
+      allow(S3QueryService).to receive(:new).and_return(s3_query_service_double)
+
+      expect(work.pre_curation_uploads_count).to eq(3)
+
+      # only loads the data once
+      expect(work.pre_curation_uploads_count).to eq(3)
+      expect(S3QueryService).to have_received(:new).once
+    end
+  end
 end

--- a/spec/services/s3_query_service_spec.rb
+++ b/spec/services/s3_query_service_spec.rb
@@ -95,18 +95,6 @@ RSpec.describe S3QueryService, mock_s3_query_service: false do
     expect(data_profile[:ok]).to eq false
   end
 
-  describe ".url_protocol" do
-    it "accesses the protocol for the S3 Bucket URL" do
-      expect(described_class.url_protocol).to eq("https")
-    end
-  end
-
-  describe ".s3_host" do
-    it "accesses the host for the S3 Bucket URL" do
-      expect(described_class.s3_host).to eq("s3.amazonaws.com")
-    end
-  end
-
   describe "#client" do
     before do
       allow(Aws::S3::Client).to receive(:new)
@@ -196,6 +184,12 @@ RSpec.describe S3QueryService, mock_s3_query_service: false do
         expect(last_modified.to_s).to eq(s3_last_modified2.to_s)
 
         expect(children.last.size).to eq(s3_size2)
+      end
+    end
+
+    describe "#file_count" do
+      it "returns only the files" do
+        expect(subject.file_count).to eq(2)
       end
     end
   end

--- a/spec/support/s3_query_service_specs.rb
+++ b/spec/support/s3_query_service_specs.rb
@@ -7,6 +7,7 @@ def stub_s3(data: [])
 
   fake_s3_query = double(S3QueryService, data_profile: { objects: data, ok: true }, client: @s3_client)
   allow(fake_s3_query).to receive(:bucket_name).and_return("example-bucket")
+  allow(fake_s3_query).to receive(:file_count).and_return(data.length)
   allow(S3QueryService).to receive(:new).and_return(fake_s3_query)
 
   fake_s3_query

--- a/spec/system/view_data_in_s3_spec.rb
+++ b/spec/system/view_data_in_s3_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe "View status of data in S3", mock_ezid_api: true, js: true do
       # Account for files in S3 added outside of ActiveStorage
       allow(S3QueryService).to receive(:new).and_return(s3_query_service_double)
       allow(s3_query_service_double).to receive(:data_profile).and_return({ objects: s3_data, ok: true })
+      allow(s3_query_service_double).to receive(:file_count).and_return(s3_data.count)
       # Account for files uploaded to S3 via ActiveStorage
       stub_request(:put, /#{bucket_url}/).to_return(status: 200)
 

--- a/spec/system/work_upload_s3_objects_spec.rb
+++ b/spec/system/work_upload_s3_objects_spec.rb
@@ -36,6 +36,7 @@ describe "Uploading S3 Bucket Objects for new Work", mock_ezid_api: true do
       # Account for files in S3 added outside of ActiveStorage
       allow(S3QueryService).to receive(:new).and_return(s3_query_service_double)
       allow(s3_query_service_double).to receive(:data_profile).and_return({ objects: s3_data, ok: true })
+      allow(s3_query_service_double).to receive(:file_count).and_return(s3_data.count)
       # Account for files uploaded to S3 via ActiveStorage
       stub_request(:put, /#{bucket_url}/).to_return(status: 200)
     end


### PR DESCRIPTION

Displays the number of files in the system and then number of files preserved on the work show page
![Screenshot 2023-02-06 at 2 27 51 PM](https://user-images.githubusercontent.com/1599081/217071784-c6652a07-7301-4c3e-bce0-b1b9597b4748.png)

Memoize file client_s3_files so that we do not make additional calls to S3 for the count 
Memoize the S3 service in the work to make sure we are not creating multiple copies 

Also removed unused methods: url_protocol &  s3_host

 fixes #927