### PR TITLE
Removing collection method from WorkDecorator

### DIFF
--- a/app/decorators/work_decorator.rb
+++ b/app/decorators/work_decorator.rb
@@ -13,12 +13,6 @@ class WorkDecorator
     @can_curate = current_user&.can_admin?(group)
   end
 
-  # @todo This supports the legacy models where Groups were previously implemented as Collections
-  # @return [Group]
-  def collection
-    group
-  end
-
   def show_approve_button?
     work.awaiting_approval? && current_user.has_role?(:group_admin, group)
   end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -8,16 +8,16 @@ class Group < ApplicationRecord
     GroupOption
   end
 
-  # GroupOptions model extensible options set for Collections and Users
+  # GroupOptions model extensible options set for Groups and Users
   has_many :group_options, dependent: :destroy
   has_many :group_messaging_options, -> { where(option_type: GroupOption::EMAIL_MESSAGES) }, class_name: "GroupOption", dependent: :destroy
 
   has_many :users_with_options, through: :group_options, source: :user
   has_many :users_with_messaging, through: :group_messaging_options, source: :user
 
-  validate do |collection|
-    if collection.title.blank?
-      collection.errors.add :base, "Title cannot be empty"
+  validate do |group|
+    if group.title.blank?
+      group.errors.add :base, "Title cannot be empty"
     end
   end
 
@@ -47,14 +47,14 @@ class Group < ApplicationRecord
   # Permit a User to receive notification messages for members of this Group
   # @param user [User]
   def enable_messages_for(user:)
-    raise(ArgumentError, "User #{user.uid} is not an administrator for this collection #{title}") unless user.can_admin?(self)
+    raise(ArgumentError, "User #{user.uid} is not an administrator for this group #{title}") unless user.can_admin?(self)
     group_messaging_options << self.class.option_class.new(option_type: self.class.option_class::EMAIL_MESSAGES, group: self, user: user)
   end
 
   # Disable a User from receiving notification messages for members of this Group
   # @param user [User]
   def disable_messages_for(user:)
-    raise(ArgumentError, "User #{user.uid} is not an administrator for this collection #{title}") unless user.can_admin?(self)
+    raise(ArgumentError, "User #{user.uid} is not an administrator for this group #{title}") unless user.can_admin?(self)
     users_with_messaging.destroy(user)
   end
 
@@ -69,19 +69,19 @@ class Group < ApplicationRecord
 
   def self.create_defaults
     return if count > 0
-    Rails.logger.info "Creating default Collections"
+    Rails.logger.info "Creating default Groups"
     create(title: "Research Data", code: "RD")
     create(title: "Princeton Plasma Physics Laboratory", code: "PPPL")
   end
 
-  # Returns the default collection.
+  # Returns the default group.
   # Used when we don't have anything else to determine a more specific Group for a user.
   def self.default
     create_defaults
     research_data
   end
 
-  # Returns the default collection for a given department number.
+  # Returns the default group for a given department number.
   # Reference: https://docs.google.com/spreadsheets/d/1_Elxs3Ex-2wCbbKUzD4ii3k16zx36sYf/edit#gid=1484576831
   def self.default_for_department(department_number)
     if department_number.present? && department_number >= "31000" && department_number <= "31026"
@@ -106,11 +106,11 @@ class Group < ApplicationRecord
   end
 
   ##
-  # The current user adds a new admin user to a collection.
+  # The current user adds a new admin user to a group.
   # For use in the UI - we need to check whether the current_user
   # has the right permissions to add someone as an admin_user.
   # @param [User] current_user - the currently logged in user
-  # @param [User] admin_user - the user who will be granted admin rights on this collection
+  # @param [User] admin_user - the user who will be granted admin rights on this group
   def add_administrator(current_user, admin_user)
     if current_user.has_role?(:super_admin) || current_user.has_role?(:group_admin, self)
       if admin_user.has_role? :group_admin, self
@@ -144,7 +144,7 @@ class Group < ApplicationRecord
       if removed_user.nil?
         errors.add(:delete_permission, "User was not found")
       elsif removed_user == current_user
-        errors.add(:delete_permission, "Cannot remove yourself from a collection. Contact a super-admin for help.")
+        errors.add(:delete_permission, "Cannot remove yourself from a group. Contact a super-admin for help.")
       else
         errors.delete(:delete_permission)
         removed_user.remove_role :group_admin, self

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -68,7 +68,7 @@ class Work < ApplicationRecord
   # Is this work editable by a given user?
   # A work is editable when:
   # * it is being edited by the person who made it
-  # * it is being edited by a collection admin of the collection where is resides
+  # * it is being edited by a group admin of the group where is resides
   # * it is being edited by a super admin
   # @param [User]
   # @return [Boolean]

--- a/app/models/work_list.rb
+++ b/app/models/work_list.rb
@@ -33,10 +33,10 @@ class WorkList
         works = search_context.where(created_by_user_id: user, state: state).to_a
 
         if user.admin_groups.count > 0
-          # The works that match the given state, in all the collections the user can admin
+          # The works that match the given state, in all the groups the user can admin
           # (regardless of who created those works)
-          user.admin_groups.each do |collection|
-            works += search_context.where(collection_id: collection.id, state: state)
+          user.admin_groups.each do |group|
+            works += search_context.where(collection_id: group.id, state: state)
           end
         end
 

--- a/app/models/work_state_transition_notification.rb
+++ b/app/models/work_state_transition_notification.rb
@@ -3,17 +3,17 @@
 # Connect with the curators of a work when an activity occurs
 #
 class WorkStateTransitionNotification
-  attr_accessor :collection_administrators, :depositor, :to_state, :from_state,
+  attr_accessor :group_administrators, :depositor, :to_state, :from_state,
                 :work_url, :notification, :users, :id, :current_user_id, :work_title
 
   def initialize(work, current_user_id)
     @to_state = work.aasm.to_state
     @from_state = work.aasm.from_state
     @depositor = work.created_by_user
-    @collection_administrators = work.group.administrators.to_a
+    @group_administrators = work.group.administrators.to_a
     @work_url = Rails.application.routes.url_helpers.work_url(work)
     @work_title = work.title
-    @users = @collection_administrators | [@depositor] # Depositor may also be an admin, but should only be listed once.
+    @users = @group_administrators | [@depositor] # Depositor may also be an admin, but should only be listed once.
     @notification = notification_for_transition
     @id = work.id
     @current_user_id = current_user_id

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -24,7 +24,7 @@
 <% if @can_edit %>
   <h2 class="dataset-section">Datasets</h2>
   <% if @group.datasets.count > 0 %>
-    <%= render partial: "dataset_table", locals: {table_id: "collection_datasets", datasets: @group.datasets} %>
+    <%= render partial: "dataset_table", locals: {table_id: "group_datasets", datasets: @group.datasets} %>
   <% else %>
     <p>No datasets have been created for this group.</p>
   <% end %>
@@ -35,7 +35,7 @@
     // https://www.datatables.net/reference/option/
     //  order: [] preserves the order from the backend
     var dataset_options = {searching: false, paging: false, info: false, order: []};
-    $('#collection_datasets').DataTable(dataset_options);
+    $('#group_datasets').DataTable(dataset_options);
   });
 </script>
 

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -9,13 +9,13 @@
         </div>
       </fieldset>
 
-      <section class="card container collections"> 
+      <section class="card container groups"> 
         <h2><%= t('users.form.group') %></h2>
         <fieldset>
           <% @user.submitter_or_admin_groups.each do |group| %>
             <legend><%= group.title %></legend>
             <div class="form-check">
-              <%= form.check_box("[groups_with_messaging][#{group.id}]", { id: "collection_messaging_#{group.id}", checked: user.messages_enabled_from?(group: group), class: ["form-check-input"] }) %>
+              <%= form.check_box("[groups_with_messaging][#{group.id}]", { id: "group_messaging_#{group.id}", checked: user.messages_enabled_from?(group: group), class: ["form-check-input"] }) %>
               <%= form.label("[groups_with_messaging][#{group.id}]", t("users.form.email_messages_enabled"), class: ["form-check-label"]) %>
             </div>
           <% end %>
@@ -72,7 +72,7 @@
   </div>
 
   <div class="field">
-    Default collection<br />
+    Default group<br />
     <input type="text" disabled value="<%= @user.default_group.title %>" />
   </div>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -34,7 +34,7 @@
 <% end %>
 
 <% if @user.super_admin? %>
-  <!-- not sure we want to display the collections here, it's pointless -->
+  <!-- not sure we want to display the groups here, it's pointless -->
 <% elsif @user.moderator? %>
   <p>Moderator for:
     <%= @user.admin_groups.map do |group|

--- a/app/views/works/_curator_controlled_form.html.erb
+++ b/app/views/works/_curator_controlled_form.html.erb
@@ -1,6 +1,6 @@
 <p>
   These metadata properties include defaults for any submissions published to the Research Data Repository.
-  These fields can only be changed by the collection moderators.
+  These fields can only be changed by the group moderators.
   Please reach out to the curator for assistance with any desired changes.
 </p>
 
@@ -8,20 +8,20 @@
 <!-- Publisher field -->
 <div class="field">
   Publisher:<span class="required-field">*</span><br>
-  <input type="text" id="publisher" name="publisher" class="input-text-long" value="<%= @work.resource.publisher %>" <%= is_collection_admin ? '' : 'readonly' %> />
+  <input type="text" id="publisher" name="publisher" class="input-text-long" value="<%= @work.resource.publisher %>" <%= is_group_admin ? '' : 'readonly' %> />
 </div>
 
 <!-- Publication year field -->
 <div class="field">
   Publication Year:<span class="required-field">*</span><br>
-  <input type="text" id="publication_year" name="publication_year" class="input-text-year" value="<%= @work.resource.publication_year %>" <%= is_collection_admin ? '' : 'readonly' %> />
+  <input type="text" id="publication_year" name="publication_year" class="input-text-year" value="<%= @work.resource.publication_year %>" <%= is_group_admin ? '' : 'readonly' %> />
 </div>
 
 <!-- DOI field (mostly for legacy DSpace works) -->
 <div class="field">
   <% if  @wizard_mode || @work.persisted? %>
     DOI: <br>
-    <input type="text" id="doi" name="doi" class="input-text-long" value="<%= @work.doi %>" <%= is_collection_admin ? '' : 'readonly' %> />
+    <input type="text" id="doi" name="doi" class="input-text-long" value="<%= @work.doi %>" <%= is_group_admin ? '' : 'readonly' %> />
   <% else %>
     DOI: <span class="text-muted field-hint">(enter the Digital Object Identifier, e.g. 10.80021/62qy-nj36)</span><br>
     <input type="text" id="doi" name="doi" class="input-text-long" value="<%= @work.doi %>"/>
@@ -31,20 +31,20 @@
 <!-- ARK field (mostly for legacy DSpace works) -->
 <div class="field">
   ARK: <span class="text-muted field-hint">(enter the core ARK identifier, e.g. ark:/88435/xyz123)</span><br>
-  <input type="text" id="ark" name="ark" class="input-text-long" value="<%= @work.resource.ark %>" <%= is_collection_admin ? '' : 'readonly' %> />
+  <input type="text" id="ark" name="ark" class="input-text-long" value="<%= @work.resource.ark %>" <%= is_group_admin ? '' : 'readonly' %> />
 </div>
 
 <!-- Resource Type -->
 <div class="field">
   Resource Type:<span class="required-field">*</span><span class="text-muted field-hint">(please see <%= link_to("the DataCite schema documentation", "https://schema.datacite.org/meta/kernel-4.4/", target: "_blank", rel: "nofollow") %>)</span><br>
-  <input type="text" id="resource_type" name="resource_type" class="input-text-long" value="<%= @work.resource_type %>" <%= is_collection_admin ? '' : 'readonly' %> />
+  <input type="text" id="resource_type" name="resource_type" class="input-text-long" value="<%= @work.resource_type %>" <%= is_group_admin ? '' : 'readonly' %> />
 </div>
 
 <!-- Resource Type General -->
 <div class="field">
   Resource Type General:<span class="required-field">*</span><span class="text-muted field-hint">(please see <%= link_to("the DataCite schema documentation", "https://schema.datacite.org/meta/kernel-4.4/", target: "_blank", rel: "nofollow") %> )</span><br>
   <input type="hidden" name="resource_type_general" value="<%= @work.resource_type_general %>"/> <!-- put the value in the form as disabled will not send the data back -->
-  <select id="resource_type_general" name="resource_type_general" <%= is_collection_admin ? '' : 'disabled' %> >
+  <select id="resource_type_general" name="resource_type_general" <%= is_group_admin ? '' : 'disabled' %> >
     <% Work.resource_type_general_values.each do |value| %>
       <option value="<%= value %>" <%= @work.resource_type_general == value ? "selected" : "" %>><%= value %></option>
     <% end %>
@@ -55,18 +55,18 @@
 <div class="field">
   Version: <span class="required-field">*</span><br>
   <input type="hidden" name="version_number" value="<%= @work.resource.version_number%>"/> <!-- put the value in the form as disabled will not send the data back -->
-  <select id="version_number" name="version_number" class="input-version" <%= is_collection_admin ? '' : 'disabled' %> >
+  <select id="version_number" name="version_number" class="input-version" <%= is_group_admin ? '' : 'disabled' %> >
     <% (1..10).each do |i| %>
       <option value="<%= i %>" <%= i.to_s == @work.resource.version_number ? "selected" : "" %>><%= i %></option>
     <% end %>
   </select>
 </div>
 
-<!-- Collection field -->
+<!-- Group field -->
 <div class="field">
   <%= t('works.form.group') %>: <span class="required-field">*</span><br>
   <input type="hidden" name="group_id" value="<%= @work.collection_id%>"/> <!-- put the value in the form as disabled will not send the data back -->
-  <select id="group_id" name="group_id" class="input-text-long"  <%= is_collection_admin ? '' : 'disabled' %> >
+  <select id="group_id" name="group_id" class="input-text-long"  <%= is_group_admin ? '' : 'disabled' %> >
     <% current_user.submitter_groups.each do |group| %>
       <option value="<%=group.id%>" <%= @work.collection_id == group.id ? "selected" : "" %>><%=group.title%></option>
     <% end %>
@@ -76,5 +76,5 @@
 <!-- Collection Tags field -->
 <div class="field">
   <%= t('works.form.collection_tags') %>: <span class="text-muted field-hint">(enter tags that identify the collect in a comma separated list, e.g. Humanities, Life Sciences)</span><br>
-  <input type="text" id="collection_tags" name="collection_tags" class="input-text-long" value="<%= @work.resource.collection_tags.join(', ') %>" <%= is_collection_admin ? '' : 'readonly' %> />
+  <input type="text" id="collection_tags" name="collection_tags" class="input-text-long" value="<%= @work.resource.collection_tags.join(', ') %>" <%= is_group_admin ? '' : 'readonly' %> />
 </div>

--- a/app/views/works/_form.html.erb
+++ b/app/views/works/_form.html.erb
@@ -32,7 +32,7 @@
 
         <!-- tab: curator controlled fields -->
         <div class="tab-pane fade" id="v-pills-curator-controlled" role="tabpanel" aria-labelledby="v-pills-curator-controlled-tab">
-          <%= render 'curator_controlled_form', is_collection_admin: current_user.has_role?(:group_admin, @work.group) %>
+          <%= render 'curator_controlled_form', is_group_admin: current_user.has_role?(:group_admin, @work.group) %>
         </div>
 
       </div>

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -118,7 +118,7 @@
         <% if @work_decorator.can_curate %>
           <select id="curator_select">
             <option value="no-one">(no one)</option>
-            <% @work_decorator.collection.administrators.each do |user| %>
+            <% @work_decorator.group.administrators.each do |user| %>
               <option value="<%= user.id %>" <%= @work.curator_user_id == user.id ? "selected" : "" %>><%= user.display_name_safe %></option>
             <% end %>
           </select>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,5 +6,5 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-# Create default collection records
+# Create default group records
 Group.create_defaults

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -2,7 +2,7 @@
 require "rails_helper"
 
 RSpec.describe Group, type: :model do
-  it "creates default collections only when needed" do
+  it "creates default groups only when needed" do
     described_class.delete_all
     expect(described_class.count).to be 0
 
@@ -28,97 +28,97 @@ RSpec.describe Group, type: :model do
   end
 
   describe ".default_for_department" do
-    subject(:collection) { described_class.default_for_department(department_number) }
+    subject(:group) { described_class.default_for_department(department_number) }
 
     context "when the department number is less than 31000" do
       let(:department_number) { "30000" }
-      it "provides the default collection" do
-        expect(collection).to be_a(described_class)
-        expect(collection.code).to eq("RD")
+      it "provides the default group" do
+        expect(group).to be_a(described_class)
+        expect(group.code).to eq("RD")
       end
     end
 
     context "when the department number is unexpected" do
       let(:department_number) { "foobar" }
-      it "provides the default collection" do
-        expect(collection).to be_a(described_class)
-        expect(collection.code).to eq("RD")
+      it "provides the default group" do
+        expect(group).to be_a(described_class)
+        expect(group.code).to eq("RD")
       end
     end
 
     context "when the department number is PPPL" do
       let(:department_number) { "31000" }
-      it "provides the default collection" do
-        expect(collection).to be_a(described_class)
-        expect(collection.code).to eq("PPPL")
+      it "provides the default group" do
+        expect(group).to be_a(described_class)
+        expect(group.code).to eq("PPPL")
       end
     end
   end
 
   describe "#disable_messages_for" do
     let(:user) { FactoryBot.create(:user) }
-    let(:collection) { described_class.create(title: "test") }
+    let(:group) { described_class.create(title: "test") }
 
     context "when the user is a super admin" do
       let(:user) { User.new_super_admin("test-admin") }
 
       it "disables email messages for notifications for a User" do
         # Initially messages are disabled for the user
-        state = collection.messages_enabled_for?(user: user)
+        state = group.messages_enabled_for?(user: user)
         expect(state).to be false
 
-        collection.enable_messages_for(user: user)
-        collection.save!
-        collection.reload
+        group.enable_messages_for(user: user)
+        group.save!
+        group.reload
 
         # After enabling messages for the user, that they are enabled is verified
-        enabled_state = collection.messages_enabled_for?(user: user)
+        enabled_state = group.messages_enabled_for?(user: user)
         expect(enabled_state).to be true
 
-        collection.disable_messages_for(user: user)
-        collection.save!
-        collection.reload
+        group.disable_messages_for(user: user)
+        group.save!
+        group.reload
 
         # After disabling messages for the user, that they are disabled is verified
-        disabled_state = collection.messages_enabled_for?(user: user)
+        disabled_state = group.messages_enabled_for?(user: user)
         expect(disabled_state).to be false
       end
     end
 
-    context "when the user is an administrator for a Collection" do
+    context "when the user is an administrator for a group" do
       before do
-        user.add_role(:group_admin, collection)
+        user.add_role(:group_admin, group)
         user.save!
       end
 
       it "disables email messages for notifications for a User" do
         # Initially messages are disabled for the user
-        state = collection.messages_enabled_for?(user: user)
+        state = group.messages_enabled_for?(user: user)
         expect(state).to be false
 
-        collection.enable_messages_for(user: user)
-        collection.save!
-        collection.reload
+        group.enable_messages_for(user: user)
+        group.save!
+        group.reload
 
         # After enabling messages for the user, that they are enabled is verified
-        enabled_state = collection.messages_enabled_for?(user: user)
+        enabled_state = group.messages_enabled_for?(user: user)
         expect(enabled_state).to be true
 
-        collection.disable_messages_for(user: user)
-        collection.save!
-        collection.reload
+        group.disable_messages_for(user: user)
+        group.save!
+        group.reload
 
         # After disabling messages for the user, that they are disabled is verified
-        disabled_state = collection.messages_enabled_for?(user: user)
+        disabled_state = group.messages_enabled_for?(user: user)
         expect(disabled_state).to be false
       end
     end
 
     it "raises an ArgumentError" do
-      state = collection.messages_enabled_for?(user: user)
+      state = group.messages_enabled_for?(user: user)
       expect(state).to be false
 
-      expect { collection.disable_messages_for(user: user) }.to raise_error(ArgumentError, "User #{user.uid} is not an administrator for this collection #{collection.title}")
+      expect { group.disable_messages_for(user: user) }.to raise_error(ArgumentError, "User #{user.uid} is not an administrator for this group #{group.title}")
     end
   end
 end

--- a/spec/system/user_edit_spec.rb
+++ b/spec/system/user_edit_spec.rb
@@ -48,14 +48,14 @@ RSpec.describe "Editing users", type: :system do
       visit edit_user_path(user)
       expect(page).to have_field("user_display_name", with: user.display_name)
       expect(page).to have_content "My Profile Settings"
-      expect(page).to have_unchecked_field "collection_messaging_#{pppl_group.id}"
-      expect(page).to have_checked_field "collection_messaging_#{rd_group.id}"
-      expect(page).not_to have_field "collection_messaging_#{random_group.id}"
-      check "collection_messaging_#{pppl_group.id}"
+      expect(page).to have_unchecked_field "group_messaging_#{pppl_group.id}"
+      expect(page).to have_checked_field "group_messaging_#{rd_group.id}"
+      expect(page).not_to have_field "group_messaging_#{random_group.id}"
+      check "group_messaging_#{pppl_group.id}"
       click_on "Update"
       visit edit_user_path(user)
-      expect(page).to have_checked_field "collection_messaging_#{pppl_group.id}"
-      expect(page).to have_checked_field "collection_messaging_#{rd_group.id}"
+      expect(page).to have_checked_field "group_messaging_#{pppl_group.id}"
+      expect(page).to have_checked_field "group_messaging_#{rd_group.id}"
     end
 
     context "User is super admin" do
@@ -65,15 +65,15 @@ RSpec.describe "Editing users", type: :system do
         visit edit_user_path(user)
         expect(page).to have_field("user_display_name", with: user.display_name)
         expect(page).to have_content "My Profile Settings"
-        expect(page).to have_unchecked_field "collection_messaging_#{pppl_group.id}"
-        expect(page).to have_checked_field "collection_messaging_#{rd_group.id}"
-        expect(page).to have_unchecked_field "collection_messaging_#{random_group.id}"
-        uncheck "collection_messaging_#{rd_group.id}"
+        expect(page).to have_unchecked_field "group_messaging_#{pppl_group.id}"
+        expect(page).to have_checked_field "group_messaging_#{rd_group.id}"
+        expect(page).to have_unchecked_field "group_messaging_#{random_group.id}"
+        uncheck "group_messaging_#{rd_group.id}"
         click_on "Update"
         visit edit_user_path(user)
-        expect(page).to have_unchecked_field "collection_messaging_#{pppl_group.id}"
-        expect(page).to have_unchecked_field "collection_messaging_#{rd_group.id}"
-        expect(page).to have_unchecked_field "collection_messaging_#{random_group.id}"
+        expect(page).to have_unchecked_field "group_messaging_#{pppl_group.id}"
+        expect(page).to have_unchecked_field "group_messaging_#{rd_group.id}"
+        expect(page).to have_unchecked_field "group_messaging_#{random_group.id}"
       end
     end
   end


### PR DESCRIPTION
Also moving some comments, ui references, and variables that were still named collection even though a group was being set

