### PR TITLE
Removing attach_works which would slow down edits

### DIFF
--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -926,12 +926,16 @@ RSpec.describe WorksController do
     end
 
     describe "#approve" do
+      before do
+        stub_s3
+        allow(Work).to receive(:find).with(work.id).and_return(work)
+        allow(Work).to receive(:find).with(work.id.to_s).and_return(work)
+        allow(work).to receive(:publish_precurated_files).and_return(true)
+      end
+
       it "handles aprovals" do
         work.complete_submission!(user)
         stub_datacite_doi
-        file_name = uploaded_file.original_filename
-        stub_work_s3_requests(work: work, file_name: file_name)
-        work.pre_curation_uploads.attach(uploaded_file)
 
         sign_in curator
         post :approve, params: { id: work.id }
@@ -945,9 +949,6 @@ RSpec.describe WorksController do
           sign_in curator
           work.complete_submission!(user)
           stub_datacite_doi(result: Failure(Faraday::Response.new(Faraday::Env.new)))
-          file_name = uploaded_file.original_filename
-          stub_work_s3_requests(work: work, file_name: file_name)
-          work.pre_curation_uploads.attach(uploaded_file)
         end
 
         it "aproves and notes that it was not published" do

--- a/spec/requests/works_spec.rb
+++ b/spec/requests/works_spec.rb
@@ -42,7 +42,6 @@ RSpec.describe "/works", type: :request do
         before do
           allow(work).to receive(:id).and_return("test-id")
           allow(work).to receive(:collection).and_return(nil)
-          allow(work).to receive(:attach_s3_resources)
 
           allow(Work).to receive(:find).and_return(work)
         end

--- a/spec/support/s3_query_service_specs.rb
+++ b/spec/support/s3_query_service_specs.rb
@@ -9,15 +9,20 @@ def stub_s3(data: [], bucket_url: nil)
   allow(fake_s3_query).to receive(:bucket_name).and_return("example-bucket")
   allow(fake_s3_query).to receive(:file_count).and_return(data.length)
   allow(fake_s3_query).to receive(:delete_s3_object)
+  allow(fake_s3_query).to receive(:publish_files).and_return([])
   allow(S3QueryService).to receive(:new).and_return(fake_s3_query)
 
+  mock_bucket(bucket_url)
+
+  fake_s3_query
+end
+
+def mock_bucket(bucket_url)
   if bucket_url.present?
     # Also stub ActiveStorage calls to the bucket
     stub_request(:put, /#{bucket_url}/).to_return(status: 200)
     stub_request(:delete, /#{bucket_url}/).to_return(status: 200)
   end
-
-  fake_s3_query
 end
 
 RSpec.configure do |config|

--- a/spec/system/authz_super_admin_spec.rb
+++ b/spec/system/authz_super_admin_spec.rb
@@ -38,8 +38,9 @@ RSpec.describe "Authz for super admins", type: :system, js: true do
 
       expect(page).to have_content "awaiting_approval"
       work = Work.last
-      file_name = "us_covid_2019.csv"
-      stub_work_s3_requests(work: work, file_name: file_name)
+      allow(Work).to receive(:find).with(work.id).and_return(work)
+      allow(Work).to receive(:find).with(work.id.to_s).and_return(work)
+      allow(work).to receive(:publish_precurated_files).and_return(true)
 
       sign_out submitter2
       sign_in super_admin
@@ -73,6 +74,9 @@ RSpec.describe "Authz for super admins", type: :system, js: true do
 
       work.save!
       work.reload
+      allow(Work).to receive(:find).with(work.id).and_return(work)
+      allow(Work).to receive(:find).with(work.id.to_s).and_return(work)
+      allow(work).to receive(:publish_precurated_files).and_return(true)
 
       sign_in super_admin
       visit work_path(work)

--- a/spec/system/migrate_submission_spec.rb
+++ b/spec/system/migrate_submission_spec.rb
@@ -115,10 +115,13 @@ RSpec.describe "Form submission for a legacy dataset", type: :system, mock_ezid_
 
       sign_in curator
 
-      stub_work_s3_requests(work: work, file_name: file_name)
-      work.pre_curation_uploads.attach(uploaded_file)
       work.save!
       work.reload
+
+      stub_s3
+      allow(Work).to receive(:find).with(work.id).and_return(work)
+      allow(Work).to receive(:find).with(work.id.to_s).and_return(work)
+      allow(work).to receive(:publish_precurated_files).and_return(true)
 
       visit work_path(work)
       click_on "Approve"

--- a/spec/system/rss_spec.rb
+++ b/spec/system/rss_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe "RSS feed of approved works, for harvesting and indexing", type: 
   let(:work2) { FactoryBot.create(:draft_work) }
   let(:work3) { FactoryBot.create(:draft_work) }
   let(:admin) { FactoryBot.create(:super_admin_user) }
-  let(:file_name) { "us_covid_2019.csv" }
-  let(:uploaded_file) { fixture_file_upload(file_name, "text/csv") }
+  let(:s3_file1) { FactoryBot.build :s3_file, filename: "us_covid_2019.csv", work: work1 }
+  let(:s3_file2) { FactoryBot.build :s3_file, filename: "us_covid_2019.csv", work: work1 }
   let(:list_objects_response) do
     <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
@@ -33,15 +33,14 @@ XML
 
     allow(work1).to receive(:publish_doi).and_return(true)
     allow(work2).to receive(:publish_doi).and_return(true)
+    allow(work1).to receive(:publish_precurated_files).and_return(true)
+    allow(work2).to receive(:publish_precurated_files).and_return(true)
+    stub_s3(data: [s3_file1])
 
     # Works 1 & 2 are approved, so they should show up in the RSS feed
-    stub_work_s3_requests(work: work1, file_name: uploaded_file.original_filename)
-    work1.pre_curation_uploads.attach(uploaded_file)
     work1.complete_submission!(admin)
     work1.approve!(admin)
 
-    stub_work_s3_requests(work: work2, file_name: uploaded_file.original_filename)
-    work2.pre_curation_uploads.attach(uploaded_file)
     work2.complete_submission!(admin)
     work2.approve!(admin)
 


### PR DESCRIPTION
This forced publish to utilize S3 instead of local files, which should be faster. 
Many tests needed to change to not attach files to precuration_uploads and instead mock S3

refs #994 

