### PR TITLE
Display each related object on a separate line

### DIFF
--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -216,13 +216,14 @@
         <dd>
           <% @work.presenter.related_objects_link_list.each do |related_object| %>
             <span class="related_object">
-            <%= related_object.relation_type %>
-              <% if related_object.link.blank? %>
-                <%= related_object.identifier %>
-              <% else %>
-                <%= link_to(related_object.identifier, related_object.link) %>                
-              <% end %>
+            <%= related_object.relation_type.titleize %>
+            <% if related_object.link.blank? %>
+              <%= related_object.identifier %>
+            <% else %>
+              <%= link_to(related_object.identifier, related_object.link) %>
+            <% end %>
             </span>
+            <br/>
           <% end %>
         </dd>
       <% end %>


### PR DESCRIPTION
Displays each related object on a separate line and titlelize the relation types, e.g. "IsCitedBy" becomes "Is Cited By")
 
Fixes #1013

![Screenshot 2023-05-10 at 8 44 01 AM](https://github.com/pulibrary/pdc_describe/assets/568286/8020e771-24c8-4543-a4b0-cfe178b67fe7)


