### PR TITLE
Removing call to disable webmock

### DIFF
--- a/spec/models/pdc_serialization/datacite_spec.rb
+++ b/spec/models/pdc_serialization/datacite_spec.rb
@@ -241,6 +241,7 @@ RSpec.describe PDCSerialization::Datacite, type: :model do
     let(:parsed_xml) { Datacite::Mapping::Resource.parse_xml(datacite) }
 
     it "references the related object in the datacite record" do
+      stub_ark
       expect(parsed_xml.related_identifiers.count).to eq 3
       expect(parsed_xml.related_identifiers[0].identifier_type.value).to eq "ARK"
       expect(parsed_xml.related_identifiers[1].identifier_type.value).to eq "arXiv"
@@ -273,6 +274,7 @@ RSpec.describe PDCSerialization::Datacite, type: :model do
     context "valid XML record" do
       let(:work) { FactoryBot.create(:distinct_cytoskeletal_proteins_work) }
       it "easily validates against our local datacite schema" do
+        stub_ark
         expect(resource.valid?).to eq true
         expect(resource.errors.empty?).to eq true
       end

--- a/spec/models/upload_snapshot_spec.rb
+++ b/spec/models/upload_snapshot_spec.rb
@@ -43,6 +43,8 @@ RSpec.describe UploadSnapshot, type: :model do
         allow(fake_s3_service_pre.client).to receive(:head_object).with(bucket: "example-post-bucket", key: work.s3_object_key).and_raise(Aws::S3::Errors::NotFound.new("blah", "error"))
         allow(fake_s3_service_post).to receive(:bucket_name).and_return("example-post-bucket")
         allow(fake_s3_service_pre).to receive(:bucket_name).and_return("example-pre-bucket")
+        stub_ark
+        stub_datacite_doi
 
         work.approve!(curator_user)
         work.save
@@ -69,6 +71,8 @@ RSpec.describe UploadSnapshot, type: :model do
         allow(fake_s3_service_pre.client).to receive(:head_object).with(bucket: "example-post-bucket", key: work.s3_object_key).and_raise(Aws::S3::Errors::NotFound.new("blah", "error"))
         allow(fake_s3_service_post).to receive(:bucket_name).and_return("example-post-bucket")
         allow(fake_s3_service_pre).to receive(:bucket_name).and_return("example-pre-bucket")
+        stub_ark
+        stub_datacite_doi
 
         work.approve!(curator_user)
         work.save

--- a/spec/models/work_activity_spec.rb
+++ b/spec/models/work_activity_spec.rb
@@ -59,7 +59,7 @@ describe WorkActivity, type: :model do
       it "finds all the activities for the work and type" do
         expect(described_class.activities_for_work(work, [WorkActivity::SYSTEM])).to eq([work_activity])
         expect(described_class.activities_for_work(work, [WorkActivity::NOTIFICATION])).to eq([notification])
-        expect(described_class.activities_for_work(work, [WorkActivity::SYSTEM, WorkActivity::NOTIFICATION])).to eq([work_activity, notification])
+        expect(described_class.activities_for_work(work, [WorkActivity::SYSTEM, WorkActivity::NOTIFICATION])).to contain_exactly(work_activity, notification)
       end
     end
 

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -133,6 +133,7 @@ RSpec.describe Work, type: :model do
   context "with related objects" do
     subject(:work) { FactoryBot.create(:distinct_cytoskeletal_proteins_work) }
     it "has related objects" do
+      stub_ark
       expect(work.resource.related_objects.first.related_identifier).to eq "https://www.biorxiv.org/content/10.1101/545517v1"
       expect(work.resource.related_objects.first.related_identifier_type).to eq "arXiv"
       expect(work.resource.related_objects.first.relation_type).to eq "IsCitedBy"
@@ -168,6 +169,7 @@ RSpec.describe Work, type: :model do
 
     context "when a Work is approved" do
       it "transfers the files to the AWS Bucket" do
+        stub_datacite_doi
         work.approve!(curator_user)
         work.reload
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -108,8 +108,3 @@ RSpec.configure do |config|
     end
   end
 end
-
-# Fix intermittent errors: "Failed to open TCP connection ... Too many open files"
-# https://stackoverflow.com/a/65946077
-# https://github.com/bblimke/webmock#connecting-on-nethttpstart
-WebMock.allow_net_connect!(net_http_connect_on_start: true)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,7 +30,11 @@ RSpec.configure do |config|
   # WebMock.enable_net_connect! setting.
   # Allow connections to local services / localhost
   allowed_sites = ["localhost", "chromedriver.storage.googleapis.com", "127.0.0.1"]
-  WebMock.disable_net_connect!(allow: allowed_sites)
+
+  # Add net_http_connect_on_start: true, to fix intermittent errors: "Failed to open TCP connection ... Too many open files"
+  # https://stackoverflow.com/a/65946077
+  # https://github.com/bblimke/webmock#connecting-on-nethttpstart
+  WebMock.disable_net_connect!(allow: allowed_sites, net_http_connect_on_start: true)
   # WebMock.enable_net_connect!
 
   # FactoryBot

--- a/spec/support/ark_specs.rb
+++ b/spec/support/ark_specs.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+def stub_ark
+  ezid = instance_double(Ezid::Identifier)
+  allow(Ezid::Identifier).to receive(:find).and_return ezid
+  ezid
+end

--- a/spec/system/work_edit_spec.rb
+++ b/spec/system/work_edit_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "Creating and updating works", type: :system, js: true do
 
   before do
     stub_s3
+    stub_ark
     stub_datacite(host: "api.datacite.org", body: datacite_register_body(prefix: "10.34770"))
   end
 

--- a/spec/system/work_show_spec.rb
+++ b/spec/system/work_show_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "Creating and updating works", type: :system, js: true do
 
   before do
     stub_s3
+    stub_ark
   end
 
   it "displays related identifiers" do

--- a/spec/system/work_spec.rb
+++ b/spec/system/work_spec.rb
@@ -135,6 +135,7 @@ RSpec.describe "Creating and updating works", type: :system do
 
     before do
       stub_s3
+      stub_ark
       sign_in user
       allow_any_instance_of(PDCMetadata::Resource).to receive(:to_xml).and_return(invalid_xml)
     end
@@ -168,6 +169,7 @@ RSpec.describe "Creating and updating works", type: :system do
     end
 
     it "allows users to modify the order of the creators", js: true do
+      stub_datacite_doi
       creator = draft_work.resource.creators.first
       sign_in user
       visit edit_work_path(draft_work)


### PR DESCRIPTION
Mock ezid as we are no longer allowing a connection to it during the tests

This [PR](https://github.com/pulibrary/pdc_describe/commit/337f7bb18274e4210ba104691e49fcd13cd6fe3f) disabled webmock, which allowed our tests to be directly connecting to ezid.

Added change to the webmock enable, where it should have gone according [the stack overflow](https://stackoverflow.com/questions/59632283/chromedriver-capybara-too-many-open-files-socket2-for-127-0-0-1-port-951/65946077#65946077) referenced in the original PR.