### PR TITLE
Fetch pre-curation files from directly from AWS 

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -64,8 +64,6 @@ class WorksController < ApplicationController
   # When requested as .json, return the internal json resource
   def show
     @work = Work.find(params[:id])
-    # check if anything was added in S3 since we last viewed this object
-    @work.attach_s3_resources
     @changes =  WorkActivity.changes_for_work(@work.id)
     @messages = WorkActivity.messages_for_work(@work.id)
 

--- a/app/models/s3_file.rb
+++ b/app/models/s3_file.rb
@@ -2,6 +2,7 @@
 class S3File
   attr_accessor :filename, :last_modified, :size, :checksum
   alias key filename
+  alias id filename
 
   def initialize(filename:, last_modified:, size:, checksum:, query_service: nil)
     @filename = filename
@@ -9,6 +10,18 @@ class S3File
     @size = size
     @checksum = checksum.delete('"')
     @query_service = query_service
+  end
+
+  def created_at
+    last_modified
+  end
+
+  def byte_size
+    size
+  end
+
+  def url
+    @query_service.file_url(key)
   end
 
   def globus_url

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -231,7 +231,7 @@
 
       <dt>Location</dt>
       <dd>
-        <% if @work.pre_curation_uploads.present? %>
+        <% if @work.pre_curation_uploads_fast.present? %>
           Amazon S3 Curation Storage
         <% elsif @work.files_location_cluster? %>
           PUL Research Cluster
@@ -256,7 +256,7 @@
         </section>
       <% end %>
     <% else %>
-      <% if @work.pre_curation_uploads.present? %>
+      <% if @work.pre_curation_uploads_fast.present? %>
         <section class="uploads">
           <h2 class="h2"><%= t('works.uploads.pre_curation.heading') %></h2>
           <%= render(partial: 'works/uploads/pre_curation_s3_resources') %>

--- a/app/views/works/uploads/_pre_curation_s3_resources.html.erb
+++ b/app/views/works/uploads/_pre_curation_s3_resources.html.erb
@@ -3,7 +3,6 @@
     <div class="card">
       <div class="files card-body">
         <!-- Only render file download table if there are files in S3 -->
-        <h3><%= "#{@work.pre_curation_uploads.count} #{'File'.pluralize(@work.pre_curation_uploads.count)}" %>  processed by the system </h3>
         <h3><%= "#{@work.pre_curation_uploads_count} #{'File'.pluralize(@work.pre_curation_uploads_count)}"%> in precuration storage  </h3>
         <table id="files-table" class="table">
           <thead>
@@ -19,12 +18,12 @@
                 <td><span></span></td>
               </tr>
               <% else %>
-                <% @work.pre_curation_uploads.sort_by(&:filename).each_with_index do |file, ix| %>
+                <% @work.pre_curation_uploads_fast.sort_by(&:filename).each_with_index do |file, ix| %>
                 <tr class="files">
                   <td>
                     <span>
                       <i class="bi bi-file-arrow-down"></i>
-                      <a href="<%= rails_blob_path(file, disposition: "attachment") %>" class="documents-file-link" target="_blank" title="<%= file.filename %>"><%= pre_curation_uploads_file_name(file: file) %></a>
+                      <a href="<%= file.url %>" class="documents-file-link" target="_blank" title="<%= file.filename %>"><%= pre_curation_uploads_file_name(file: file) %></a>
                     </span>
                   </td>
                   <td>

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -10,9 +10,11 @@ amazon: &amazon
   bucket: <%= S3QueryService.pre_curation_config.fetch(:bucket) %>
 
 development: &development
-  <<: *local
-# Or uncomment this line to develop against AWS:
-#   <<: *amazon
+# AWS is the default as the will not really work without AWS
+#  You can go back to local if needed for some reason, just be aware the uploaded
+#  files will not display in the edit or the show pages
+#  <<: *local
+   <<: *amazon
 
 
 amazon_pre_curation:

--- a/spec/services/s3_query_service_spec.rb
+++ b/spec/services/s3_query_service_spec.rb
@@ -243,6 +243,30 @@ RSpec.describe S3QueryService, mock_s3_query_service: false do
     end
   end
 
+  describe "#delete_s3_object" do
+    let(:response_headers) do
+      {
+        'Accept-Ranges': "bytes",
+        'Content-Length': 71,
+        'Content-Type': "text/plain",
+        'ETag': "6805f2cfc46c0f04559748bb039d69ae",
+        'Last-Modified': Time.parse("Thu, 15 Dec 2016 01:19:41 GMT")
+      }
+    end
+
+    subject(:s3_query_service) { described_class.new(work) }
+    let(:s3_file) { S3File.new(filename: "test_key", last_modified: Time.zone.now, size: 12_739, checksum: "abc567") }
+
+    before do
+      stub_request(:delete, "https://example-bucket.s3.amazonaws.com/test_key").to_return(status: 200)
+    end
+
+    it "retrieves the S3 Object from the HTTP API" do
+      s3_query_service.delete_s3_object(s3_file.key)
+      assert_requested(:delete, "https://example-bucket.s3.amazonaws.com/test_key")
+    end
+  end
+
   describe "#find_s3_file" do
     subject(:s3_query_service) { described_class.new(work) }
     let(:filename) { "test.txt" }

--- a/spec/services/work_upload_edit_service_spec.rb
+++ b/spec/services/work_upload_edit_service_spec.rb
@@ -23,21 +23,53 @@ RSpec.describe WorkUploadsEditService do
 
   let(:attachment_url) { "#{bucket_url}#{work.doi}/#{work.id}/us_covid_2019.csv" }
 
-  before do
-    stub_request(:put, /#{bucket_url}/).to_return(status: 200)
-    work.pre_curation_uploads.attach(uploaded_file)
-    stub_request(:delete, attachment_url).to_return(status: 200)
+  let(:s3_query_service_double) { instance_double(S3QueryService) }
+  let(:s3_file1) do
+    S3File.new(
+      filename: "#{work.doi}/#{work.id}/us_covid_2019.csv",
+      last_modified: Time.parse("2022-04-21T18:29:40.000Z"),
+      size: 10_759,
+      checksum: "abc123",
+      query_service: s3_query_service_double
+    )
   end
+  let(:s3_file2) do
+    S3File.new(
+      filename: "#{work.doi}/#{work.id}/us_covid_2020.csv",
+      last_modified: Time.parse("2022-04-21T18:30:07.000Z"),
+      size: 12_739,
+      checksum: "abc567",
+      query_service: s3_query_service_double
+    )
+  end
+  let(:s3_file3) do
+    S3File.new(
+      filename: "#{work.doi}/#{work.id}/orcid.csv",
+      last_modified: Time.parse("2022-04-21T18:30:07.000Z"),
+      size: 12_739,
+      checksum: "abc567",
+      query_service: s3_query_service_double
+    )
+  end
+  let(:s3_data) { [s3_file1, s3_file2] }
+
+  # before do
+  # stub_request(:put, /#{bucket_url}/).to_return(status: 200)
+  # work.pre_curation_uploads.attach(uploaded_file)
+  # stub_request(:delete, attachment_url).to_return(status: 200)
+  # end
 
   context "When no uploads changes are in the params" do
     let(:params) { { "work_id" => "" }.with_indifferent_access }
 
     it "returns all existing files" do
+      fake_s3_service = stub_s3(data: s3_data, bucket_url: bucket_url)
+
       upload_service = described_class.new(work, user)
       updated_work = upload_service.update_precurated_file_list(params)
-      list = updated_work.pre_curation_uploads
-      expect(list.map(&:filename)).to eq([uploaded_file.original_filename])
-      expect(a_request(:delete, attachment_url)).not_to have_been_made
+      filenames = updated_work.pre_curation_uploads_fast.map(&:filename)
+      expect(filenames).to eq(s3_data.map(&:filename))
+      expect(fake_s3_service).not_to have_received(:delete_s3_object)
       expect(work.work_activity.count).to be 0
     end
   end
@@ -47,44 +79,53 @@ RSpec.describe WorkUploadsEditService do
   end
 
   context "When upload removals are in the params" do
-    let(:params) { { "work_id" => "", "deleted_uploads" => { "10.34770/123-abc/#{work.id}/#{uploaded_file.original_filename}" => "1" } }.with_indifferent_access }
-
-    before do
-      work.pre_curation_uploads.attach(uploaded_file2)
-    end
+    let(:params) { { "work_id" => "", "deleted_uploads" => { s3_data[0].filename => "1" } }.with_indifferent_access }
 
     it "returns all existing files except the deleted one" do
+      fake_s3_service = stub_s3(bucket_url: bucket_url)
+      allow(fake_s3_service).to receive(:client_s3_files).and_return(s3_data, [s3_file2])
+
       upload_service = described_class.new(work, user)
       updated_work = upload_service.update_precurated_file_list(params)
-      list = updated_work.pre_curation_uploads
-      expect(list.map(&:filename)).to eq([uploaded_file2.original_filename])
-      expect(a_request(:delete, attachment_url)).to have_been_made.once
-      # it logs the delete
+      expect(updated_work.pre_curation_uploads_fast.map(&:filename)).to eq([s3_file2.key])
+      expect(fake_s3_service).to have_received(:delete_s3_object).with(s3_file1.key).once
+
+      # it logs the delete (and no additions)
       activity_log = JSON.parse(work.work_activity.first.message)
-      expect(activity_log.find { |log| log["action"] == "deleted" && log["filename"] == "us_covid_2019.csv" }).not_to be nil
+      expect(activity_log.find { |log| log["action"] == "deleted" && log["filename"] == s3_data[0].filename }).not_to be nil
+      expect(activity_log.find { |log| log["action"] == "added" }).to be nil
     end
   end
 
   context "When upload replacements are in the params" do
     let(:attachment_url) { "#{bucket_url}#{work.doi}/#{work.id}/us_covid_2020.csv" }
-    before do
-      work.pre_curation_uploads.attach(uploaded_file2)
-      work.pre_curation_uploads.attach(uploaded_file3)
+    let(:s3_file4) do
+      S3File.new(
+        filename: "#{work.doi}/#{work.id}/datacite_basic.xml",
+        last_modified: Time.parse("2022-04-21T18:30:07.000Z"),
+        size: 12_739,
+        checksum: "abc567",
+        query_service: s3_query_service_double
+      )
     end
-    let(:params) { { "work_id" => "", "replaced_uploads" => { work.pre_curation_uploads[1].key => uploaded_file4 } }.with_indifferent_access }
+
+    let(:params) { { "work_id" => "", "replaced_uploads" => { work.pre_curation_uploads_fast.last.key => uploaded_file4 } }.with_indifferent_access }
 
     it "replaces the correct file" do
+      fake_s3_service = stub_s3(bucket_url: bucket_url)
+      # TODO: why do I need the first set of files twice.  Maybe a memo is not getting set properly?
+      allow(fake_s3_service).to receive(:client_s3_files).and_return([s3_file1, s3_file2, s3_file3], [s3_file1, s3_file2, s3_file3], [s3_file1, s3_file3, s3_file4])
       upload_service = described_class.new(work, user)
       updated_work = upload_service.update_precurated_file_list(params)
-      list = updated_work.pre_curation_uploads
+      list = updated_work.pre_curation_uploads_fast
 
       # remeber order of the files will be alphabetical
-      expect(list.map(&:filename)).to eq([uploaded_file.original_filename, uploaded_file3.original_filename, uploaded_file4.original_filename])
-      expect(a_request(:delete, attachment_url)).to have_been_made.once
+      expect(list.map(&:filename)).to eq([s3_file4.key, s3_file3.key, s3_file1.key])
+      expect(fake_s3_service).to have_received(:delete_s3_object).with(s3_file2.key).once
 
       # it logs the activity
       activity_log = JSON.parse(work.work_activity.first.message)
-      expect(activity_log.find { |log| log["action"] == "deleted" && log["filename"] == "us_covid_2020.csv" }).not_to be nil
+      expect(activity_log.find { |log| log["action"] == "deleted" && log["filename"] == s3_file2.key }).not_to be nil
       expect(activity_log.find { |log| log["action"] == "added" && log["filename"] == "datacite_basic.xml" }).not_to be nil
     end
   end
@@ -93,37 +134,44 @@ RSpec.describe WorkUploadsEditService do
     let(:params) { { "work_id" => "", "pre_curation_uploads" => [uploaded_file2, uploaded_file3] }.with_indifferent_access }
 
     it "replaces all the files" do
+      fake_s3_service = stub_s3(bucket_url: bucket_url)
+      # TODO: why do I need the first set of files twice.  Maybe a memo is not getting set properly?
+      allow(fake_s3_service).to receive(:client_s3_files).and_return([s3_file1], [s3_file1], [s3_file2, s3_file3])
       upload_service = described_class.new(work, user)
       updated_work = upload_service.update_precurated_file_list(params)
-      list = updated_work.reload.pre_curation_uploads
-      expect(list.map(&:filename)).to eq([uploaded_file2.original_filename, uploaded_file3.original_filename])
-      expect(a_request(:delete, attachment_url)).to have_been_made.once
+      list = updated_work.reload.pre_curation_uploads_fast
+      expect(list.map(&:filename)).to eq([s3_file3.key, s3_file2.key])
+      expect(fake_s3_service).to have_received(:delete_s3_object).with(s3_file1.key).once
 
       # it logs the activity
       activity_log = JSON.parse(work.work_activity.first.message)
-      expect(activity_log.find { |log| log["action"] == "deleted" && log["filename"] == "us_covid_2019.csv" }).not_to be nil
+      expect(activity_log.find { |log| log["action"] == "deleted" && log["filename"] == s3_file1.key }).not_to be nil
       expect(activity_log.find { |log| log["action"] == "added" && log["filename"] == "us_covid_2020.csv" }).not_to be nil
       expect(activity_log.find { |log| log["action"] == "added" && log["filename"] == "orcid.csv" }).not_to be nil
     end
   end
 
-  context "When replacing all uploads is the params, but some overlap" do
-    let(:params) { { "work_id" => "", "pre_curation_uploads" => [uploaded_file, uploaded_file3] }.with_indifferent_access }
+  context "When replacing all uploads in the params, but some overlap" do
+    let(:params) { { "work_id" => "", "pre_curation_uploads" => [uploaded_file2, uploaded_file3] }.with_indifferent_access }
 
     it "replaces all the files" do
+      fake_s3_service = stub_s3(data: s3_data, bucket_url: bucket_url)
+
+      # upload the two new files
       upload_service = described_class.new(work, user)
       updated_work = upload_service.update_precurated_file_list(params)
-      list = updated_work.pre_curation_uploads
-      expect(list.map(&:filename)).to eq([uploaded_file.original_filename, uploaded_file3.original_filename])
+      filenames = updated_work.reload.pre_curation_uploads.map { |attachment| attachment.filename.to_s }
+      expect(filenames).to eq([uploaded_file2.original_filename, uploaded_file3.original_filename])
 
-      # we delete all items and start over because even if the filename matches we want the new version of the file they just uploaded
-      expect(a_request(:delete, attachment_url)).to have_been_made.once
+      # deleted the two existing files
+      expect(fake_s3_service).to have_received(:delete_s3_object).twice
 
-      # it logs the activity
+      # it logs the activity (2 deletes + 2 adds)
       activity_log = JSON.parse(work.work_activity.first.message)
-      expect(activity_log.find { |log| log["action"] == "deleted" && log["filename"] == "us_covid_2019.csv" }).not_to be nil
-      expect(activity_log.find { |log| log["action"] == "added" && log["filename"] == "us_covid_2019.csv" }).not_to be nil
-      expect(activity_log.find { |log| log["action"] == "added" && log["filename"] == "orcid.csv" }).not_to be nil
+      expect(activity_log.find { |log| log["action"] == "deleted" && log["filename"].include?("us_covid_2019.csv") }).not_to be nil
+      expect(activity_log.find { |log| log["action"] == "deleted" && log["filename"].include?("us_covid_2020.csv") }).not_to be nil
+      expect(activity_log.find { |log| log["action"] == "added" && log["filename"].include?("us_covid_2020.csv") }).not_to be nil
+      expect(activity_log.find { |log| log["action"] == "added" && log["filename"].include?("orcid.csv") }).not_to be nil
     end
   end
 end

--- a/spec/support/s3_query_service_specs.rb
+++ b/spec/support/s3_query_service_specs.rb
@@ -1,14 +1,21 @@
 # frozen_string_literal: true
 
-def stub_s3(data: [])
+def stub_s3(data: [], bucket_url: nil)
   @s3_client = instance_double(Aws::S3::Client)
   allow(@s3_client).to receive(:head_object)
   allow(@s3_client).to receive(:delete_object)
 
-  fake_s3_query = double(S3QueryService, data_profile: { objects: data, ok: true }, client: @s3_client)
+  fake_s3_query = double(S3QueryService, data_profile: { objects: data, ok: true }, client: @s3_client, client_s3_files: data)
   allow(fake_s3_query).to receive(:bucket_name).and_return("example-bucket")
   allow(fake_s3_query).to receive(:file_count).and_return(data.length)
+  allow(fake_s3_query).to receive(:delete_s3_object)
   allow(S3QueryService).to receive(:new).and_return(fake_s3_query)
+
+  if bucket_url.present?
+    # Also stub ActiveStorage calls to the bucket
+    stub_request(:put, /#{bucket_url}/).to_return(status: 200)
+    stub_request(:delete, /#{bucket_url}/).to_return(status: 200)
+  end
 
   fake_s3_query
 end

--- a/spec/system/authz_super_admin_spec.rb
+++ b/spec/system/authz_super_admin_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "Authz for super admins", type: :system, js: true do
     end
 
     it "should be able to edit someone else's work" do
+      stub_s3
       sign_in submitter2
       visit user_path(submitter2)
       expect(page).to have_content submitter2.display_name

--- a/spec/system/data_migration/sowingseeds_form_submission_spec.rb
+++ b/spec/system/data_migration/sowingseeds_form_submission_spec.rb
@@ -28,6 +28,7 @@ Download the README.txt for a detailed description of this dataset's content."
   end
   context "migrate record from dataspace" do
     it "produces and saves a valid datacite record" do
+      stub_s3
       sign_in user
       # we need to use the wizard because this work does not have a doi and it needs one to be registered
       visit "/works/new"

--- a/spec/system/view_data_in_s3_spec.rb
+++ b/spec/system/view_data_in_s3_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe "View status of data in S3", mock_ezid_api: true, js: true do
         filename: "#{work.doi}/#{work.id}/SCoData_combined_v1_2020-07_README.txt",
         last_modified: Time.parse("2022-04-21T18:29:40.000Z"),
         size: 10_759,
-        checksum: "abc123"
+        checksum: "abc123",
+        query_service: s3_query_service_double
       )
     end
     let(:file2) do
@@ -24,7 +25,8 @@ RSpec.describe "View status of data in S3", mock_ezid_api: true, js: true do
         filename: "#{work.doi}/#{work.id}/SCoData_combined_v1_2020-07_datapackage.json",
         last_modified: Time.parse("2022-04-21T18:30:07.000Z"),
         size: 12_739,
-        checksum: "abc567"
+        checksum: "abc567",
+        query_service: s3_query_service_double
       )
     end
     let(:s3_data) { [file1, file2] }
@@ -34,15 +36,12 @@ RSpec.describe "View status of data in S3", mock_ezid_api: true, js: true do
     end
 
     it "shows data from S3 on the Show and Edit pages" do
-      # Account for files in S3 added outside of ActiveStorage
       allow(S3QueryService).to receive(:new).and_return(s3_query_service_double)
       allow(s3_query_service_double).to receive(:data_profile).and_return({ objects: s3_data, ok: true })
       allow(s3_query_service_double).to receive(:file_count).and_return(s3_data.count)
-      # Account for files uploaded to S3 via ActiveStorage
-      stub_request(:put, /#{bucket_url}/).to_return(status: 200)
+      allow(s3_query_service_double).to receive(:client_s3_files).and_return(s3_data)
+      allow(s3_query_service_double).to receive(:file_url).and_return("https://something-something")
 
-      file = fixture_file_upload("us_covid_2019.csv", "text/csv")
-      work.pre_curation_uploads.attach(file)
       work.save
       work.reload
       work.state = "awaiting_approval"
@@ -50,15 +49,12 @@ RSpec.describe "View status of data in S3", mock_ezid_api: true, js: true do
 
       visit work_path(work)
       expect(page).to have_content work.title
-      expect(page).to have_content "us_covid_2019.csv"
-
-      expect(page).to have_content ActiveStorage::Filename.new(file1.filename).to_s
-      expect(page).to have_content ActiveStorage::Filename.new(file2.filename).to_s
+      expect(page).to have_content file1.filename
+      expect(page).to have_content file2.filename
 
       click_on "Edit"
-      expect(page).to have_content "us_covid_2019.csv"
-      expect(page).to have_content ActiveStorage::Filename.new(file1.filename).to_s
-      expect(page).to have_content ActiveStorage::Filename.new(file2.filename).to_s
+      expect(page).to have_content file1.filename
+      expect(page).to have_content file2.filename
     end
 
     context "when item is approved" do

--- a/spec/system/work_comment_spec.rb
+++ b/spec/system/work_comment_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "Commenting on works sends emails or not", type: :system, js: tru
   let(:message) { "@#{user2.uid} Look at this work!" }
 
   before do
+    stub_s3
     sign_in user
     visit work_path(work)
   end

--- a/spec/system/work_create_spec.rb
+++ b/spec/system/work_create_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe "Form submission for a legacy dataset", type: :system do
   let(:collection) { "Research Data" }
 
   before do
+    stub_s3
     stub_datacite(host: "api.datacite.org", body: datacite_register_body(prefix: "10.34770"))
   end
   context "happy path" do

--- a/spec/system/work_upload_max_spec.rb
+++ b/spec/system/work_upload_max_spec.rb
@@ -4,7 +4,9 @@ require "rails_helper"
 RSpec.describe "File selection", type: :system do
   let(:work) { FactoryBot.create :draft_work }
   let(:user) { work.created_by_user }
-
+  before do
+    stub_s3
+  end
   it "errors when more than 20 files are attached in the wizard", js: true do
     sign_in user
     visit work_file_upload_path(work)

--- a/spec/system/work_upload_s3_objects_spec.rb
+++ b/spec/system/work_upload_s3_objects_spec.rb
@@ -6,13 +6,14 @@ describe "Uploading S3 Bucket Objects for new Work", mock_ezid_api: true do
   context "when creating a Work", mock_s3_query_service: false do
     let(:user) { FactoryBot.create :princeton_submitter }
     let(:work) { FactoryBot.create(:shakespeare_and_company_work, created_by_user_id: user.id) }
-    let(:s3_query_service_double) { instance_double(S3QueryService) }
+    let(:s3_query_service_double) { instance_double(S3QueryService, client_s3_files: s3_data) }
     let(:file1) do
       S3File.new(
         filename: "#{work.doi}/#{work.id}/SCoData_combined_v1_2020-07_README.txt",
         last_modified: Time.parse("2022-04-21T18:29:40.000Z"),
         size: 10_759,
-        checksum: "abc123"
+        checksum: "abc123",
+        query_service: work.s3_query_service
       )
     end
     let(:file2) do
@@ -20,9 +21,11 @@ describe "Uploading S3 Bucket Objects for new Work", mock_ezid_api: true do
         filename: "#{work.doi}/#{work.id}/SCoData_combined_v1_2020-07_datapackage.json",
         last_modified: Time.parse("2022-04-21T18:30:07.000Z"),
         size: 12_739,
-        checksum: "abc567"
+        checksum: "abc567",
+        query_service: work.s3_query_service
       )
     end
+    let(:fake_s3_service) { stub_s3 }
     let(:filename1) { file1.filename.split("/").last }
     let(:filename2) { file2.filename.split("/").last }
     let(:s3_data) { [file1, file2] }
@@ -33,11 +36,10 @@ describe "Uploading S3 Bucket Objects for new Work", mock_ezid_api: true do
     before do
       sign_in user
 
-      # Account for files in S3 added outside of ActiveStorage
-      allow(S3QueryService).to receive(:new).and_return(s3_query_service_double)
-      allow(s3_query_service_double).to receive(:data_profile).and_return({ objects: s3_data, ok: true })
-      allow(s3_query_service_double).to receive(:file_count).and_return(s3_data.count)
-      # Account for files uploaded to S3 via ActiveStorage
+      allow(fake_s3_service).to receive(:client_s3_files).and_return(s3_data)
+      allow(fake_s3_service).to receive(:file_url).with(file1.key).and_return("https://example-bucket.s3.amazonaws.com/#{file1.key}")
+      allow(fake_s3_service).to receive(:file_url).with(file2.key).and_return("https://example-bucket.s3.amazonaws.com/#{file2.key}")
+
       stub_request(:put, /#{bucket_url}/).to_return(status: 200)
     end
 
@@ -48,6 +50,15 @@ describe "Uploading S3 Bucket Objects for new Work", mock_ezid_api: true do
       let(:upload_file) do
         fixture_file_upload(upload_file_name, "text/csv")
       end
+      let(:upload_s3_file) do
+        S3File.new(
+          filename: "us_covid_2019.csv",
+          last_modified: Time.parse("2022-04-21T18:29:40.000Z"),
+          size: 10_759,
+          checksum: "abc123",
+          query_service: work.s3_query_service
+        )
+      end
 
       before do
         # work.pre_curation_uploads.attach(upload_file)
@@ -56,6 +67,8 @@ describe "Uploading S3 Bucket Objects for new Work", mock_ezid_api: true do
         work.reload
 
         stub_request(:delete, /#{bucket_url}/).to_return(status: 200)
+        allow(fake_s3_service).to receive(:client_s3_files).and_return(s3_data + [upload_s3_file])
+        allow(fake_s3_service).to receive(:file_url).with(upload_s3_file.key).and_return("https://example-bucket.s3.amazonaws.com/#{file1.key}")
       end
 
       after do
@@ -73,7 +86,7 @@ describe "Uploading S3 Bucket Objects for new Work", mock_ezid_api: true do
         expect(page).to have_content upload_file_name
         expect(page).to have_content filename1
         expect(page).to have_content filename2
-        expect(work.reload.pre_curation_uploads.length).to eq(3)
+        expect(work.reload.pre_curation_uploads_fast.length).to eq(3)
       end
 
       it "renders S3 Bucket Objects and file uploads on the edit page", js: true do
@@ -81,7 +94,7 @@ describe "Uploading S3 Bucket Objects for new Work", mock_ezid_api: true do
 
         expect(work.pre_curation_uploads.length).to eq(1)
         visit work_path(work)
-        expect(work.reload.pre_curation_uploads.length).to eq(3)
+        expect(work.reload.pre_curation_uploads_fast.length).to eq(3)
         visit edit_work_path(work) # can not click Edit link becuase wizard does not show files
 
         expect(page).to have_content upload_file_name
@@ -91,6 +104,7 @@ describe "Uploading S3 Bucket Objects for new Work", mock_ezid_api: true do
 
       context "when files are deleted from a Work" do
         before do
+          allow(fake_s3_service).to receive(:client_s3_files).and_return(s3_data)
           attachments = work.pre_curation_uploads.select { |e| e.filename.to_s == upload_file_name }
           attachments.each(&:purge)
           work.save
@@ -104,15 +118,17 @@ describe "Uploading S3 Bucket Objects for new Work", mock_ezid_api: true do
           expect(page).not_to have_content upload_file_name
           expect(page).to have_content filename1
           expect(page).to have_content filename2
-          expect(work.reload.pre_curation_uploads.length).to eq(2)
+          expect(work.reload.pre_curation_uploads_fast.length).to eq(2)
         end
 
         it "renders only the S3 Bucket Objects on the edit page", js: true do
           visit work_path(work)
-          expect(work.pre_curation_uploads.length).to eq(2)
-          click_on "Edit"
+          expect(work.pre_curation_uploads_fast.length).to eq(2)
+          visit edit_work_path(work) # can not click Edit link becuase wizard does not show files
 
           expect(page).not_to have_content upload_file_name
+          expect(page).to have_content filename1
+          expect(page).to have_content filename2
         end
       end
 
@@ -126,6 +142,7 @@ describe "Uploading S3 Bucket Objects for new Work", mock_ezid_api: true do
           # approved_work.pre_curation_uploads.attach(upload_file)
           # approved_work.save
           # approved_work.reload
+          allow(fake_s3_service).to receive(:data_profile).and_return({ objects: s3_data, ok: true })
           approved_work.state = "approved"
           approved_work.save
         end


### PR DESCRIPTION
Re-route the call to always fetch pre-curation files directly from AWS, bypassing ActiveStorage. 

Fixes #941