### PR TITLE
Updating display name in the user to be given name

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -72,7 +72,7 @@ class UsersController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def user_params
-      @user_params ||= params.require(:user).permit([:display_name, :full_name, :family_name, :orcid, :email_messages_enabled, groups_with_messaging: {}])
+      @user_params ||= params.require(:user).permit([:given_name, :full_name, :family_name, :orcid, :email_messages_enabled, groups_with_messaging: {}])
     end
 
     def can_edit?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,7 +43,7 @@ class User < ApplicationRecord
     user.provider = access_token.provider
     user.uid = access_token.uid # this is the netid
     user.email = access_token.extra.mail
-    user.display_name = access_token.extra.givenname || access_token.uid # Harriet
+    user.given_name = access_token.extra.givenname || access_token.uid # Harriet
     user.family_name = access_token.extra.sn || access_token.uid # Tubman
     user.full_name = access_token.extra.displayname || access_token.uid # "Harriet Tubman"
     user.default_group_id = Group.default_for_department(access_token.extra.departmentnumber)&.id
@@ -57,7 +57,7 @@ class User < ApplicationRecord
   def update_with_cas(access_token)
     self.provider = access_token.provider
     self.email = access_token.extra.mail
-    self.display_name = access_token.extra.givenname || access_token.uid # Harriet
+    self.given_name = access_token.extra.givenname || access_token.uid # Harriet
     self.family_name = access_token.extra.sn || access_token.uid # Tubman
     self.full_name = access_token.extra.displayname || access_token.uid # "Harriet Tubman"
     self.default_group_id = Group.default_for_department(access_token.extra.departmentnumber)&.id
@@ -86,7 +86,7 @@ class User < ApplicationRecord
     email = "#{csv_params['Net ID']}@princeton.edu"
     uid = csv_params["Net ID"]
     full_name = "#{csv_params['First Name']} #{csv_params['Last Name']}"
-    display_name = csv_params["First Name"]
+    given_name = csv_params["First Name"]
     orcid = csv_params["ORCID ID"]
     user = User.where(email: email).first_or_create
     params_hash = {
@@ -94,7 +94,7 @@ class User < ApplicationRecord
       uid: uid,
       orcid: orcid,
       full_name: (full_name if user.full_name.blank?),
-      display_name: (display_name if user.display_name.blank?)
+      given_name: (given_name if user.given_name.blank?)
     }.compact
 
     user.update(params_hash)
@@ -162,8 +162,8 @@ class User < ApplicationRecord
   # Returns a display name that always has a value
   # This is needed because we have records in the Users table that are created automatically
   # in which the only value we have for sure its their uid (aka NetID).
-  def display_name_safe
-    display_name.presence || uid
+  def given_name_safe
+    given_name.presence || uid
   end
 
   def moderator?

--- a/app/models/work_activity.rb
+++ b/app/models/work_activity.rb
@@ -111,7 +111,7 @@ class WorkActivity < ApplicationRecord
     def created_by_user_html
       return UNKNOWN_USER unless @work_activity.created_by_user
 
-      @work_activity.created_by_user.display_name_safe
+      @work_activity.created_by_user.given_name_safe
     end
 
     def created_updated_html
@@ -203,7 +203,7 @@ class WorkActivity < ApplicationRecord
         if uid
           user = User.find_by(uid: uid)
           user_info = if user
-                        user.display_name_safe
+                        user.given_name_safe
                       else
                         uid
                       end
@@ -228,7 +228,7 @@ class WorkActivity < ApplicationRecord
       return UNKNOWN_USER unless @work_activity.created_by_user
 
       user = @work_activity.created_by_user
-      "#{user.display_name_safe} (@#{user.uid})"
+      "#{user.given_name_safe} (@#{user.uid})"
     end
 
     def title_html

--- a/app/views/groups/_dataset_table.html.erb
+++ b/app/views/groups/_dataset_table.html.erb
@@ -22,7 +22,7 @@
           </td>
           <td><%= ds.created_by_user.uid %></td>
           <td>
-              <span title="<%= ds.curator&.display_name %>"><%= ds.curator&.uid %></span>
+              <span title="<%= ds.curator&.given_name %>"><%= ds.curator&.uid %></span>
           </td>
           <td><%= ds.state %></td>
           <!-- see https://datatables.net/manual/data/orthogonal-data for sorting options -->

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -18,7 +18,7 @@
 
 <p>
   Users that are allowed to approve submissions to this group:
-  <%= @group.administrators.map { |user| link_to(user.display_name_safe, user_path(user.uid)) }.to_sentence.html_safe %>
+  <%= @group.administrators.map { |user| link_to(user.given_name_safe, user_path(user.uid)) }.to_sentence.html_safe %>
 </p>
 
 <% if @can_edit %>

--- a/app/views/notification_mailer/build_message.html.erb
+++ b/app/views/notification_mailer/build_message.html.erb
@@ -6,7 +6,7 @@
     <h1>PDC Describe</h1>
     <section>
       <p>
-        <span>Hello <%= @user.display_name %>,</span>
+        <span>Hello <%= @user.given_name %>,</span>
         <span>This message is to notify you of a new notification for your account with PDC Describe:</span>
         <span><%= @message_html %></span>
       </p>

--- a/app/views/notification_mailer/build_message.text.erb
+++ b/app/views/notification_mailer/build_message.text.erb
@@ -1,4 +1,4 @@
-Hello <%= @user.display_name %>,
+Hello <%= @user.given_name %>,
 
 This message is to notify you of a new notification for your account with PDC Describe:
 <%= @message %>

--- a/app/views/users/_dataset_table.html.erb
+++ b/app/views/users/_dataset_table.html.erb
@@ -22,7 +22,7 @@
           </td>
           <td><%= ds.created_by_user.uid %></td>
           <td>
-              <span title="<%= ds.curator&.display_name %>"><%= ds.curator&.uid %></span>
+              <span title="<%= ds.curator&.given_name %>"><%= ds.curator&.uid %></span>
           </td>
           <td><%= ds.state %></td>
           <!-- see https://datatables.net/manual/data/orthogonal-data for sorting options -->

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -41,13 +41,13 @@
   <% end %>
 
   <div class="field">
-  Display name
+  Given name (First name)
   <br />
-  <%= form.text_field :display_name %>
+  <%= form.text_field :given_name %>
   </div>
 
   <div class="field">
-    Family name
+    Family name (Last name)
     <br />
     <%= form.text_field :family_name %>
   </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,7 +1,7 @@
 <h1>Users</h1>
 
 <% @users.each do |user| %>
-  <p><%= link_to(user.display_name_safe, user_path(user)) %></p>
+  <p><%= link_to(user.given_name_safe, user_path(user)) %></p>
 <% end %>
 
 <div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -8,7 +8,7 @@
 </div>
 
 <h2>
-  <%= @my_dashboard ? "Welcome " : "" %><%= @user.display_name_safe %>
+  <%= @my_dashboard ? "Welcome " : "" %><%= @user.given_name_safe %>
   <% if @user.super_admin? %>
     <span class="badge rounded-pill bg-primary text-bg-secondary">Administrator</span>
   <% elsif @user.moderator? %>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,6 +1,6 @@
 <% if current_user %>
   <div class="content">
-    <h2>Welcome, <%= current_user.display_name %></h2>
+    <h2>Welcome, <%= current_user.given_name %></h2>
     <%= link_to "My Dashboard", user_path(current_user), class: "btn btn-primary" %>
   </div>
 <% else %>

--- a/app/views/works/_form_hidden_fields.html.erb
+++ b/app/views/works/_form_hidden_fields.html.erb
@@ -20,6 +20,6 @@
   <% end %>
 
   <input type="text" id="user_orcid" name="user_orcid" value="<%= current_user.orcid %>" class="hidden" />
-  <input type="text" id="user_given_name" name="user_given_name" value="<%= current_user.display_name %>" class="hidden" />
+  <input type="text" id="user_given_name" name="user_given_name" value="<%= current_user.given_name %>" class="hidden" />
   <input type="text" id="user_family_name" name="user_family_name" value="<%= current_user.family_name %>" class="hidden" />
 </div>

--- a/app/views/works/_orcid_link.html.erb
+++ b/app/views/works/_orcid_link.html.erb
@@ -1,4 +1,4 @@
-<% display_name = capture do %>
+<% given_name = capture do %>
   <%= person.value %>
   <% if person.type.present? %>
     (<%= person.type.titleize %>)
@@ -8,8 +8,8 @@
 <span class="author-name">
   <% if person.orcid.present? %>
     <img alt="ORCID logo" src="https://info.orcid.org/wp-content/uploads/2019/11/orcid_16x16.png" width="16" height="16" />
-    <a href="https://orcid.org/<%= person.orcid %>" target="_blank"><%= display_name %></a>
+    <a href="https://orcid.org/<%= person.orcid %>" target="_blank"><%= given_name %></a>
   <% else %>
-    <%= display_name -%>
+    <%= given_name -%>
   <% end %>
 </span>

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -119,14 +119,14 @@
           <select id="curator_select">
             <option value="no-one">(no one)</option>
             <% @work_decorator.group.administrators.each do |user| %>
-              <option value="<%= user.id %>" <%= @work.curator_user_id == user.id ? "selected" : "" %>><%= user.display_name_safe %></option>
+              <option value="<%= user.id %>" <%= @work.curator_user_id == user.id ? "selected" : "" %>><%= user.given_name_safe %></option>
             <% end %>
           </select>
         <% else %>
           <% if @work.curator_user_id.nil? %>
             none
           <% else %>
-            <%= User.find(@work.curator_user_id).display_name_safe %>
+            <%= User.find(@work.curator_user_id).given_name_safe %>
           <% end %>
         <% end %>
       </dd>

--- a/db/migrate/20230524181606_user_display_name_to_given_name.rb
+++ b/db/migrate/20230524181606_user_display_name_to_given_name.rb
@@ -1,0 +1,8 @@
+class UserDisplayNameToGivenName < ActiveRecord::Migration[6.1]
+  def up
+    rename_column :users, :display_name, :given_name
+  end
+  def down
+    rename_column :users, :given_name, :display_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_18_155600) do
+ActiveRecord::Schema.define(version: 2023_05_24_181606) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -101,7 +101,7 @@ ActiveRecord::Schema.define(version: 2023_05_18_155600) do
     t.string "uid"
     t.string "orcid"
     t.integer "default_group_id"
-    t.string "display_name"
+    t.string "given_name"
     t.string "full_name"
     t.string "family_name"
     t.boolean "email_messages_enabled", default: true

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     uid { FFaker::InternetSE.unique.login_user_name }
     email { FFaker::InternetSE.unique.email }
     full_name { FFaker::Name.name }
-    display_name { full_name.split(" ").first }
+    given_name { full_name.split(" ").first }
     provider { :cas }
     after(:create) do |user, evaluator|
       evaluator.groups_to_admin.each do |group|

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -26,7 +26,7 @@ describe NotificationMailer, type: :mailer do
       expect(message.body.parts.first.content_type).to eq("text/plain; charset=UTF-8")
       expect(message.body.parts.last).to be_an(Mail::Part)
       expect(message.body.parts.last.content_type).to eq("text/html; charset=UTF-8")
-      expect(message.body.encoded).to include("Hello #{user.display_name},")
+      expect(message.body.encoded).to include("Hello #{user.given_name},")
       expect(message.body.encoded).to include(work_activity.message)
       expect(message.body.encoded).to include("To view the notification, please browse to http://www.example.com/works/#{work.id}.")
     end
@@ -44,11 +44,11 @@ describe NotificationMailer, type: :mailer do
         html_part = message.html_part
         expect(text_part.content_type).to eq("text/plain; charset=UTF-8")
         expect(html_part.content_type).to eq("text/html; charset=UTF-8")
-        expect(html_part.encoded).to include("Hello #{user.display_name},")
+        expect(html_part.encoded).to include("Hello #{user.given_name},")
         expect(html_part.encoded).to include("To view the notification, please browse to http://www.example.com/works/#{work.id}.")
         expect(html_part.encoded).to include("I like to send &lt;a href=&quot;https://www.google.com&quot;&gt;links&lt;/a&gt;")
         expect(text_part.encoded).to include(work_activity.message)
-        expect(text_part.encoded).to include("Hello #{user.display_name},")
+        expect(text_part.encoded).to include("Hello #{user.given_name},")
         expect(text_part.encoded).to include("To view the notification, please browse to http://www.example.com/works/#{work.id}.")
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe User, type: :model do
       user = described_class.from_cas(access_token_full_extras)
       expect(user.email).to eq "who@princeton.edu"
       expect(user.full_name).to eq "Areyou, Who"
-      expect(user.display_name).to eq "Who"
+      expect(user.given_name).to eq "Who"
       expect(user.family_name).to eq "Areyou"
     end
 
@@ -63,13 +63,13 @@ RSpec.describe User, type: :model do
       described_class.where(uid: "test123").delete_all
       user = described_class.new(uid: "test123", email: "test123@princeton.edu")
       user.save!
-      expect(user.display_name).to be nil
+      expect(user.given_name).to be nil
 
       # ...make sure it's updated with CAS info
       user = described_class.from_cas(access_token_full_extras)
       expect(user.email).to eq "who@princeton.edu"
       expect(user.full_name).to eq "Areyou, Who"
-      expect(user.display_name).to eq "Who"
+      expect(user.given_name).to eq "Who"
       expect(user.family_name).to eq "Areyou"
     end
   end
@@ -118,12 +118,12 @@ RSpec.describe User, type: :model do
       described_class.where(uid: "fake_netid_dw1234").delete_all
       user = described_class.new_from_csv_params(csv_params)
       user.full_name = "Darryl Arthur Williamson"
-      user.display_name = "D. Williamson"
+      user.given_name = "D. Williamson"
       user.orcid = "0000-0000-0000-1111"
       user.save!
       user = described_class.new_from_csv_params(csv_params)
       expect(user.full_name).to eq "Darryl Arthur Williamson"
-      expect(user.display_name).to eq "D. Williamson"
+      expect(user.given_name).to eq "D. Williamson"
       expect(user.orcid).to eq "0000-0000-0000-0000"
     end
   end

--- a/spec/requests/welcome_spec.rb
+++ b/spec/requests/welcome_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Home Page", type: :request do
   describe "GET /" do
     context "Authenticated user" do
       let(:email) { "pul123@princeton.edu" }
-      let(:user) { FactoryBot.create :user, email: email, uid: "pul123", display_name: "Toni", full_name: "Toni Morrison" }
+      let(:user) { FactoryBot.create :user, email: email, uid: "pul123", given_name: "Toni", full_name: "Toni Morrison" }
       before do
         sign_in user
       end

--- a/spec/system/authz_submitter_spec.rb
+++ b/spec/system/authz_submitter_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Authz for submitters", type: :system, js: true do
     it "should not be able to edit someone else's work" do
       sign_in submitter1
       visit user_path(submitter1)
-      expect(page).to have_content submitter1.display_name
+      expect(page).to have_content submitter1.given_name
       click_on "Submit New"
       fill_in "title_main", with: title1
 

--- a/spec/system/authz_super_admin_spec.rb
+++ b/spec/system/authz_super_admin_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Authz for super admins", type: :system, js: true do
       stub_s3
       sign_in submitter2
       visit user_path(submitter2)
-      expect(page).to have_content submitter2.display_name
+      expect(page).to have_content submitter2.given_name
       click_on "Submit New"
       fill_in "title_main", with: title1
 

--- a/spec/system/user_edit_spec.rb
+++ b/spec/system/user_edit_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Editing users", type: :system do
 
     it "allows an admin to edit other users ORCID", js: true do
       visit user_path(user)
-      expect(page).to have_content user.display_name
+      expect(page).to have_content user.given_name
       click_on "Edit"
       expect(page).to have_content "My Profile Settings"
       fill_in "user_orcid", with: orcid
@@ -27,7 +27,7 @@ RSpec.describe "Editing users", type: :system do
 
     it "allows an admin to edit other users ORCID", js: true do
       visit user_path(user_other)
-      expect(page).to have_content user_other.display_name
+      expect(page).to have_content user_other.given_name
       expect(page).to_not have_content "Edit"
     end
   end
@@ -46,7 +46,7 @@ RSpec.describe "Editing users", type: :system do
 
     it "shows the form" do
       visit edit_user_path(user)
-      expect(page).to have_field("user_display_name", with: user.display_name)
+      expect(page).to have_field("user_given_name", with: user.given_name)
       expect(page).to have_content "My Profile Settings"
       expect(page).to have_unchecked_field "group_messaging_#{pppl_group.id}"
       expect(page).to have_checked_field "group_messaging_#{rd_group.id}"
@@ -63,7 +63,7 @@ RSpec.describe "Editing users", type: :system do
 
       it "shows the form with all the collections and only the default group is checked" do
         visit edit_user_path(user)
-        expect(page).to have_field("user_display_name", with: user.display_name)
+        expect(page).to have_field("user_given_name", with: user.given_name)
         expect(page).to have_content "My Profile Settings"
         expect(page).to have_unchecked_field "group_messaging_#{pppl_group.id}"
         expect(page).to have_checked_field "group_messaging_#{rd_group.id}"

--- a/spec/system/work_approve_spec.rb
+++ b/spec/system/work_approve_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Work Approval", type: :system do
     it "produces and saves a valid datacite record", js: true do
       sign_in curator
       visit(user_path(curator))
-      expect(page).to have_content curator.display_name
+      expect(page).to have_content curator.given_name
       click_link work.title
       expect(page).to have_content(work.doi)
       click_on "Approve Dataset"

--- a/spec/system/work_create_spec.rb
+++ b/spec/system/work_create_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe "Form submission for a legacy dataset", type: :system do
       sign_out user
       sign_in curator
       visit(user_path(curator))
-      expect(page).to have_content curator.display_name
+      expect(page).to have_content curator.given_name
       # This is the blue badge on the work that should show up for a curator
       #  when a work is startend and marked completed by a submitter
       within("#unfinished_datasets span.badge.rounded-pill.bg-primary") do


### PR DESCRIPTION
We have been using the display name as the given name in the system.  This PR updates the database field name and all calls to it to given_name so there is no confusion about it in the future