### PR TITLE
Trigger the creation of the preservation once work has been approved

### DIFF
--- a/app/services/work_preservation_service.rb
+++ b/app/services/work_preservation_service.rb
@@ -5,21 +5,18 @@
 # with our AWS credentials, but allows the bucket and path to be configurable.
 class WorkPreservationService
 
-  # @param work [Work] The work to preserve.
+  # @param work [Integer] The ID of the work to preserve.
   # @param bucket_name [String] The AWS S3 bucket name where the work will be preserved.
-  # @param path [String] The path where the work will be preserved, e.g.
-  def initialize(work:, bucket_name: nil, path: nil)
-    @work = work
-    # Defaults to the post curation bucket, e.g. "pdc-describe-staging-postcuration"
-    @bucket_name = bucket_name || @work.s3_query_service.bucket_name
-    # Defaults to the DOI prefix + DOI + work.id, e.g. "10.1234/xy123/10/"
-    @path = path || @work.s3_query_service.prefix
+  # @param path [String] The path where the work will be preserved.
+  def initialize(work_id:, bucket_name:, path:)
+    @work = Work.find(work_id)
+    @bucket_name = bucket_name
+    @path = path
   end
 
   # Creates and stores the preservation files for the work.
   # @return [String] The AWS S3 path where the files were stored
   def preserve!
-    raise StandardError.new("Cannot preserve work #{@work.id} because it has not been approved") unless @work.approved?
     create_preservation_directory
     upload_file(io: metadata_io, filename: "metadata.json")
     upload_file(io: datacite_io, filename: "datacite.xml")
@@ -34,7 +31,8 @@ class WorkPreservationService
     end
 
     def metadata_io
-      StringIO.new(@work.to_json)
+      # Always use the post-curation file list
+      StringIO.new(@work.to_json(force_post_curation: true))
     end
 
     def datacite_io

--- a/app/services/work_preservation_service.rb
+++ b/app/services/work_preservation_service.rb
@@ -5,7 +5,7 @@
 # with our AWS credentials, but allows the bucket and path to be configurable.
 class WorkPreservationService
 
-  # @param work [Integer] The ID of the work to preserve.
+  # @param work_id [Integer] The ID of the work to preserve.
   # @param bucket_name [String] The AWS S3 bucket name where the work will be preserved.
   # @param path [String] The path where the work will be preserved.
   def initialize(work_id:, bucket_name:, path:)

--- a/lib/tasks/works.rake
+++ b/lib/tasks/works.rake
@@ -95,10 +95,12 @@ namespace :works do
     end
   end
 
-  desc "Preserves a single work"
+  desc "Creates the preservation objects for a given work and saves them in the indicated bucket and path"
   task :preserve, [:work_id, :bucket_name, :path] => :environment do |_, args|
-    work = Work.find(args[:work_id])
-    work_preservation = WorkPreservationService.new(work: work)
+    work_id = args[:work_id].to_i
+    bucket_name = args[:bucket_name] # e.g. "pdc-describe-staging-postcuration"
+    path = args[:path] # e.g. "10.34770/xy123/10"
+    work_preservation = WorkPreservationService.new(work_id: work_id, bucket_name: bucket_name, path: path)
     puts work_preservation.preserve!
   end
 end

--- a/spec/jobs/approved_file_copy_job_spec.rb
+++ b/spec/jobs/approved_file_copy_job_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe ApprovedFileMoveJob, type: :job do
     allow(fake_s3_service).to receive(:copy_file).and_return(fake_completion)
     allow(fake_s3_service).to receive(:delete_s3_object).and_return(fake_completion)
     allow(fake_s3_service).to receive(:check_file).and_return(true)
+    allow(fake_s3_service.client).to receive(:put_object).and_return(nil)
   end
 
   it "runs an aws copy and delete" do
@@ -24,6 +25,7 @@ RSpec.describe ApprovedFileMoveJob, type: :job do
                                                               target_bucket: "example-bucket-post", target_key: "10.34770/ackh-7y71/1/test_key")
     expect(fake_s3_service).to have_received(:delete_s3_object).with("10.34770/ackh-7y71/1/test_key", bucket: "example-bucket")
     expect(fake_s3_service).to have_received(:delete_s3_object).with(work.s3_object_key, bucket: "example-bucket")
+    expect(fake_s3_service.client).to have_received(:put_object).with({ bucket: "example-bucket-post", content_length: 0, key: "#{work.doi}/#{work.id}/princeton_data_commons/" })
   end
 
   context "the copy fails" do

--- a/spec/services/work_preservation_service_spec.rb
+++ b/spec/services/work_preservation_service_spec.rb
@@ -2,7 +2,7 @@
 require "rails_helper"
 
 RSpec.describe WorkPreservationService do
-  describe "preserves to default location" do
+  describe "#preserve!" do
     let(:approved_work) { FactoryBot.create :approved_work, doi: "10.34770/pe9w-x904" }
     let(:bucket_name) { approved_work.s3_query_service.bucket_name }
     let(:path) { approved_work.s3_query_service.prefix }

--- a/spec/services/work_preservation_service_spec.rb
+++ b/spec/services/work_preservation_service_spec.rb
@@ -2,44 +2,22 @@
 require "rails_helper"
 
 RSpec.describe WorkPreservationService do
-  let(:draft_work) { FactoryBot.create :draft_work, doi: "10.34770/pe9w-x904" }
-
-  it "raises an exception if the work has not been approved" do
-    subject = described_class.new(work: draft_work)
-    expect { subject.preserve! }.to raise_error(StandardError, /Cannot preserve work/)
-  end
-
   describe "preserves to default location" do
     let(:approved_work) { FactoryBot.create :approved_work, doi: "10.34770/pe9w-x904" }
-    let(:prefix) { approved_work.s3_query_service.prefix }
-    let(:preservation_directory) { prefix + "princeton_data_commons/" }
+    let(:bucket_name) { approved_work.s3_query_service.bucket_name }
+    let(:path) { approved_work.s3_query_service.prefix }
+    let(:preservation_directory) { path + "princeton_data_commons/" }
 
     before do
       stub_request(:put, "https://example-bucket-post.s3.amazonaws.com/#{preservation_directory}").to_return(status: 200)
-      stub_request(:get, "https://example-bucket-post.s3.amazonaws.com/?list-type=2&max-keys=1000&prefix=#{prefix}").to_return(status: 200)
+      stub_request(:get, "https://example-bucket-post.s3.amazonaws.com/?list-type=2&max-keys=1000&prefix=#{path}").to_return(status: 200)
       stub_request(:put, "https://example-bucket-post.s3.amazonaws.com/#{preservation_directory}metadata.json").to_return(status: 200)
       stub_request(:put, "https://example-bucket-post.s3.amazonaws.com/#{preservation_directory}datacite.xml").to_return(status: 200)
     end
 
-    it "preserves a work to the default location" do
-      subject = described_class.new(work: approved_work)
+    it "preserves a work to the indicated location" do
+      subject = described_class.new(work_id: approved_work.id, bucket_name: bucket_name, path: path)
       expect(subject.preserve!).to eq "s3://example-bucket-post/#{preservation_directory}"
-    end
-  end
-
-  describe "preserve to custom location" do
-    let(:approved_work) { FactoryBot.create :approved_work, doi: "10.34770/pe9w-x904" }
-
-    before do
-      stub_request(:put, "https://custom-bucket.s3.amazonaws.com/custom/path/princeton_data_commons/").to_return(status: 200)
-      stub_request(:get, "https://example-bucket-post.s3.amazonaws.com/?list-type=2&max-keys=1000&prefix=#{approved_work.s3_query_service.prefix}").to_return(status: 200)
-      stub_request(:put, "https://custom-bucket.s3.amazonaws.com/custom/path/princeton_data_commons/metadata.json").to_return(status: 200)
-      stub_request(:put, "https://custom-bucket.s3.amazonaws.com/custom/path/princeton_data_commons/datacite.xml").to_return(status: 200)
-    end
-
-    it "preserves a work a custom location" do
-      subject = described_class.new(work: approved_work, bucket_name: "custom-bucket", path: "custom/path/")
-      expect(subject.preserve!).to eq "s3://custom-bucket/custom/path/princeton_data_commons/"
     end
   end
 end

--- a/spec/support/s3_query_service_specs.rb
+++ b/spec/support/s3_query_service_specs.rb
@@ -4,6 +4,7 @@ def stub_s3(data: [], bucket_url: nil, prefix: "10.34770/123-abc/1")
   @s3_client = instance_double(Aws::S3::Client)
   allow(@s3_client).to receive(:head_object)
   allow(@s3_client).to receive(:delete_object)
+  allow(@s3_client).to receive(:put_object)
 
   fake_s3_query = instance_double(S3QueryService, data_profile: { objects: data, ok: true }, client: @s3_client,
                                                   client_s3_files: data, prefix: prefix)
@@ -22,6 +23,7 @@ def mock_methods(fake_s3_query, data)
   allow(fake_s3_query).to receive(:create_directory)
   allow(fake_s3_query).to receive(:publish_files).and_return([])
   allow(fake_s3_query).to receive(:upload_file).and_return(true)
+  allow(fake_s3_query).to receive(:md5).and_return(nil)
 end
 
 def mock_bucket(bucket_url)


### PR DESCRIPTION
Automatically triggers the creation of the preservation metadata once the last file of the work has been moved to the post-curation bucket.

Triggering the code at the right time was trickier than I expected because the work is not marked as "approved" until *after all the actions in the state machine have completed*. The code to create the preservation files is inside the transition, it's the last step, which makes sense, but the state not being completely saved threw me off for a while. 

I had to add a method to the work to force it to fetch post curation files (regardless of the state of the work in the database) because we want to include the file list as part of the preservation metadata and the files at this stage have all been moved to the post-curation bucket.

Closes #512 