### PR TITLE
ESLint: Scan every file in the directory, instead of listing extensions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,9 @@ jobs:
       - install_dependencies
       - run:
           name: Run eslint
-          command: yarn run eslint app/assets app/javascript --ext .js,.jsx,es6   
+          # Quote directory globs so not they are expanded by shell,
+          # and every file will be checked, regardless of extension.
+          command: yarn run eslint 'app/assets/javascripts/**' 'app/javascript/**'
 
   test:
     working_directory: *root


### PR DESCRIPTION
- Fix #955

This is slightly more robust: if `.ts` or anything else is included in these directories, it will also be scanned.

I don't see a way to specify the target directories in the `.eslintrc.yaml`, so I think this should close issue.