### PR TITLE
Remove duplicate uploads for the same file in dspace and AWS

### DIFF
--- a/app/jobs/dspace_file_copy_job.rb
+++ b/app/jobs/dspace_file_copy_job.rb
@@ -2,9 +2,12 @@
 class DspaceFileCopyJob < ApplicationJob
   queue_as :default
 
-  def perform(dspace_doi, s3_key, s3_size, work_id, migration_snapshot_id)
+  def perform(s3_file_json:, work_id:, migration_snapshot_id:)
+    s3_file = JSON.parse(s3_file_json)
     work = Work.find(work_id)
-    new_key = s3_key.gsub("#{dspace_doi}/".tr(".", "-"), work.s3_query_service.prefix)
+    new_key = s3_file["filename_display"]
+    s3_key = s3_file["filename"]
+    s3_size = s3_file["size"]
     resp = work.s3_query_service.copy_file(source_key: "#{dspace_bucket_name}/#{s3_key}",
                                            target_bucket: work.s3_query_service.bucket_name,
                                            target_key: new_key, size: s3_size)

--- a/app/models/migration_upload_snapshot.rb
+++ b/app/models/migration_upload_snapshot.rb
@@ -6,7 +6,7 @@ class MigrationUploadSnapshot < UploadSnapshot
   end
 
   def store_files(s3_files, pre_existing_files: [])
-    self.files = s3_files.map { |file| { "filename" => file.filename, "checksum" => file.checksum, "migrate_status" => "started" } }
+    self.files = s3_files.map { |file| { "filename" => file.filename_display, "checksum" => file.checksum, "migrate_status" => "started" } }
     files.concat pre_existing_files if pre_existing_files.present?
   end
 

--- a/app/services/pul_dspace_aws_connector.rb
+++ b/app/services/pul_dspace_aws_connector.rb
@@ -12,10 +12,10 @@ class PULDspaceAwsConnector
     dspace_files.map do |dspace_file|
       filename = dspace_file.filename
       match_dspace_file = dspace_file.clone
-      basename = File.basename(filename)
-      match_dspace_file.filename = work.s3_query_service.prefix + basename
+      basename = File.basename(dspace_file.filename_display)
+      match_dspace_file.filename = dspace_file.filename_display
       io = File.open(filename)
-      key = work.s3_query_service.upload_file(io: io, filename: basename)
+      key = work.s3_query_service.upload_file(io: io, filename: basename, md5_digest: dspace_file.checksum)
       if key
         { key: key, file: match_dspace_file, error: nil }
       else

--- a/app/services/pul_dspace_migrate.rb
+++ b/app/services/pul_dspace_migrate.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class PULDspaceMigrate
-  attr_reader :work, :ark, :file_keys, :directory_keys, :dpsace_connector, :aws_connector, :migration_snapshot
+  attr_reader :work, :ark, :file_keys, :directory_keys, :dpsace_connector,
+              :aws_connector, :migration_snapshot, :dspace_files, :aws_files_and_directories
 
   delegate :doi, to: :dpsace_connector
 
@@ -12,17 +13,19 @@ class PULDspaceMigrate
     @dpsace_connector = PULDspaceConnector.new(work)
     @aws_connector = PULDspaceAwsConnector.new(work, doi)
     @migration_snapshot = nil
+    @aws_files_and_directories = nil
+    @dspace_files = nil
   end
 
   def migrate
     return if ark.nil?
     work.resource.migrated = true
     work.save
-    aws_files = aws_connector.aws_files
-    dspace_files = dpsace_connector.download_bitstreams
-    generate_migration_snapshot(dspace_files, aws_files)
+    @aws_files_and_directories = aws_connector.aws_files
+    @dspace_files = dpsace_connector.download_bitstreams
+    generate_migration_snapshot
     migrate_dspace(dspace_files)
-    aws_copy(aws_files)
+    aws_copy(aws_files_and_directories)
   end
 
   def migration_message
@@ -31,8 +34,8 @@ class PULDspaceMigrate
 
   private
 
-    def generate_migration_snapshot(dspace_files, aws_files)
-      files = new_dspace_files(dspace_files) + new_aws_files(aws_files)
+    def generate_migration_snapshot
+      files = remove_overlap_and_combine
       snapshot = MigrationUploadSnapshot.new(work: work, url: work.s3_query_service.prefix)
       last_snapshot = work.upload_snapshots.first
       snapshot.store_files(files, pre_existing_files: last_snapshot&.files)
@@ -40,19 +43,41 @@ class PULDspaceMigrate
       @migration_snapshot = snapshot
     end
 
-    def new_dspace_files(dspace_files)
-      dspace_files.map do |s3_file|
-        new_s3 = s3_file.clone
-        new_s3.filename = work.s3_query_service.prefix + File.basename(s3_file.filename)
-        new_s3
+    def remove_overlap_and_combine
+      dpsace_update_display_to_final_key(dspace_files)
+      aws_files_only = aws_files_and_directories.reject(&:directory?)
+      aws_update_display_to_final_key(aws_files_only)
+      aws_file_names = aws_files_only.map(&:filename_display)
+      files_to_remove = []
+      dspace_files.each do |s3_file|
+        idx = aws_file_names.index(s3_file.filename_display)
+        if idx.present?
+          check_matching_files(aws_files_only[idx], s3_file, files_to_remove)
+        end
+      end
+      @dspace_files = dspace_files - files_to_remove
+      dspace_files + aws_files_only
+    end
+
+    def dpsace_update_display_to_final_key(dspace_files)
+      dspace_files.each do |s3_file|
+        s3_file.filename_display = work.s3_query_service.prefix + File.basename(s3_file.filename)
       end
     end
 
-    def new_aws_files(aws_files)
-      aws_files.reject(&:directory?).map do |s3_file|
-        new_s3 = s3_file.clone
-        new_s3.filename = s3_file.filename.gsub("#{doi}/".tr(".", "-"), work.s3_query_service.prefix)
-        new_s3
+    def aws_update_display_to_final_key(aws_files)
+      aws_files.each do |s3_file|
+        s3_file.filename_display = s3_file.filename.gsub("#{doi}/".tr(".", "-"), work.s3_query_service.prefix)
+      end
+    end
+
+    def check_matching_files(aws_file, dpace_file, files_to_remove)
+      if dpace_file.checksum == aws_file.checksum
+        files_to_remove << dpace_file
+      else
+        basename = File.basename(dpace_file.filename_display)
+        dpace_file.filename_display.gsub!(basename, "data_space_#{basename}")
+        aws_file.filename_display.gsub!(basename, "globus_#{basename}")
       end
     end
 
@@ -85,11 +110,11 @@ class PULDspaceMigrate
 
     def aws_copy(files)
       files.each do |s3_file|
-        DspaceFileCopyJob.perform_later(doi, s3_file.key, s3_file.size, work.id, @migration_snapshot&.id)
+        DspaceFileCopyJob.perform_later(s3_file_json: s3_file.to_json, work_id: work.id, migration_snapshot_id: @migration_snapshot&.id)
         if s3_file.directory?
           directory_keys << s3_file.key
         else
-          file_keys << s3_file.key
+          file_keys << s3_file.filename_display
         end
       end
     end

--- a/spec/jobs/dspace_file_copy_job_spec.rb
+++ b/spec/jobs/dspace_file_copy_job_spec.rb
@@ -4,10 +4,11 @@ require "rails_helper"
 RSpec.describe DspaceFileCopyJob, type: :job do
   include ActiveJob::TestHelper
 
-  subject(:job) { described_class.perform_later("10.34770/ackh-7y71", "10-34770/ackh-7y71/test_key", 10_759, 1, migration_snapshot.id) }
+  let(:s3_file) { FactoryBot.build :s3_file, filename: "10-34770/ackh-7y71/test_key", size: 10_759, filename_display: "abc/123/#{work.id}/test_key" }
+  subject(:job) { described_class.perform_later(s3_file_json: s3_file.to_json, work_id: work.id, migration_snapshot_id: migration_snapshot.id) }
   let(:work) { FactoryBot.create :draft_work }
   let(:fake_s3_service) { instance_double(S3QueryService, bucket_name: "work-bucket", prefix: "abc/123/#{work.id}/") }
-  let(:migration_snapshot) { MigrationUploadSnapshot.create(files: [FactoryBot.build(:s3_file, filename: "10-34770/ackh-7y71/test_key")], work: work, url: "example.com") }
+  let(:migration_snapshot) { MigrationUploadSnapshot.create(files: [s3_file], work: work, url: "example.com") }
 
   before do
     allow(Work).to receive(:find).and_return(work)
@@ -24,8 +25,7 @@ RSpec.describe DspaceFileCopyJob, type: :job do
   end
 
   context "when the files is a directory" do
-    subject(:job) { described_class.perform_later("10.34770/ackh-7y71", "10-34770/ackh-7y71/dir/", 0, 1, migration_snapshot.id) }
-    let(:migration_snapshot) { MigrationUploadSnapshot.create(files: [FactoryBot.build(:s3_file, filename: "10-34770/ackh-7y71/dir/")], work: work, url: "example.com") }
+    let(:s3_file) { FactoryBot.build :s3_file, filename: "10-34770/ackh-7y71/dir/", size: 0, filename_display: "abc/123/#{work.id}/dir/" }
 
     it "copies directory" do
       perform_enqueued_jobs { job }
@@ -36,7 +36,8 @@ RSpec.describe DspaceFileCopyJob, type: :job do
   end
 
   context "when the file is not part of the migration" do
-    subject(:job) { described_class.perform_later("10.34770/ackh-7y71", "10-34770/ackh-7y71/abc", 1, 1, migration_snapshot.id) }
+    let(:s3_file2) { FactoryBot.build :s3_file, filename: "10-34770/ackh-7y71/abc", size: 1, filename_display: "abc/123/#{work.id}/abc" }
+    subject(:job) { described_class.perform_later(s3_file_json: s3_file2.to_json, work_id: work.id, migration_snapshot_id: migration_snapshot.id) }
 
     it "Sends the error to HoneyBadger" do
       allow(Honeybadger).to receive(:notify)

--- a/spec/services/pul_dspace_migrate_spec.rb
+++ b/spec/services/pul_dspace_migrate_spec.rb
@@ -41,53 +41,103 @@ RSpec.describe PULDspaceMigrate, type: :model do
 
     describe "#migrate" do
       let(:s3_file) { FactoryBot.build :s3_file, filename: "10-34770/ackh-7y71/test_key" }
+      let(:s3_file2) { FactoryBot.build :s3_file, filename: "10-34770/ackh-7y71/SCoData_combined_v1_2020-07_README.txt" }
       let(:s3_directory) { FactoryBot.build :s3_file, filename: "10-34770/ackh-7y71/test_directory_key", size: 0 }
-      let(:fake_s3_service) { stub_s3(data: [s3_file, s3_directory], prefix: "bucket/123/abc/") }
+      let(:fake_s3_service) { stub_s3(data: [s3_file, s3_file2, s3_directory], prefix: "abc/123/") }
+      let(:fake_completion) { instance_double(Seahorse::Client::Response, "successful?": true) }
 
       before do
-        allow(fake_s3_service).to receive(:upload_file).with(hash_including(filename: /SCoData_combined_v1_2020-07_README/))
-                                                       .and_return("abc/123/SCoData_combined_v1_2020-07_README.txt")
+        allow(fake_s3_service).to receive(:upload_file).with(hash_including(filename: /data_space_SCoData_combined_v1_2020-07_README/))
+                                                       .and_return("abc/123/data_space_SCoData_combined_v1_2020-07_README.txt")
+        allow(fake_s3_service).to receive(:upload_file).with(hash_including(filename: /globus_SCoData_combined_v1_2020-07_README/))
+                                                       .and_return("abc/123/globus_SCoData_combined_v1_2020-07_README.txt")
         allow(fake_s3_service).to receive(:upload_file).with(hash_including(filename: /SCoData_combined_v1_2020-07_datapackage/))
                                                        .and_return("abc/123/SCoData_combined_v1_2020-07_datapackage.json")
         allow(fake_s3_service).to receive(:upload_file).with(hash_including(filename: /license/))
                                                        .and_return("abc/123/license.txt")
-        fake_completion = instance_double(Seahorse::Client::Response, "successful?": true)
         allow(fake_s3_service).to receive(:copy_file).with(hash_including(target_key: /test_key/))
                                                      .and_return(fake_completion)
         allow(fake_s3_service).to receive(:copy_file).with(hash_including(target_key: /test_directory_key/))
                                                      .and_return(fake_completion)
+        allow(fake_s3_service).to receive(:copy_file).with(hash_including(target_key: /globus_SCoData_combined_v1_2020-07_README.txt/))
+                                                     .and_return(fake_completion)
       end
       it "migrates the content from dspace and aws" do
         expect(UploadSnapshot.all.count).to eq(0)
-        FactoryBot.create(:upload_snapshot, work: work, files: [{ "checksum" => "abc123", "filename" => "bucket/123/abc/test_exist_key" }])
+        FactoryBot.create(:upload_snapshot, work: work, files: [{ "checksum" => "abc123", "filename" => "abc/123/test_exist_key" }])
         dspace_data.migrate
-        expect(dspace_data.file_keys).to eq(["abc/123/SCoData_combined_v1_2020-07_README.txt",
+        expect(dspace_data.file_keys).to eq(["abc/123/data_space_SCoData_combined_v1_2020-07_README.txt",
                                              "abc/123/SCoData_combined_v1_2020-07_datapackage.json",
                                              "abc/123/license.txt",
-                                             "10-34770/ackh-7y71/test_key"])
+                                             "abc/123/test_key",
+                                             "abc/123/globus_SCoData_combined_v1_2020-07_README.txt"])
         expect(dspace_data.directory_keys).to eq(["10-34770/ackh-7y71/test_directory_key"])
-        expect(dspace_data.migration_message).to eq("Migration for 4 files and 1 directory")
+        expect(dspace_data.migration_message).to eq("Migration for 5 files and 1 directory")
 
         expect(work.reload.resource.migrated).to be_truthy
-        expect(enqueued_jobs.size).to eq(2)
-        expect(MigrationUploadSnapshot.last.files).to eq([{ "checksum" => "008eec11c39e7038409739c0160a793a", "filename" => "bucket/123/abc/SCoData_combined_v1_2020-07_README.txt",
+        expect(enqueued_jobs.size).to eq(3)
+        expect(MigrationUploadSnapshot.last.files).to eq([{ "checksum" => "008eec11c39e7038409739c0160a793a", "filename" => "abc/123/data_space_SCoData_combined_v1_2020-07_README.txt",
                                                             "migrate_status" => "complete" },
-                                                          { "checksum" => "7bd3d4339c034ebc663b990657714688", "filename" => "bucket/123/abc/SCoData_combined_v1_2020-07_datapackage.json",
+                                                          { "checksum" => "7bd3d4339c034ebc663b990657714688", "filename" => "abc/123/SCoData_combined_v1_2020-07_datapackage.json",
                                                             "migrate_status" => "complete" },
-                                                          { "checksum" => "1e204dad3e9e1e2e6660eef9c33467e9", "filename" => "bucket/123/abc/license.txt", "migrate_status" => "complete" },
-                                                          { "checksum" => "abc123", "filename" => "bucket/123/abc/test_key", "migrate_status" => "started" },
-                                                          { "checksum" => "abc123", "filename" => "bucket/123/abc/test_exist_key" }])
+                                                          { "checksum" => "1e204dad3e9e1e2e6660eef9c33467e9", "filename" => "abc/123/license.txt", "migrate_status" => "complete" },
+                                                          { "checksum" => "abc123", "filename" => "abc/123/test_key", "migrate_status" => "started" },
+                                                          { "checksum" => "abc123", "filename" => "abc/123/globus_SCoData_combined_v1_2020-07_README.txt", "migrate_status" => "started" },
+                                                          { "checksum" => "abc123", "filename" => "abc/123/test_exist_key" }])
         perform_enqueued_jobs
         expect(enqueued_jobs.size).to eq(0)
         expect(UploadSnapshot.all.count).to eq(2)
-        expect(MigrationUploadSnapshot.last.files).to eq([{ "checksum" => "008eec11c39e7038409739c0160a793a", "filename" => "bucket/123/abc/SCoData_combined_v1_2020-07_README.txt",
+        expect(MigrationUploadSnapshot.last.files).to eq([{ "checksum" => "008eec11c39e7038409739c0160a793a", "filename" => "abc/123/data_space_SCoData_combined_v1_2020-07_README.txt",
                                                             "migrate_status" => "complete" },
-                                                          { "checksum" => "7bd3d4339c034ebc663b990657714688", "filename" => "bucket/123/abc/SCoData_combined_v1_2020-07_datapackage.json",
+                                                          { "checksum" => "7bd3d4339c034ebc663b990657714688", "filename" => "abc/123/SCoData_combined_v1_2020-07_datapackage.json",
                                                             "migrate_status" => "complete" },
-                                                          { "checksum" => "1e204dad3e9e1e2e6660eef9c33467e9", "filename" => "bucket/123/abc/license.txt", "migrate_status" => "complete" },
-                                                          { "checksum" => "abc123", "filename" => "bucket/123/abc/test_key", "migrate_status" => "complete" },
-                                                          { "checksum" => "abc123", "filename" => "bucket/123/abc/test_exist_key" }])
+                                                          { "checksum" => "1e204dad3e9e1e2e6660eef9c33467e9", "filename" => "abc/123/license.txt", "migrate_status" => "complete" },
+                                                          { "checksum" => "abc123", "filename" => "abc/123/test_key", "migrate_status" => "complete" },
+                                                          { "checksum" => "abc123", "filename" => "abc/123/globus_SCoData_combined_v1_2020-07_README.txt", "migrate_status" => "complete" },
+                                                          { "checksum" => "abc123", "filename" => "abc/123/test_exist_key" }])
         expect(MigrationUploadSnapshot.last.migration_complete?).to be_truthy
+      end
+
+      context "the checksums are the same" do
+        let(:s3_file2) { FactoryBot.build :s3_file, filename: "10-34770/ackh-7y71/SCoData_combined_v1_2020-07_README.txt", checksum: "008eec11c39e7038409739c0160a793a" }
+
+        before do
+          allow(fake_s3_service).to receive(:copy_file).with(hash_including(target_key: /SCoData_combined_v1_2020-07_README.txt/))
+                                                       .and_return(fake_completion)
+        end
+
+        it "migrates the content from dspace and aws skipping the same file" do
+          expect(UploadSnapshot.all.count).to eq(0)
+          FactoryBot.create(:upload_snapshot, work: work, files: [{ "checksum" => "abc123", "filename" => "abc/123/test_exist_key" }])
+          dspace_data.migrate
+          expect(dspace_data.file_keys).to eq(["abc/123/SCoData_combined_v1_2020-07_datapackage.json",
+                                               "abc/123/license.txt",
+                                               "abc/123/test_key",
+                                               "abc/123/SCoData_combined_v1_2020-07_README.txt"])
+          expect(dspace_data.directory_keys).to eq(["10-34770/ackh-7y71/test_directory_key"])
+          expect(dspace_data.migration_message).to eq("Migration for 4 files and 1 directory")
+
+          expect(work.reload.resource.migrated).to be_truthy
+          expect(enqueued_jobs.size).to eq(3)
+          expect(MigrationUploadSnapshot.last.files).to eq([{ "checksum" => "7bd3d4339c034ebc663b990657714688", "filename" => "abc/123/SCoData_combined_v1_2020-07_datapackage.json",
+                                                              "migrate_status" => "complete" },
+                                                            { "checksum" => "1e204dad3e9e1e2e6660eef9c33467e9", "filename" => "abc/123/license.txt", "migrate_status" => "complete" },
+                                                            { "checksum" => "abc123", "filename" => "abc/123/test_key", "migrate_status" => "started" },
+                                                            { "checksum" => "008eec11c39e7038409739c0160a793a", "filename" => "abc/123/SCoData_combined_v1_2020-07_README.txt",
+                                                              "migrate_status" => "started" },
+                                                            { "checksum" => "abc123", "filename" => "abc/123/test_exist_key" }])
+          perform_enqueued_jobs
+          expect(enqueued_jobs.size).to eq(0)
+          expect(UploadSnapshot.all.count).to eq(2)
+          expect(MigrationUploadSnapshot.last.files).to eq([{ "checksum" => "7bd3d4339c034ebc663b990657714688", "filename" => "abc/123/SCoData_combined_v1_2020-07_datapackage.json",
+                                                              "migrate_status" => "complete" },
+                                                            { "checksum" => "1e204dad3e9e1e2e6660eef9c33467e9", "filename" => "abc/123/license.txt", "migrate_status" => "complete" },
+                                                            { "checksum" => "abc123", "filename" => "abc/123/test_key", "migrate_status" => "complete" },
+                                                            { "checksum" => "008eec11c39e7038409739c0160a793a", "filename" => "abc/123/SCoData_combined_v1_2020-07_README.txt",
+                                                              "migrate_status" => "complete" },
+                                                            { "checksum" => "abc123", "filename" => "abc/123/test_exist_key" }])
+          expect(MigrationUploadSnapshot.last.migration_complete?).to be_truthy
+        end
       end
     end
   end


### PR DESCRIPTION
If the checksum matches only one file will be uploaded 
If the checksums are different the files will be renamed to show where the duplicates came from and both will be uploaded

Also changed the code that was cloning the s3_files to just put the new AWS filename in the filename_display instead of creating a second copy.  This allowed us to more easily rename the file if needed and should be faster.

fixes #1118