### PR TITLE
Call draft to trigger state change actions

### DIFF
--- a/lib/tasks/works.rake
+++ b/lib/tasks/works.rake
@@ -77,8 +77,7 @@ namespace :works do
       work = Work.new(resource: resource)
       work.group = Group.where(code: hash["group"]["code"]).first
       work.created_by_user_id = approver.id
-      work.state = "draft"
-      work.save
+      work.draft!(approver)
       puts "\t#{file_name}"
     end
   end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Work, type: :model do
   end
 
   it "drafts a doi only once" do
-    work = Work.new(group: group, resource: FactoryBot.build(:resource))
+    work = Work.new(group: group, resource: FactoryBot.build(:resource, doi: ""))
     work.draft_doi
     work.draft_doi # Doing this multiple times on purpose to make sure the api is only called once
     expect(a_request(:post, "https://#{Rails.configuration.datacite.host}/dois")).to have_been_made.once

--- a/spec/system/data_migration/cklibrary_form_submission_spec.rb
+++ b/spec/system/data_migration/cklibrary_form_submission_spec.rb
@@ -59,8 +59,6 @@ RSpec.describe "Form submission for migrating cklibrary", type: :system, mock_ez
       datacite = PDCSerialization::Datacite.new_from_work(cklibrary_work)
       expect(datacite.valid?).to eq true
       expect(datacite.to_xml).to be_equivalent_to(File.read("spec/system/data_migration/cklibrary.xml"))
-      # Ensure the DOI is blank so a new one will be minted when this is imported
-      cklibrary_work.resource.doi = nil
       export_spec_data("cklibrary.json", cklibrary_work.to_json)
     end
   end

--- a/spec/system/data_migration/sowingseeds_form_submission_spec.rb
+++ b/spec/system/data_migration/sowingseeds_form_submission_spec.rb
@@ -76,8 +76,6 @@ Download the README.txt for a detailed description of this dataset's content."
       datacite = PDCSerialization::Datacite.new_from_work(sowingseeds_work)
       expect(datacite.valid?).to eq true
       expect(datacite.to_xml).to be_equivalent_to(File.read("spec/system/data_migration/sowingseeds.xml"))
-      # Ensure the DOI is blank so a new one will be minted when this is imported
-      sowingseeds_work.resource.doi = nil
       export_spec_data("sowingseeds.json", sowingseeds_work.to_json)
     end
   end


### PR DESCRIPTION
When setting the state to a specific value you do not trigger any of the state transitions.  This is why the doi was not getting set for certain records Also remove the nil setting as it was not needed

refs #1153