### PR TITLE
Reduce the number of ESLint rules we ignore

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -14,7 +14,6 @@ rules:
   no-alert: off
   no-console: off
   no-param-reassign: off
-  no-plusplus: off
   no-restricted-globals: off
   no-restricted-syntax: off
   no-undef: off

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -10,7 +10,6 @@ ignorePatterns:
   'app/javascript/entrypoints/vendor/**'
 rules:
   block-scoped-var: off
-  camelcase: off
   import/prefer-default-export: off
   no-alert: off
   no-console: off

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -17,5 +17,3 @@ rules:
   no-alert: off             # OK: A lot easier than coding up new UI.
   no-console: off           # TODO: Probably just warnings and errors.
   no-restricted-syntax: off # Probably OK? Research more.
-  no-var: off               # TODO
-  vars-on-top: off          # TODO: Moot once vars are cleaned up. 

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -8,6 +8,10 @@ parserOptions:
   sourceType: module
 ignorePatterns:
   'app/javascript/entrypoints/vendor/**'
+globals:
+  $: readonly
+  pdc: readonly # TODO: Used to pass datacite enums from Ruby to JS. When we move form construction to Ruby, should not be needed.
+  isOrcid: readonly # TODO: Clean this up by using ESM import/export.
 rules:
   block-scoped-var: off
   import/prefer-default-export: off
@@ -16,7 +20,6 @@ rules:
   no-param-reassign: off
   no-restricted-globals: off
   no-restricted-syntax: off
-  no-undef: off
   no-var: off
   prefer-const: off
   vars-on-top: off

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -17,7 +17,6 @@ rules:
   no-restricted-globals: off
   no-restricted-syntax: off
   no-undef: off
-  no-unused-vars: off
   no-var: off
   prefer-const: off
   vars-on-top: off

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -14,6 +14,8 @@ globals:
   isOrcid: readonly # TODO: Clean this up by using ESM import/export.
 rules:
   import/prefer-default-export: off # TODO: Fix orcid.js
-  no-alert: off             # OK: A lot easier than coding up new UI.
-  no-console: off           # TODO: Probably just warnings and errors.
+  no-alert: off # OK: A lot easier than coding up new UI.
+  no-console:   # OK: console.log is fine for debugging, but we don't want to keep it around indefinitely.
+    - error     # Also make sure that warnings and errors are marked as such.
+    - { allow: ["warn", "error"] }
   no-restricted-syntax: off # Probably OK? Research more.

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -13,9 +13,7 @@ globals:
   pdc: readonly     # TODO: Used to pass datacite enums from Ruby to JS. When we move form construction to Ruby, should not be needed.
   isOrcid: readonly # TODO: Clean this up by using ESM import/export.
 rules:
-  # import/prefer-default-export: off # TODO: Fix orcid.js
   no-alert: off # OK: A lot easier than coding up new UI.
   no-console:   # OK: console.log is fine for debugging, but we don't want to keep it around indefinitely.
     - error     # Also make sure that warnings and errors are marked as such.
     - { allow: ["warn", "error"] }
-  no-restricted-syntax: off # Probably OK? Research more.

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -12,12 +12,10 @@ globals:
   $: readonly
   pdc: readonly # TODO: Used to pass datacite enums from Ruby to JS. When we move form construction to Ruby, should not be needed.
   isOrcid: readonly # TODO: Clean this up by using ESM import/export.
-  confirm: readonly # Used sparingly, window.confirm() is a good alternative to coding up the UI for a modal.
 rules:
   import/prefer-default-export: off
   no-alert: off
   no-console: off
-  no-restricted-globals: off
   no-restricted-syntax: off
   no-var: off
   prefer-const: off

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -13,7 +13,6 @@ globals:
   pdc: readonly # TODO: Used to pass datacite enums from Ruby to JS. When we move form construction to Ruby, should not be needed.
   isOrcid: readonly # TODO: Clean this up by using ESM import/export.
 rules:
-  block-scoped-var: off
   import/prefer-default-export: off
   no-alert: off
   no-console: off

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -18,5 +18,4 @@ rules:
   no-console: off
   no-restricted-syntax: off
   no-var: off
-  prefer-const: off
   vars-on-top: off

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -17,7 +17,6 @@ rules:
   no-restricted-globals: off
   no-restricted-syntax: off
   no-undef: off
-  no-underscore-dangle: [ "error", { "allow": ["_rails_loaded"] } ]
   no-unused-vars: off
   no-var: off
   prefer-const: off

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -13,7 +13,7 @@ globals:
   pdc: readonly     # TODO: Used to pass datacite enums from Ruby to JS. When we move form construction to Ruby, should not be needed.
   isOrcid: readonly # TODO: Clean this up by using ESM import/export.
 rules:
-  import/prefer-default-export: off # TODO: Fix orcid.js
+  # import/prefer-default-export: off # TODO: Fix orcid.js
   no-alert: off # OK: A lot easier than coding up new UI.
   no-console:   # OK: console.log is fine for debugging, but we don't want to keep it around indefinitely.
     - error     # Also make sure that warnings and errors are marked as such.

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -20,7 +20,7 @@ rules:
   no-restricted-globals: off
   no-restricted-syntax: off
   no-undef: off
-  no-underscore-dangle: off
+  no-underscore-dangle: [ "error", { "allow": ["_rails_loaded"] } ]
   no-unused-vars: off
   no-var: off
   prefer-const: off

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -12,6 +12,7 @@ globals:
   $: readonly
   pdc: readonly # TODO: Used to pass datacite enums from Ruby to JS. When we move form construction to Ruby, should not be needed.
   isOrcid: readonly # TODO: Clean this up by using ESM import/export.
+  confirm: readonly # Used sparingly, window.confirm() is a good alternative to coding up the UI for a modal.
 rules:
   import/prefer-default-export: off
   no-alert: off

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -16,7 +16,6 @@ rules:
   no-console: off
   no-param-reassign: off
   no-plusplus: off
-  no-redeclare: off
   no-restricted-globals: off
   no-restricted-syntax: off
   no-undef: off

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -11,7 +11,6 @@ ignorePatterns:
 rules:
   block-scoped-var: off
   camelcase: off
-  eqeqeq: off
   import/prefer-default-export: off
   no-alert: off
   no-console: off

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -17,3 +17,4 @@ rules:
   no-console:   # OK: console.log is fine for debugging, but we don't want to keep it around indefinitely.
     - error     # Also make sure that warnings and errors are marked as such.
     - { allow: ["warn", "error"] }
+  no-restricted-syntax: off # TODO: Just one failure

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -17,7 +17,6 @@ rules:
   import/prefer-default-export: off
   no-alert: off
   no-console: off
-  no-param-reassign: off
   no-restricted-globals: off
   no-restricted-syntax: off
   no-var: off

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -10,12 +10,12 @@ ignorePatterns:
   'app/javascript/entrypoints/vendor/**'
 globals:
   $: readonly
-  pdc: readonly # TODO: Used to pass datacite enums from Ruby to JS. When we move form construction to Ruby, should not be needed.
+  pdc: readonly     # TODO: Used to pass datacite enums from Ruby to JS. When we move form construction to Ruby, should not be needed.
   isOrcid: readonly # TODO: Clean this up by using ESM import/export.
 rules:
-  import/prefer-default-export: off
-  no-alert: off
-  no-console: off
-  no-restricted-syntax: off
-  no-var: off
-  vars-on-top: off
+  import/prefer-default-export: off # TODO: Fix orcid.js
+  no-alert: off             # OK: A lot easier than coding up new UI.
+  no-console: off           # TODO: Probably just warnings and errors.
+  no-restricted-syntax: off # Probably OK? Research more.
+  no-var: off               # TODO
+  vars-on-top: off          # TODO: Moot once vars are cleaned up. 

--- a/app/assets/javascripts/edit_collection_utils.js
+++ b/app/assets/javascripts/edit_collection_utils.js
@@ -22,13 +22,13 @@ $(() => {
     var base_user_url = pdc.userPath;
     var show_user_url = base_user_url.replace('user-placeholder', uid);
     var html = `<li class="li-user-${uid}"> <a href="${show_user_url}">${uid}</a>`;
-    if (isYou == true) {
+    if (isYou) {
       html += ' (you)';
     }
-    if (is_super_admin == true) {
+    if (is_super_admin) {
       html += ' <i title="This is a system administrator, access cannot be changed." class="bi bi-person-workspace"></i>';
     }
-    if (canDelete == true) {
+    if (canDelete) {
       html += `
         <span>
         <a class="delete-user-from-collection" data-collection-id="${collectionId}" data-uid="${uid}"
@@ -44,7 +44,7 @@ $(() => {
   function addUserToCollection(url, elTxt, elError, elList, role) {
     var { collectionId } = pdc;
     var uid = $(elTxt).val().trim();
-    if (uid == '') {
+    if (uid === '') {
       $(elError).text('Enter netid of user to add');
       return;
     }
@@ -83,14 +83,14 @@ $(() => {
     return false;
   });
 
-  if ($('#data-loaded').text() != 'true') {
+  if ($('#data-loaded').text() !== 'true') {
     // Displays the initial list of submitters.
     $('.submitter-data').each((ix, el) => {
       var elList = $('#submitter-list');
       var uid = $(el).data('uid');
       var collectionId = $(el).data('collectionId');
       var canDelete = $(el).data('canDelete');
-      var isYou = $(el).data('you') == true;
+      var isYou = $(el).data('you');
       var is_super_admin = false;
       addUserHtml(elList, uid, collectionId, 'submit', canDelete, isYou, is_super_admin);
     });
@@ -101,7 +101,7 @@ $(() => {
       var uid = $(el).data('uid');
       var collectionId = $(el).data('collectionId');
       var canDelete = $(el).data('canDelete');
-      var isYou = $(el).data('you') == true;
+      var isYou = $(el).data('you');
       addUserHtml(elList, uid, collectionId, 'admin', canDelete, isYou, false);
     });
 
@@ -110,7 +110,7 @@ $(() => {
       var elList = $('#sysadmin-list');
       var uid = $(el).data('uid');
       var collectionId = $(el).data('collectionId');
-      var isYou = $(el).data('you') == true;
+      var isYou = $(el).data('you');
       addUserHtml(elList, uid, collectionId, 'admin', false, isYou, true);
     });
 

--- a/app/assets/javascripts/edit_collection_utils.js
+++ b/app/assets/javascripts/edit_collection_utils.js
@@ -19,9 +19,9 @@ $(() => {
   // for the collection.
   // `elList` is the reference to the <ul> HTML element that hosts the list.
   function addUserHtml(elList, uid, collectionId, role, canDelete, isYou, isSuperAdmin) {
-    var baseUserUrl = pdc.userPath;
-    var showUserUrl = baseUserUrl.replace('user-placeholder', uid);
-    var html = `<li class="li-user-${uid}"> <a href="${showUserUrl}">${uid}</a>`;
+    const baseUserUrl = pdc.userPath;
+    const showUserUrl = baseUserUrl.replace('user-placeholder', uid);
+    let html = `<li class="li-user-${uid}"> <a href="${showUserUrl}">${uid}</a>`;
     if (isYou) {
       html += ' (you)';
     }
@@ -42,8 +42,8 @@ $(() => {
 
   // Issues the HTTP POST to add a user to a collection and updates the UI
   function addUserToCollection(url, elTxt, elError, elList, role) {
-    var { collectionId } = pdc;
-    var uid = $(elTxt).val().trim();
+    const { collectionId } = pdc;
+    const uid = $(elTxt).val().trim();
     if (uid === '') {
       $(elError).text('Enter netid of user to add');
       return;
@@ -56,9 +56,9 @@ $(() => {
       success() {
         $(elTxt).val('');
         $(elError).text('');
-        var canDelete = true;
-        var isYou = false;
-        var isSuperAdmin = false;
+        const canDelete = true;
+        const isYou = false;
+        const isSuperAdmin = false;
         addUserHtml(elList, uid, collectionId, role, canDelete, isYou, isSuperAdmin);
       },
       error(x) {
@@ -69,7 +69,7 @@ $(() => {
 
   // Adds a submitter to the collection
   $('#btn-add-submitter').on('click', () => {
-    var url = pdc.addSubmitterUrl;
+    const url = pdc.addSubmitterUrl;
     addUserToCollection(url, '#submitter-uid-to-add', '#add-submitter-message', '#submitter-list', 'submit');
     $('#submitter-uid-to-add').focus();
     return false;
@@ -77,7 +77,7 @@ $(() => {
 
   // Adds an administrator to the collection
   $('#btn-add-admin').on('click', () => {
-    var url = pdc.addAdminUrl;
+    const url = pdc.addAdminUrl;
     addUserToCollection(url, '#admin-uid-to-add', '#add-admin-message', '#curator-list', 'admin');
     $('#admin-uid-to-add').focus();
     return false;
@@ -86,31 +86,31 @@ $(() => {
   if ($('#data-loaded').text() !== 'true') {
     // Displays the initial list of submitters.
     $('.submitter-data').each((ix, el) => {
-      var elList = $('#submitter-list');
-      var uid = $(el).data('uid');
-      var collectionId = $(el).data('collectionId');
-      var canDelete = $(el).data('canDelete');
-      var isYou = $(el).data('you');
-      var isSuperAdmin = false;
+      const elList = $('#submitter-list');
+      const uid = $(el).data('uid');
+      const collectionId = $(el).data('collectionId');
+      const canDelete = $(el).data('canDelete');
+      const isYou = $(el).data('you');
+      const isSuperAdmin = false;
       addUserHtml(elList, uid, collectionId, 'submit', canDelete, isYou, isSuperAdmin);
     });
 
     // Displays the initial list of curators.
     $('.curator-data').each((ix, el) => {
-      var elList = $('#curator-list');
-      var uid = $(el).data('uid');
-      var collectionId = $(el).data('collectionId');
-      var canDelete = $(el).data('canDelete');
-      var isYou = $(el).data('you');
+      const elList = $('#curator-list');
+      const uid = $(el).data('uid');
+      const collectionId = $(el).data('collectionId');
+      const canDelete = $(el).data('canDelete');
+      const isYou = $(el).data('you');
       addUserHtml(elList, uid, collectionId, 'admin', canDelete, isYou, false);
     });
 
     // Displays the list of system administrators.
     $('.sysadmin-data').each((ix, el) => {
-      var elList = $('#sysadmin-list');
-      var uid = $(el).data('uid');
-      var collectionId = $(el).data('collectionId');
-      var isYou = $(el).data('you');
+      const elList = $('#sysadmin-list');
+      const uid = $(el).data('uid');
+      const collectionId = $(el).data('collectionId');
+      const isYou = $(el).data('you');
       addUserHtml(elList, uid, collectionId, 'admin', false, isYou, true);
     });
 
@@ -127,9 +127,9 @@ $(() => {
   // is the case when a user adds a new submitter or admin to the collection.
   // Reference: https://stackoverflow.com/a/17086311/446681
   $(document).on('click', '.delete-user-from-collection', (el) => {
-    var url = pdc.deleteUserFromCollectionUrl;
-    var uid = $(el.target).data('uid');
-    var message = `Revoke access to user ${uid}`;
+    const url = pdc.deleteUserFromCollectionUrl;
+    const uid = $(el.target).data('uid');
+    const message = `Revoke access to user ${uid}`;
     if (window.confirm(message)) {
       deleteUserFromCollection(el, url, uid);
     }

--- a/app/assets/javascripts/edit_collection_utils.js
+++ b/app/assets/javascripts/edit_collection_utils.js
@@ -68,7 +68,7 @@ $(() => {
   }
 
   // Adds a submitter to the collection
-  $('#btn-add-submitter').on('click', (x) => {
+  $('#btn-add-submitter').on('click', () => {
     var url = pdc.addSubmitterUrl;
     addUserToCollection(url, '#submitter-uid-to-add', '#add-submitter-message', '#submitter-list', 'submit');
     $('#submitter-uid-to-add').focus();
@@ -76,7 +76,7 @@ $(() => {
   });
 
   // Adds an administrator to the collection
-  $('#btn-add-admin').on('click', (x) => {
+  $('#btn-add-admin').on('click', () => {
     var url = pdc.addAdminUrl;
     addUserToCollection(url, '#admin-uid-to-add', '#add-admin-message', '#curator-list', 'admin');
     $('#admin-uid-to-add').focus();

--- a/app/assets/javascripts/edit_collection_utils.js
+++ b/app/assets/javascripts/edit_collection_utils.js
@@ -18,14 +18,14 @@ $(() => {
   // Adds the information for a given user to the lists of administrators/submitters
   // for the collection.
   // `elList` is the reference to the <ul> HTML element that hosts the list.
-  function addUserHtml(elList, uid, collectionId, role, canDelete, isYou, is_super_admin) {
-    var base_user_url = pdc.userPath;
-    var show_user_url = base_user_url.replace('user-placeholder', uid);
-    var html = `<li class="li-user-${uid}"> <a href="${show_user_url}">${uid}</a>`;
+  function addUserHtml(elList, uid, collectionId, role, canDelete, isYou, isSuperAdmin) {
+    var baseUserUrl = pdc.userPath;
+    var showUserUrl = baseUserUrl.replace('user-placeholder', uid);
+    var html = `<li class="li-user-${uid}"> <a href="${showUserUrl}">${uid}</a>`;
     if (isYou) {
       html += ' (you)';
     }
-    if (is_super_admin) {
+    if (isSuperAdmin) {
       html += ' <i title="This is a system administrator, access cannot be changed." class="bi bi-person-workspace"></i>';
     }
     if (canDelete) {
@@ -58,8 +58,8 @@ $(() => {
         $(elError).text('');
         var canDelete = true;
         var isYou = false;
-        var is_super_admin = false;
-        addUserHtml(elList, uid, collectionId, role, canDelete, isYou, is_super_admin);
+        var isSuperAdmin = false;
+        addUserHtml(elList, uid, collectionId, role, canDelete, isYou, isSuperAdmin);
       },
       error(x) {
         $(elError).text(x.responseJSON.message);
@@ -91,8 +91,8 @@ $(() => {
       var collectionId = $(el).data('collectionId');
       var canDelete = $(el).data('canDelete');
       var isYou = $(el).data('you');
-      var is_super_admin = false;
-      addUserHtml(elList, uid, collectionId, 'submit', canDelete, isYou, is_super_admin);
+      var isSuperAdmin = false;
+      addUserHtml(elList, uid, collectionId, 'submit', canDelete, isYou, isSuperAdmin);
     });
 
     // Displays the initial list of curators.

--- a/app/assets/javascripts/edit_collection_utils.js
+++ b/app/assets/javascripts/edit_collection_utils.js
@@ -130,7 +130,7 @@ $(() => {
     var url = pdc.deleteUserFromCollectionUrl;
     var uid = $(el.target).data('uid');
     var message = `Revoke access to user ${uid}`;
-    if (confirm(message)) {
+    if (window.confirm(message)) {
       deleteUserFromCollection(el, url, uid);
     }
     return false;

--- a/app/assets/javascripts/edit_work_utils.js
+++ b/app/assets/javascripts/edit_work_utils.js
@@ -447,12 +447,12 @@ $(() => {
     addRelatedObjectHtml(num, '', '', '');
   } else {
     // Add existing related objects for editing
-    for (const relatedObject of $('.related-object-data')) {
+    $('.related-object-data').each((relatedObject) => {
       const {
         num, relatedIdentifier, relatedIdentifierType, relationType,
       } = relatedObject.dataset;
       addRelatedObjectHtml(num, relatedIdentifier, relatedIdentifierType, relationType);
-    }
+    });
   }
 
   if ($('.contributor-data').length === 0) {

--- a/app/assets/javascripts/edit_work_utils.js
+++ b/app/assets/javascripts/edit_work_utils.js
@@ -256,12 +256,10 @@ $(() => {
 
   // Returns true if the "user entered" textboxes for the row are empty.
   function isEmptyRow(rowId) {
-    let selector; let textboxes; let i; let textboxId; let
-      value;
-    selector = `#${rowId} > td > input`;
-    textboxes = $(selector);
-    for (i = 0; i < textboxes.length; i += 1) {
-      textboxId = textboxes[i].id;
+    let i; let textboxId; let value;
+    const $textboxes = $(`#${rowId} > td > input`);
+    for (i = 0; i < $textboxes.length; i += 1) {
+      textboxId = $textboxes[i].id;
       if (textboxId.startsWith('orcid_') || textboxId.startsWith('given_name_') || textboxId.startsWith('family_name_')) {
         value = $(`#${textboxId}`).val().trim();
         if (value !== '') {

--- a/app/assets/javascripts/edit_work_utils.js
+++ b/app/assets/javascripts/edit_work_utils.js
@@ -209,7 +209,7 @@ $(() => {
     }
   }
 
-  function addTitlePlaceholder(_el) {
+  function addTitlePlaceholder() {
     const newTitleCount = incrementCounter('#new_title_count');
     const containerId = `new_title_container_${newTitleCount}`;
     const titleId = `new_title_${newTitleCount}`;
@@ -332,19 +332,19 @@ $(() => {
     return false;
   });
 
-  $('#btn-add-creator').on('click', (el) => {
+  $('#btn-add-creator').on('click', () => {
     const num = incrementCounter('#creator_count');
     addCreatorHtml(num, '', '', '');
     return false;
   });
 
-  $('#btn-add-related-object').on('click', (el) => {
+  $('#btn-add-related-object').on('click', () => {
     const num = incrementCounter('#related_object_count');
     addRelatedObjectHtml(num, '', '', '');
     return false;
   });
 
-  $('#btn-add-me-creator').on('click', (el) => {
+  $('#btn-add-me-creator').on('click', () => {
     const num = incrementCounter('#creator_count');
     const orcid = $('#user_orcid').val();
     const givenName = $('#user_given_name').val();
@@ -358,23 +358,23 @@ $(() => {
     return false;
   });
 
-  $('#btn-add-contributor').on('click', (el) => {
+  $('#btn-add-contributor').on('click', () => {
     const num = incrementCounter('#contributor_count');
     addContributorHtml(num, '', '', '', 'Other');
     return false;
   });
 
-  $('#btn-add-title').on('click', (el) => {
-    addTitlePlaceholder(el);
+  $('#btn-add-title').on('click', (event) => {
+    addTitlePlaceholder(event);
     return false;
   });
 
-  $('#btn-submit').on('click', (el) => {
+  $('#btn-submit').on('click', () => {
     updateCreatorsSequence();
   });
 
   // Client side validations before allowing user to create the dataset.
-  $('#btn-create-new').on('click', (el) => {
+  $('#btn-create-new').on('click', () => {
     const title = $('#title_main').val() || '';
     let status = true;
 

--- a/app/assets/javascripts/edit_work_utils.js
+++ b/app/assets/javascripts/edit_work_utils.js
@@ -447,12 +447,12 @@ $(() => {
     addRelatedObjectHtml(num, '', '', '');
   } else {
     // Add existing related objects for editing
-    $('.related-object-data').each((relatedObject) => {
+    for (const relatedObject of $('.related-object-data')) {
       const {
         num, relatedIdentifier, relatedIdentifierType, relationType,
       } = relatedObject.dataset;
       addRelatedObjectHtml(num, relatedIdentifier, relatedIdentifierType, relationType);
-    });
+    }
   }
 
   if ($('.contributor-data').length === 0) {

--- a/app/assets/javascripts/edit_work_utils.js
+++ b/app/assets/javascripts/edit_work_utils.js
@@ -184,7 +184,7 @@ $(() => {
       if (emptyRow) {
         // delete it without asking
         $(rowToDelete).remove();
-      } else if (confirm(`Remove ${type} ${rowText}`)) {
+      } else if (window.confirm(`Remove ${type} ${rowText}`)) {
         $(rowToDelete).remove();
       }
     }

--- a/app/assets/javascripts/edit_work_utils.js
+++ b/app/assets/javascripts/edit_work_utils.js
@@ -316,7 +316,7 @@ $(() => {
           $(familyNameId).val(familyName);
         })
         .fail((XMLHttpRequest, textStatus, errorThrown) => {
-          console.log(`Error fetching ORCID for ${errorThrown}`);
+          console.error(`Error fetching ORCID for ${errorThrown}`);
         });
     }
   }

--- a/app/assets/javascripts/edit_work_utils.js
+++ b/app/assets/javascripts/edit_work_utils.js
@@ -19,7 +19,7 @@ an export that we can call as-needed.
 $(() => {
   function incrementCounter(elementId) {
     let counter = parseInt($(elementId)[0].value, 10);
-    counter++;
+    counter += 1;
     $(elementId)[0].value = counter;
     return counter;
   }
@@ -173,7 +173,7 @@ $(() => {
     let i; let
       token;
     let rowText = '';
-    for (i = 0; i < rowData.length; i++) {
+    for (i = 0; i < rowData.length; i += 1) {
       token = $(rowData[i]).val();
       if (token.trim().length > 0) {
         rowText += `${token} `;
@@ -204,7 +204,7 @@ $(() => {
   function updateCreatorsSequence() {
     let i;
     const sequences = $('.creators-table-row > td > input.sequence');
-    for (i = 0; i < sequences.length; i++) {
+    for (i = 0; i < sequences.length; i += 1) {
       sequences[i].value = i + 1;
     }
   }
@@ -238,7 +238,7 @@ $(() => {
       creator;
     const creatorSpans = $(selector);
     const creators = [];
-    for (i = 0; i < creatorSpans.length; i++) {
+    for (i = 0; i < creatorSpans.length; i += 1) {
       el = $(creatorSpans[i]);
       creator = {
         num: el.data('num'),
@@ -260,7 +260,7 @@ $(() => {
       value;
     selector = `#${rowId} > td > input`;
     textboxes = $(selector);
-    for (i = 0; i < textboxes.length; i++) {
+    for (i = 0; i < textboxes.length; i += 1) {
       textboxId = textboxes[i].id;
       if (textboxId.startsWith('orcid_') || textboxId.startsWith('given_name_') || textboxId.startsWith('family_name_')) {
         value = $(`#${textboxId}`).val().trim();
@@ -276,7 +276,7 @@ $(() => {
   function findEmptyCreator() {
     let i;
     const rows = $('.creators-table-row');
-    for (i = 0; i < rows.length; i++) {
+    for (i = 0; i < rows.length; i += 1) {
       if (isEmptyRow(rows[i].id)) {
         return rows[i].id;
       }
@@ -288,7 +288,7 @@ $(() => {
   function hasCreators() {
     let i;
     const rows = $('.creators-table-row');
-    for (i = 0; i < rows.length; i++) {
+    for (i = 0; i < rows.length; i += 1) {
       if (!isEmptyRow(rows[i].id)) {
         return true;
       }
@@ -429,7 +429,7 @@ $(() => {
   } else {
     // Adds the existing creators making sure we honor the ordering.
     const creators = peopleSorted('.creator-data');
-    for (let i = 0; i < creators.length; i++) {
+    for (let i = 0; i < creators.length; i += 1) {
       const creator = creators[i];
       addCreatorHtml(
         creator.num,
@@ -464,7 +464,7 @@ $(() => {
   } else {
     // Adds the existing contributors making sure we honor the ordering.
     const contributors = peopleSorted('.contributor-data');
-    for (i = 0; i < contributors.length; i++) {
+    for (i = 0; i < contributors.length; i += 1) {
       const contributor = contributors[i];
       addContributorHtml(
         contributor.num,

--- a/app/assets/javascripts/edit_work_utils.js
+++ b/app/assets/javascripts/edit_work_utils.js
@@ -464,7 +464,7 @@ $(() => {
   } else {
     // Adds the existing contributors making sure we honor the ordering.
     const contributors = peopleSorted('.contributor-data');
-    for (i = 0; i < contributors.length; i += 1) {
+    for (let i = 0; i < contributors.length; i += 1) {
       const contributor = contributors[i];
       addContributorHtml(
         contributor.num,

--- a/app/assets/javascripts/edit_work_utils.js
+++ b/app/assets/javascripts/edit_work_utils.js
@@ -493,11 +493,12 @@ $(() => {
 
   // Drop the "http..."" portion of the URL if the user enters the full URL of a DataSpace ARK
   // http://arks.princeton.edu/ark:/88435/dsp01hx11xj13h => ark:/88435/dsp01hx11xj13h
-  $('#ark').on('input', (el) => {
+  $('#ark').on('input', (event) => {
     const prefix = 'http://arks.princeton.edu/';
-    const ark = el.currentTarget.value.trim();
+    const target = event.currentTarget;
+    const ark = target.value.trim();
     if (ark.startsWith(prefix)) {
-      el.currentTarget.value = ark.replace(prefix, '');
+      target.value = ark.replace(prefix, '');
     }
   });
 

--- a/app/assets/javascripts/edit_work_utils.js
+++ b/app/assets/javascripts/edit_work_utils.js
@@ -70,25 +70,25 @@ $(() => {
   // ************************************************ //
   // Related Objects
   // related_identifier:, related_identifier_type:, relation_type
-  function addRelatedObjectHtml(num, related_identifier, related_identifier_type, relation_type) {
+  function addRelatedObjectHtml(num, relatedIdentifier, relatedIdentifierType, relationType) {
     const rowId = `related_object_row_${num}`;
     const relatedIdentifierId = `related_identifier_${num}`;
     const relatedIdentifierTypeId = `related_identifier_type_${num}`;
     const relationTypeId = `relation_type_${num}`;
     const relatedIdentifierTypeHtml = makeSelectHtml(
       relatedIdentifierTypeId,
-      related_identifier_type,
+      relatedIdentifierType,
       pdc.datacite.RelatedIdentifierType,
     );
     const relationTypeHtml = makeSelectHtml(
       relationTypeId,
-      relation_type,
+      relationType,
       pdc.datacite.RelationType,
     );
 
     const rowHtml = `<tr id="${rowId}" class="related-objects-table-row">
       <td>
-        <input type="text" id="${relatedIdentifierId}" name="${relatedIdentifierId}" value="${related_identifier}" data-num="${num}"/>
+        <input type="text" id="${relatedIdentifierId}" name="${relatedIdentifierId}" value="${relatedIdentifier}" data-num="${num}"/>
       </td>
       <td>
         ${relatedIdentifierTypeHtml}
@@ -449,10 +449,10 @@ $(() => {
     addRelatedObjectHtml(num, '', '', '');
   } else {
     // Add existing related objects for editing
-    for (const related_object of $('.related-object-data')) {
+    for (const relatedObject of $('.related-object-data')) {
       const {
         num, relatedIdentifier, relatedIdentifierType, relationType,
-      } = related_object.dataset;
+      } = relatedObject.dataset;
       addRelatedObjectHtml(num, relatedIdentifier, relatedIdentifierType, relationType);
     }
   }

--- a/app/assets/javascripts/edit_work_utils.js
+++ b/app/assets/javascripts/edit_work_utils.js
@@ -62,9 +62,9 @@ $(() => {
     const options = allValues.filter(
       (value) => !blocklist.includes(value),
     ).map(
-      (value) => `<option value="${value}" ${currentValue == value ? 'selected' : ''}>${value}</option>`,
+      (value) => `<option value="${value}" ${currentValue === value ? 'selected' : ''}>${value}</option>`,
     );
-    return `<select id="${selectId}" name="${selectId}"><option value="" ${currentValue == '' ? 'selected' : ''}></option>${options}</select>`;
+    return `<select id="${selectId}" name="${selectId}"><option value="" ${currentValue === '' ? 'selected' : ''}></option>${options}</select>`;
   }
 
   // ************************************************ //
@@ -179,7 +179,7 @@ $(() => {
         rowText += `${token} `;
       }
     }
-    const emptyRow = (rowText.trim().length == 0);
+    const emptyRow = (rowText.trim().length === 0);
     if (rowExists) {
       if (emptyRow) {
         // delete it without asking
@@ -264,7 +264,7 @@ $(() => {
       textboxId = textboxes[i].id;
       if (textboxId.startsWith('orcid_') || textboxId.startsWith('given_name_') || textboxId.startsWith('family_name_')) {
         value = $(`#${textboxId}`).val().trim();
-        if (value != '') {
+        if (value !== '') {
           return false;
         }
       }
@@ -387,7 +387,7 @@ $(() => {
       status = false;
     }
 
-    if (title.trim() == '') {
+    if (title.trim() === '') {
       $('#title_main').focus();
       $('#title-required-message').removeClass('hidden');
       status = false;
@@ -422,7 +422,7 @@ $(() => {
     return false;
   });
 
-  if ($('.creator-data').length == 0) {
+  if ($('.creator-data').length === 0) {
     // Add an empty creator for the use to fill it out
     const num = incrementCounter('#creator_count');
     addCreatorHtml(num, '', '', '', 1);
@@ -443,7 +443,7 @@ $(() => {
 
   // Load any existing related objects into the edit form.
   // If there are any related objects they should appear in hidden <span> tags.
-  if ($('.related-object-data').length == 0) {
+  if ($('.related-object-data').length === 0) {
     // Add an empty related object for the user to fill it out
     const num = incrementCounter('#related_object_count');
     addRelatedObjectHtml(num, '', '', '');
@@ -457,7 +457,7 @@ $(() => {
     }
   }
 
-  if ($('.contributor-data').length == 0) {
+  if ($('.contributor-data').length === 0) {
     // Add an empty contributor for the use to fill it out
     const num = incrementCounter('#contributor_count');
     addContributorHtml(num, '', '', '', 'Other', 1);

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -33,7 +33,7 @@ console.log('Visit the guide for more information: ', 'https://vite-ruby.netlify
 // ActiveStorage.start()
 //
 // Import all channels.
-const channels = import.meta.globEager('../channels/*.js');
+import.meta.globEager('../channels/*.js');
 
 /* eslint no-underscore-dangle: [ "error", { "allow": ["_rails_loaded"] } ] */
 if (typeof (window._rails_loaded) === 'undefined' || window._rails_loaded == null || !window._rails_loaded) {

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -35,6 +35,7 @@ console.log('Visit the guide for more information: ', 'https://vite-ruby.netlify
 // Import all channels.
 const channels = import.meta.globEager('../channels/*.js');
 
+/* eslint no-underscore-dangle: [ "error", { "allow": ["_rails_loaded"] } ] */
 if (typeof (window._rails_loaded) === 'undefined' || window._rails_loaded == null || !window._rails_loaded) {
   Rails.start();
 }

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -1,3 +1,6 @@
+/* eslint no-underscore-dangle: [ "error", { "allow": ["_rails_loaded"] } ] */
+/* eslint no-console: "off" */
+
 // To see this message, add the following to the `<head>` section in your
 // views/layouts/application.html.erb
 //
@@ -35,7 +38,6 @@ console.log('Visit the guide for more information: ', 'https://vite-ruby.netlify
 // Import all channels.
 import.meta.globEager('../channels/*.js');
 
-/* eslint no-underscore-dangle: [ "error", { "allow": ["_rails_loaded"] } ] */
 if (typeof (window._rails_loaded) === 'undefined' || window._rails_loaded == null || !window._rails_loaded) {
   Rails.start();
 }

--- a/app/javascript/entrypoints/orcid.js
+++ b/app/javascript/entrypoints/orcid.js
@@ -5,5 +5,3 @@ function isOrcid(value) {
 }
 
 window.isOrcid = isOrcid;
-
-export { isOrcid };

--- a/app/javascript/entrypoints/orcid.js
+++ b/app/javascript/entrypoints/orcid.js
@@ -5,3 +5,5 @@ function isOrcid(value) {
 }
 
 window.isOrcid = isOrcid;
+
+export { isOrcid };

--- a/app/javascript/entrypoints/pdc/copy_to_clipboard.es6
+++ b/app/javascript/entrypoints/pdc/copy_to_clipboard.es6
@@ -35,7 +35,7 @@ export default class CopytoClipboard {
   errorCopyToClipboard(iconEl, errorMsg) {
     $(iconEl).removeClass('bi-clipboard');
     $(iconEl).addClass('bi-clipboard-minus');
-    console.log(errorMsg);
+    console.error(errorMsg);
   }
 
   // Copies a value to the clipboard and notifies the user

--- a/app/javascript/entrypoints/pdc/copy_to_clipboard.es6
+++ b/app/javascript/entrypoints/pdc/copy_to_clipboard.es6
@@ -8,7 +8,7 @@ export default class CopytoClipboard {
   }
 
   copy_doi() {
-    var doi = $('#copy-doi').data('url');
+    const doi = $('#copy-doi').data('url');
     this.copyToClipboard(doi, '#copy-doi-icon', '#copy-doi-label', 'copy-doi-label-normal', 'copy-doi-label-copied');
     return false;
   }

--- a/app/javascript/entrypoints/pdc/maximum_file_upload.es6
+++ b/app/javascript/entrypoints/pdc/maximum_file_upload.es6
@@ -6,7 +6,6 @@ export default class MaximumFileUpload {
   }
 
   attach_validation() {
-    console.log('attaching validation');
     this.upload_element.on('change', this.validate.bind(this));
   }
 

--- a/app/javascript/entrypoints/pdc/maximum_file_upload.es6
+++ b/app/javascript/entrypoints/pdc/maximum_file_upload.es6
@@ -1,8 +1,8 @@
 export default class MaximumFileUpload {
-  constructor(upload_id, save_id, error_id = 'file-error') {
-    this.upload_element = $(`#${upload_id}`);
-    this.save_element = document.getElementById(save_id);
-    this.error_element = document.getElementById(error_id);
+  constructor(uploadId, saveId, errorId = 'file-error') {
+    this.upload_element = $(`#${uploadId}`);
+    this.save_element = document.getElementById(saveId);
+    this.error_element = document.getElementById(errorId);
   }
 
   attach_validation() {


### PR DESCRIPTION
- Fix #957
- Explicitly list a couple globals we need for now, but add a TODO with next steps.
- Leave disabled `no-alert`: This seems fine for an application like this that doesn't need a stunning UI, but we could discuss this more.
- Restrict `no-console`: In my experience, adding console.log is a fine debugging tool, but it's useful to have linting that reminds you to clean it up before merging.
- We have one error with `no-restricted-syntax`, but I haven't reproduced the CI behavior locally. Leave it as a TODO.