### PR TITLE
Handles external user ids

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -53,8 +53,21 @@ class UsersController < ApplicationController
 
     # Use callbacks to share common setup or constraints between actions.
     def set_user
-      @user = User.friendly.find(params[:id])
-      redirect_to action: action_name, id: @user.friendly_id, status: :moved_permanently unless @user.friendly_id == params[:id]
+      user_id = user_id_from_url
+      @user = User.friendly.find(user_id)
+      redirect_to action: action_name, id: @user.friendly_id, status: :moved_permanently unless @user.friendly_id == user_id
+    end
+
+    def user_id_from_url
+      # For external users UID is in the form `user-name@gmail.com`, however, Rails eats the ".com" from
+      # the UID and dumps it into the `format` param. Here we make sure the ".com" is preserved when the
+      # UID looks to be an external user id.
+      external_uid = params[:id].include?("@")
+      if external_uid && params["format"] == "com"
+        "#{params[:id]}.#{params['format']}"
+      else
+        params[:id]
+      end
     end
 
     # Only allow a list of trusted parameters through.

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe UsersController do
   it "renders the show page for external users" do
     # Notice that for external users like "pppltest@gmail.com" Rails splits the ".com" in the URL
     sign_in user_external
-    get :show, params: { id: user_external.friendly_id.gsub(".com",""), format: "com"}
+    get :show, params: { id: user_external.friendly_id.gsub(".com", ""), format: "com" }
     expect(response).to render_template("show")
   end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -4,10 +4,18 @@ require "rails_helper"
 RSpec.describe UsersController do
   let(:user) { FactoryBot.create(:user) }
   let(:user_other) { FactoryBot.create(:user) }
+  let(:user_external) { FactoryBot.create(:external_user) }
 
   it "renders the show page" do
     sign_in user
     get :show, params: { id: user_other.friendly_id }
+    expect(response).to render_template("show")
+  end
+
+  it "renders the show page for external users" do
+    # Notice that for external users like "pppltest@gmail.com" Rails splits the ".com" in the URL
+    sign_in user_external
+    get :show, params: { id: user_external.friendly_id.gsub(".com",""), format: "com"}
     expect(response).to render_template("show")
   end
 

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -55,4 +55,10 @@ FactoryBot.define do
       User.new_super_admin(user.uid)
     end
   end
+
+  factory :external_user, class: "User" do
+    uid { FFaker::InternetSE.user_name + "@gmail.com"}
+    email { "#{uid}@princeton.edu" }
+    provider { :cas }
+  end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -57,7 +57,7 @@ FactoryBot.define do
   end
 
   factory :external_user, class: "User" do
-    uid { FFaker::InternetSE.user_name + "@gmail.com"}
+    uid { FFaker::InternetSE.user_name + "@gmail.com" }
     email { "#{uid}@princeton.edu" }
     provider { :cas }
   end


### PR DESCRIPTION
Fixes the problem with the redirect for external net id used in guest accounts (e.g. sometest@gmail.com)

Fixes #993 
