### PR TITLE
Adding a database migration to move existing Collection privileges to Group

### DIFF
--- a/db/migrate/20230516133007_role_collection_to_group.rb
+++ b/db/migrate/20230516133007_role_collection_to_group.rb
@@ -1,0 +1,27 @@
+class RoleCollectionToGroup < ActiveRecord::Migration[6.1]
+  # Please note that for some reason roles are not valid, although the system still seems to work
+  # This may be related to the Collection is a parent of Group.  We may want to unwind that once the crisis is over
+  def up
+    Role.where(resource_type: "Collection", name: "collection_admin").each do |role|
+      role.resource_type = "Group"
+      role.name = "group_admin"
+      role.save(validate: false)
+    end
+    Role.where(resource_type: "Collection").each do |role|
+      role.resource_type = "Group"
+      role.save(validate: false)
+    end
+  end
+
+  def down
+    Role.where(resource_type: "Group", name: "group_admin").each do |role|
+      role.resource_type = "Collection"
+      role.name = "collection_admin"
+      role.save(validate: false)
+    end
+    Role.where(resource_type: "Group").each do |role|
+      role.resource_type = "Collection"
+      role.save(validate: false)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_04_164626) do
+ActiveRecord::Schema.define(version: 2023_05_16_133007) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,11 +72,11 @@ ActiveRecord::Schema.define(version: 2023_05_04_164626) do
   end
 
   create_table "upload_snapshots", force: :cascade do |t|
-    t.string "url", null: false
+    t.string "url"
+    t.bigint "version"
     t.bigint "work_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "version"
     t.jsonb "files"
     t.index ["work_id"], name: "index_upload_snapshots_on_work_id"
   end


### PR DESCRIPTION
fixes #1167 

Worked on production...
```
irb(main):004:0> Role.all
=> 
[#<Role:0x00007fd35f2fa050                                      
  id: 1,                                                        
  name: "super_admin",                                          
  resource_type: nil,                                           
  resource_id: nil,                                             
  created_at: Wed, 31 Aug 2022 12:55:09.569705000 EDT -04:00,   
  updated_at: Wed, 31 Aug 2022 12:55:09.569705000 EDT -04:00>,  
 #<Role:0x00007fd35f2f9f88                                      
  id: 2,                                                        
  name: "submitter",                                            
  resource_type: "Collection",                                  
  resource_id: 1,                                               
  created_at: Wed, 31 Aug 2022 13:43:23.479372000 EDT -04:00,   
  updated_at: Wed, 31 Aug 2022 13:43:23.479372000 EDT -04:00>,  
 #<Role:0x00007fd35f2f9ec0
  id: 3,
  name: "collection_admin",
  resource_type: "Collection",
  resource_id: 1,
  created_at: Wed, 31 Aug 2022 13:43:23.535553000 EDT -04:00,
  updated_at: Wed, 31 Aug 2022 13:43:23.535553000 EDT -04:00>,
 #<Role:0x00007fd35f2f9df8
  id: 4,
  name: "collection_admin",
  resource_type: "Collection",
  resource_id: 2,
  created_at: Wed, 31 Aug 2022 13:43:23.560775000 EDT -04:00,
  updated_at: Wed, 31 Aug 2022 13:43:23.560775000 EDT -04:00>,
 #<Role:0x00007fd35f2f9d30
  id: 5,
  name: "collection_admin",
  resource_type: nil,
  resource_id: nil,
  created_at: Fri, 09 Sep 2022 11:48:40.026940000 EDT -04:00,
  updated_at: Fri, 09 Sep 2022 11:48:40.026940000 EDT -04:00>,
 #<Role:0x00007fd35f2f9c68
  id: 7,
  name: "group_admin",
  resource_type: "Group",
  resource_id: 1,
  created_at: Mon, 15 May 2023 11:40:26.053966000 EDT -04:00,
  updated_at: Mon, 15 May 2023 11:40:26.053966000 EDT -04:00>]
```

after:
```
irb(main):005:0> Role.where(resource_type: "Collection")
=> []
irb(main):006:0> Role.all
=> 
[#<Role:0x00007fd35ffb48e0                             
  id: 1,                                               
  name: "super_admin",                                 
  resource_type: nil,                                  
  resource_id: nil,
  created_at: Wed, 31 Aug 2022 12:55:09.569705000 EDT -04:00,
  updated_at: Wed, 31 Aug 2022 12:55:09.569705000 EDT -04:00>,
 #<Role:0x00007fd35ffb45c0
  id: 5,
  name: "collection_admin",
  resource_type: nil,
  resource_id: nil,
  created_at: Fri, 09 Sep 2022 11:48:40.026940000 EDT -04:00,
  updated_at: Fri, 09 Sep 2022 11:48:40.026940000 EDT -04:00>,
 #<Role:0x00007fd35ffb4408
  id: 7,
  name: "group_admin",
  resource_type: "Group",
  resource_id: 1,
  created_at: Mon, 15 May 2023 11:40:26.053966000 EDT -04:00,
  updated_at: Mon, 15 May 2023 11:40:26.053966000 EDT -04:00>,
 #<Role:0x00007fd35ffbbc30
  id: 3,
  name: "group_admin",
  resource_type: "Group",
  resource_id: 1,
  created_at: Wed, 31 Aug 2022 13:43:23.535553000 EDT -04:00,
  updated_at: Tue, 16 May 2023 11:32:43.702271000 EDT -04:00>,
 #<Role:0x00007fd35ffbb3c0
  id: 4,
  name: "group_admin",
  resource_type: "Group",
  resource_id: 2,
  created_at: Wed, 31 Aug 2022 13:43:23.560775000 EDT -04:00,
  updated_at: Tue, 16 May 2023 11:32:43.754385000 EDT -04:00>,
 #<Role:0x00007fd35ffbaab0
  id: 2,
  name: "submitter",
  resource_type: "Group",
  resource_id: 1,
  created_at: Wed, 31 Aug 2022 13:43:23.479372000 EDT -04:00,
  updated_at: Tue, 16 May 2023 11:32:43.760990000 EDT -04:00>]
irb(main):007:0> 
```