### PR TITLE
Process uploads when creating a dataset outside the wizard

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -44,6 +44,11 @@ class WorksController < ApplicationController
     # We currently do not and therefore there are not saved to the work.
     # See https://github.com/pulibrary/pdc_describe/issues/1041
     @work = Work.new(created_by_user_id: current_user.id, collection_id: params_collection_id, user_entered_doi: params["doi"].present?)
+
+    byebug
+
+    upload_service = WorkUploadsEditService.new(@work, current_user)
+    upload_service.update_precurated_file_list(added_files_param, deleted_files_param)
     @work.resource = FormToResourceService.convert(params, @work)
     if @work.valid?
       @work.draft!(current_user)

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -40,18 +40,12 @@ class WorksController < ApplicationController
   end
 
   def create
-    # TODO: We need to process files submitted by the user in this method.
-    # We currently do not and therefore there are not saved to the work.
-    # See https://github.com/pulibrary/pdc_describe/issues/1041
     @work = Work.new(created_by_user_id: current_user.id, collection_id: params_collection_id, user_entered_doi: params["doi"].present?)
-
-    byebug
-
-    upload_service = WorkUploadsEditService.new(@work, current_user)
-    upload_service.update_precurated_file_list(added_files_param, deleted_files_param)
     @work.resource = FormToResourceService.convert(params, @work)
     if @work.valid?
       @work.draft!(current_user)
+      upload_service = WorkUploadsEditService.new(@work, current_user)
+      upload_service.update_precurated_file_list(added_files_param, deleted_files_param)
       redirect_to work_url(@work), notice: "Work was successfully created."
     else
       render :new, status: :unprocessable_entity

--- a/app/views/works/_required_form.html.erb
+++ b/app/views/works/_required_form.html.erb
@@ -1,4 +1,4 @@
-<div class="field">  
+<div class="field">
   <p class="doi-text">
     By initiating this new submission, we have reserved a draft DOI for your use.
     This DOI will not go live until the data review process is complete,
@@ -16,8 +16,8 @@
 
 <!-- Description (one for now)-->
 <div class="field">
-  <%= render partial: "required_form_field_details", locals: { name: "description", display_name: "Description", 
-                                                       field_detail: "Please enter a brief summary of this item specifically &mdash; not identical to the abstract of a corresponding paper. The focus should be on the nature of the materials constituting the item (scope, purpose, methods, etc.), as opposed to substantive claims made in related publications.",
+  <%= render partial: "required_form_field_details", locals: { name: "description", display_name: "Description",
+                                                       field_detail: "Please enter a brief summary of this item specifically - not identical to the abstract of a corresponding paper. The focus should be on the nature of the materials constituting the item (scope, purpose, methods, etc.), as opposed to substantive claims made in related publications.",
                                                       }
   %>
   <textarea type="text" id="description" name="description" class="input-text-long" rows="5" cols="120"

--- a/spec/system/data_migration/attention_form_submission_spec.rb
+++ b/spec/system/data_migration/attention_form_submission_spec.rb
@@ -14,12 +14,17 @@ This dataset is too large to download directly from this item page. You can acce
   let(:publisher) { "Princeton University" }
   let(:doi) { "10.34770/9425-b553" }
   let(:file_upload) { Pathname.new(fixture_path).join("dataspace_migration", "attention", "Attention_Awareness_Dorsal_Attention_README.txt").to_s }
+  let(:file1) { FactoryBot.build :s3_file, filename: file_upload }
+  let(:bucket_url) do
+    "https://example-bucket.s3.amazonaws.com/"
+  end
 
   before do
     stub_datacite(host: "api.datacite.org", body: datacite_register_body(prefix: "10.34770"))
     stub_request(:get, "https://handle.stage.datacite.org/10.34770/9425-b553")
       .to_return(status: 200, body: "", headers: {})
-    stub_s3
+    stub_request(:put, /#{bucket_url}/).to_return(status: 200)
+    stub_s3(data: [file1])
   end
   context "migrate record from dataspace" do
     it "produces and saves a valid datacite record" do


### PR DESCRIPTION
Makes sure files uploaded are processed when creating a new dataset without using the Wizard.

Closes #1041

I also bundled the fix for #1068 since it was a simple typo in a view.

