### PR TITLE
Blanking the migration test DOI so it will be minted on the server when a DOI is not part of the original metadata

### DIFF
--- a/spec/system/data_migration/cklibrary_form_submission_spec.rb
+++ b/spec/system/data_migration/cklibrary_form_submission_spec.rb
@@ -61,6 +61,8 @@ RSpec.describe "Form submission for migrating cklibrary", type: :system, mock_ez
       datacite = PDCSerialization::Datacite.new_from_work(cklibrary_work)
       expect(datacite.valid?).to eq true
       expect(datacite.to_xml).to be_equivalent_to(File.read("spec/system/data_migration/cklibrary.xml"))
+      # Ensure the DOI is blank so a new one will be minted when this is imported
+      cklibrary_work.resource.doi = nil
       export_spec_data("cklibrary.json", cklibrary_work.to_json)
     end
   end

--- a/spec/system/data_migration/sowingseeds_form_submission_spec.rb
+++ b/spec/system/data_migration/sowingseeds_form_submission_spec.rb
@@ -75,6 +75,8 @@ Download the README.txt for a detailed description of this dataset's content."
       datacite = PDCSerialization::Datacite.new_from_work(sowingseeds_work)
       expect(datacite.valid?).to eq true
       expect(datacite.to_xml).to be_equivalent_to(File.read("spec/system/data_migration/sowingseeds.xml"))
+      # Ensure the DOI is blank so a new one will be minted when this is imported
+      sowingseeds_work.resource.doi = nil
       export_spec_data("sowingseeds.json", sowingseeds_work.to_json)
     end
   end


### PR DESCRIPTION
Updated the two tests that do not fill in the DOI

fixes #970