### PR TITLE
Fix deprecation warning

### DIFF
--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -629,7 +629,7 @@ RSpec.describe Work, type: :model do
     end
 
     it "notes a issue when an error occurs" do
-      stub_datacite_doi(result: Failure(Faraday::Response.new(Faraday::Env.new(status: "bad", reason_phrase: "a problem"))))
+      stub_datacite_doi(result: Failure(Faraday::Response.new(Faraday::Env.new({status: "bad", reason_phrase: "a problem"}))))
       expect { approved_work }.to change { WorkActivity.where(activity_type: WorkActivity::DATACITE_ERROR).count }.by(1)
     end
 

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -629,7 +629,7 @@ RSpec.describe Work, type: :model do
     end
 
     it "notes a issue when an error occurs" do
-      stub_datacite_doi(result: Failure(Faraday::Response.new(Faraday::Env.new({status: "bad", reason_phrase: "a problem"}))))
+      stub_datacite_doi(result: Failure(Faraday::Response.new(Faraday::Env.new({ status: "bad", reason_phrase: "a problem" }))))
       expect { approved_work }.to change { WorkActivity.where(activity_type: WorkActivity::DATACITE_ERROR).count }.by(1)
     end
 


### PR DESCRIPTION
Ruby 3.2+ is going to start requiring an explicit hash when passing named parameters