### PR TITLE
Adding migration button to the Dataset Creation page to migrate content from dspace to pre-curation

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -41,6 +41,12 @@
   margin-bottom: 0px !important;
 }
 
+.btn-secondary.migrate-button {
+  float: right;
+  margin-right: 1em;
+  background-color: #0d6efd;
+}
+
 .wizard-radio-button {
   margin-right: 5px;
 }

--- a/app/controllers/work_migration_controller.rb
+++ b/app/controllers/work_migration_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+class WorkMigrationController < ApplicationController
+  def migrate
+    work = Work.find(params[:id])
+    if work.ark.present? && current_user.can_admin?(work.collection)
+      dspace = PULDspaceData.new(work)
+      dspace.migrate
+      flash[:notice] = dspace.migration_message
+      # TODO: Add in WorkActivity here since we know the use information here
+    elsif !current_user.can_admin?(work.collection)
+      flash[:notice] = "Unauthorized migration"
+      Honeybadger.notify("Unauthorized to migration work #{work.id} (current user: #{current_user.id})")
+    else
+      flash[:notice] = "The ark is blank, no migration from Dataspace is possible"
+    end
+    redirect_to work_path(work)
+    # TODO: migrate the work content if the user is allowed and the work has an ark and is migrated
+  end
+end

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -42,6 +42,7 @@ class WorksController < ApplicationController
   def create
     @work = Work.new(created_by_user_id: current_user.id, collection_id: params_collection_id, user_entered_doi: params["doi"].present?)
     @work.resource = FormToResourceService.convert(params, @work)
+    @work.resource.migrated = (params[:submit] == "Migrate")
     if @work.valid?
       @work.draft!(current_user)
       upload_service = WorkUploadsEditService.new(@work, current_user)

--- a/app/decorators/work_decorator.rb
+++ b/app/decorators/work_decorator.rb
@@ -2,7 +2,8 @@
 class WorkDecorator
   attr_reader :work, :changes, :messages, :can_curate, :current_user
 
-  delegate :collection, to: :work
+  delegate :collection, :resource, :draft?, to: :work
+  delegate :migrated, to: :resource
 
   def initialize(work, current_user)
     @work = work
@@ -10,5 +11,21 @@ class WorkDecorator
     @changes =  WorkActivity.changes_for_work(work.id)
     @messages = WorkActivity.messages_for_work(work.id)
     @can_curate = current_user&.can_admin?(collection)
+  end
+
+  def show_approve_button?
+    work.awaiting_approval? && current_user.has_role?(:collection_admin, collection)
+  end
+
+  def show_complete_button?
+    work.draft? && work.created_by_user_id == current_user.id
+  end
+
+  def show_migrate_button?
+    work.draft? && migrated && current_user.has_role?(:collection_admin, collection)
+  end
+
+  def wizard_mode?
+    draft? && !migrated
   end
 end

--- a/app/models/s3_file.rb
+++ b/app/models/s3_file.rb
@@ -26,6 +26,10 @@ class S3File
     size
   end
 
+  def directory?
+    size == 0
+  end
+
   def globus_url
     encoded_filename = filename.split("/").map { |name| ERB::Util.url_encode(name) }.join("/")
     File.join(Rails.configuration.globus["post_curation_base_url"], encoded_filename)

--- a/app/services/form_to_resource_service.rb
+++ b/app/services/form_to_resource_service.rb
@@ -35,6 +35,7 @@ class FormToResourceService
 
         resource.doi = work.doi
         resource.ark = work.ark
+        resource.migrated = work.resource.migrated
         resource.collection_tags = work.resource.collection_tags || []
         resource
       end

--- a/app/views/works/_form.html.erb
+++ b/app/views/works/_form.html.erb
@@ -65,7 +65,8 @@
         <% if @work.persisted? %>
           <%= form.submit "Save Work", class: "btn btn-primary wizard-next-button", id: "btn-submit" %>
         <% else %>
-          <%= form.submit "Create", class: "btn btn-primary wizard-next-button", id: "btn-submit" %>
+          <%= form.submit "Create", class: "btn btn-primary wizard-next-button", id: "btn-submit", name: "submit" %>
+          <%= form.submit "Migrate", class: "btn btn-secondary migrate-button", id: "btn-submit", name: "submit" %>
         <% end %>
       </div>
 

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -75,17 +75,20 @@
 <div class="row">
   <div class="col-8">
     <% if @work.editable_in_current_state?(current_user)  %>
-      <%= link_to("Edit", edit_work_path(@work, wizard: @work.draft?), class: "btn btn-primary") %>
+      <%= link_to("Edit", edit_work_path(@work, wizard: @work_decorator.wizard_mode?), class: "btn btn-primary") %>
     <% end %>
-    <% if @work.awaiting_approval? && current_user.has_role?(:collection_admin, @work_decorator.collection) %>
+    <% if @work_decorator.show_approve_button? %>
       <%= button_to("Approve Dataset", approve_work_path(@work), class: "btn btn-secondary", method: :post) %>
     <% elsif @work.approved? %>
       <%= button_to("Withdraw Dataset", withdraw_work_path(@work), class: "btn btn-secondary", method: :post) %>
     <% elsif @work.withdrawn? %>
       <%= button_to("Resubmit for approval", resubmit_work_path(@work), class: "btn btn-secondary", method: :post) %>
     <% end %>
-    <% if @work.draft? && @work.created_by_user_id == current_user.id %>
+    <% if @work_decorator.show_complete_button? %>
       <%= button_to("Complete", work_validate_path(@work), class: "btn btn-secondary", method: :post) %>
+    <% end %>
+    <% if @work_decorator.show_migrate_button? %>
+      <%= button_to("Migrate Dataspace Files", work_migrate_content_path(@work), class: "btn btn-secondary", method: :post) %>
     <% end %>
     <%= link_to "My Dashboard", user_path(current_user), class: "btn btn-secondary" %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,7 @@ Rails.application.routes.draw do
   get "works/:id/datacite", to: "works#datacite", as: :datacite_work
   get "works/:id/datacite/validate", to: "works#datacite_validate", as: :datacite_validate_work
   get "works/:id/download", controller: "work_downloader", action: "download", as: :work_download
+  post "works/:id/migrate_content", controller: "work_migration", action: "migrate", as: :work_migrate_content
   resources :works
   match "/doi/*doi", via: :get, to: "works#resolve_doi", as: :resolve_doi, format: false
   match "/ark/*ark", via: :get, to: "works#resolve_ark", as: :resolve_ark, format: false

--- a/lib/tasks/dspace.rake
+++ b/lib/tasks/dspace.rake
@@ -9,6 +9,6 @@ namespace :dspace do
     puts "Migrating Files from dspace to PDC for Work #{work.title}"
     dspace = PULDspaceData.new(work)
     dspace.migrate
-    puts "Sucessfully migrated #{dspace.keys.count} files for work"
+    puts dspace.migration_message
   end
 end

--- a/spec/controllers/works_migration_controller_spec.rb
+++ b/spec/controllers/works_migration_controller_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe WorkMigrationController do
+  let(:work) { FactoryBot.create :draft_work }
+  let(:user) { FactoryBot.create :research_data_moderator }
+  it "does nothing if no ark is set" do
+    sign_in user
+    post :migrate, params: { id: work.id }
+    expect(response).to redirect_to work_path(work)
+    expect(flash[:notice]).to eq("The ark is blank, no migration from Dataspace is possible")
+  end
+
+  context "when the ark is set" do
+    let(:work) { FactoryBot.create :draft_work, ark: "ark:/88435/dsp01zc77st047" }
+    let(:fake_dpsace_data) { instance_double(PULDspaceData, migrate: true, migration_message: "Migration for 3 files was queued for processing") }
+
+    it "migrates the files using a PULDspaceData instance", mock_ezid_api: true do
+      allow(PULDspaceData).to receive(:new).and_return(fake_dpsace_data)
+      sign_in user
+      post :migrate, params: { id: work.id }
+      expect(response).to redirect_to work_path(work)
+      expect(flash[:notice]).to eq("Migration for 3 files was queued for processing")
+    end
+  end
+
+  context "when the user is not an admin" do
+    let(:user) { FactoryBot.create :user }
+
+    it "does nothing" do
+      sign_in user
+      allow(Honeybadger).to receive(:notify)
+      post :migrate, params: { id: work.id }
+      expect(response).to redirect_to work_path(work)
+      expect(flash[:notice]).to eq("Unauthorized migration")
+      expect(Honeybadger).to have_received(:notify)
+    end
+  end
+end

--- a/spec/decorators/work_decorator_spec.rb
+++ b/spec/decorators/work_decorator_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+describe WorkDecorator, type: :model do
+  subject(:decorator) { WorkDecorator.new(work, user) }
+  let(:user) { FactoryBot.create(:user) }
+  let(:work) { FactoryBot.create(:draft_work) }
+
+  it "delgate methods" do
+    expect(decorator.collection).to eq(work.collection)
+    expect(decorator.resource).to eq(work.resource)
+    expect(decorator.migrated).to be_falsey
+    work.resource.migrated = true
+    expect(decorator.migrated).to be_truthy
+  end
+end

--- a/spec/requests/works_spec.rb
+++ b/spec/requests/works_spec.rb
@@ -34,6 +34,8 @@ RSpec.describe "/works", type: :request do
           stubbed = instance_double(Work)
           allow(stubbed).to receive(:s3_object_key).and_return("test-key")
           allow(stubbed).to receive(:reload_snapshots)
+          stubbed_resource = instance_double(PDCMetadata::Resource)
+          allow(stubbed).to receive(:resource).and_return(stubbed_resource)
           stubbed
         end
 

--- a/spec/system/migrate_submission_spec.rb
+++ b/spec/system/migrate_submission_spec.rb
@@ -33,6 +33,17 @@ RSpec.describe "Form submission for a legacy dataset", type: :system, mock_ezid_
   let(:ark) { "http://arks.princeton.edu/ark:/88435/dsp01d791sj97j" }
   let(:collection) { "Research Data" }
 
+  context "non moderator user" do
+    let(:user) { FactoryBot.create(:user) }
+
+    it "does not allow any user to migrate a dataset" do
+      sign_in user
+      visit user_path(user)
+      click_on(user.uid)
+      expect(page).not_to have_link("Create Dataset")
+    end
+  end
+
   context "happy path" do
     before do
       stub_request(:get, "https://handle.stage.datacite.org/10.34770/123-abc").to_return(status: 200, body: "", headers: {})
@@ -43,6 +54,7 @@ RSpec.describe "Form submission for a legacy dataset", type: :system, mock_ezid_
       sign_in user
       visit user_path(user)
       click_on(user.uid)
+      expect(page).to have_link("Create Dataset")
       click_on "Create Dataset"
       fill_in "title_main", with: title
       fill_in "given_name_1", with: "Samantha"
@@ -54,6 +66,30 @@ RSpec.describe "Form submission for a legacy dataset", type: :system, mock_ezid_
       fill_in "ark", with: ark
       fill_in "publication_year", with: issue_date
       click_on "Create"
+      expect(Work.last.resource.migrated).to be_falsey
+      expect(page).not_to have_button("Migrate Dataspace Files")
+      click_on "Complete"
+      expect(page).to have_content "awaiting_approval"
+    end
+
+    it "produces and saves a valid datacite record that is migrated" do
+      sign_in user
+      visit user_path(user)
+      click_on(user.uid)
+      expect(page).to have_link("Create Dataset")
+      click_on "Create Dataset"
+      fill_in "title_main", with: title
+      fill_in "given_name_1", with: "Samantha"
+      fill_in "family_name_1", with: "Abrams"
+      fill_in "description", with: description
+      select "GNU General Public License", from: "rights_identifier"
+      click_on "Curator Controlled"
+      fill_in "doi", with: doi
+      fill_in "ark", with: ark
+      fill_in "publication_year", with: issue_date
+      click_on "Migrate"
+      expect(Work.last.resource.migrated).to be_truthy
+      expect(page).to have_button("Migrate Dataspace Files")
       click_on "Complete"
       expect(page).to have_content "awaiting_approval"
     end


### PR DESCRIPTION
This is step one for the provenance.  This PR adds the buttons to the UI for running the migration, so that we know who is running the migration.

- Adds migrate file button to work create page to mark the work as being migrated
- Changes edit button on show page to never show the wizard if the file is being migrated
- Adds WorkMigrationController
- Makes small changes to migration to show files and directories separately

refs #1109

New Button on Dataset Creation page
![Screenshot 2023-05-04 at 9 00 24 AM](https://user-images.githubusercontent.com/1599081/236258452-80a17f12-c8a8-4d85-a4f7-64134c815d68.png)

New Button on Show page:
![Screenshot 2023-05-04 at 11 13 01 AM](https://user-images.githubusercontent.com/1599081/236258059-183fa78d-4776-4124-a5ae-5b14f0233b6d.png)

Message for successful migration:
![Screenshot 2023-05-04 at 11 33 08 AM](https://user-images.githubusercontent.com/1599081/236258032-1ad3b027-0375-423e-86fe-489de8df4ef7.png)

Message when the ark is blank:
![Screenshot 2023-05-04 at 10 01 24 AM](https://user-images.githubusercontent.com/1599081/236258261-6c2a42dc-e379-4e25-946c-cd5cd1e47754.png)

