### PR TITLE
Changing specs to use the new migrate button

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,4 @@
 ruby 3.1.0
 nodejs 16.15.0
 yarn 1.22.19
+awscli 2.7.31

--- a/spec/system/data_migration/attention_form_submission_spec.rb
+++ b/spec/system/data_migration/attention_form_submission_spec.rb
@@ -59,7 +59,8 @@ RSpec.describe "Form submission for migrating attention", type: :system, mock_ez
       fill_in "doi", with: doi
       fill_in "ark", with: ark
       page.attach_file("work[pre_curation_uploads_added][]", [file_upload], make_visible: true)
-      click_on "Create"
+      click_on "Migrate"
+      expect(page).to have_button("Migrate Dataspace Files")
       expect(page).to have_content "marked as Draft"
       expect(page).to have_content "Creative Commons Attribution 4.0 International"
       click_on "Complete"

--- a/spec/system/data_migration/baldwin_form_submission_spec.rb
+++ b/spec/system/data_migration/baldwin_form_submission_spec.rb
@@ -51,7 +51,8 @@ RSpec.describe "Form submission for migrating baldwin", type: :system, mock_ezid
       fill_in "doi", with: doi
       fill_in "ark", with: ark
       select "Research Data", from: "group_id"
-      click_on "Create"
+      click_on "Migrate"
+      expect(page).to have_button("Migrate Dataspace Files")
       expect(page).to have_content "marked as Draft"
       expect(page).to have_content "Creative Commons Attribution 4.0 International"
       click_on "Complete"

--- a/spec/system/data_migration/bitklavier_form_submission_spec.rb
+++ b/spec/system/data_migration/bitklavier_form_submission_spec.rb
@@ -49,7 +49,8 @@ RSpec.describe "Form submission for migrating bitklavier", type: :system, mock_e
       click_on "Curator Controlled"
       fill_in "doi", with: doi
       fill_in "ark", with: ark
-      click_on "Create"
+      click_on "Migrate"
+      expect(page).to have_button("Migrate Dataspace Files")
       expect(page).to have_content "marked as Draft"
       expect(page).to have_content "Creative Commons Attribution 4.0 International"
       click_on "Complete"

--- a/spec/system/data_migration/bitklavierimage_form_submission_spec.rb
+++ b/spec/system/data_migration/bitklavierimage_form_submission_spec.rb
@@ -57,7 +57,8 @@ Piano Bar: Earthworks—omni-directionals. This microphone system suspends omnid
       fill_in "ark", with: ark
       select group, from: "group_id"
       fill_in "collection_tags", with: collection_tags.join(", ")
-      click_on "Create"
+      click_on "Migrate"
+      expect(page).to have_button("Migrate Dataspace Files")
       expect(page).to have_content "marked as Draft"
       expect(page).to have_content "Creative Commons Attribution 4.0 International"
       click_on "Complete"

--- a/spec/system/data_migration/cklibrary_form_submission_spec.rb
+++ b/spec/system/data_migration/cklibrary_form_submission_spec.rb
@@ -45,7 +45,8 @@ RSpec.describe "Form submission for migrating cklibrary", type: :system, mock_ez
       click_on "Curator Controlled"
       fill_in "doi", with: doi
       fill_in "ark", with: ark
-      click_on "Create"
+      click_on "Migrate"
+      expect(page).to have_button("Migrate Dataspace Files")
       expect(page).to have_content "marked as Draft"
       expect(page).to have_content "Creative Commons Attribution 4.0 International"
       click_on "Complete"

--- a/spec/system/data_migration/cytoskeletal_form_submission_spec.rb
+++ b/spec/system/data_migration/cytoskeletal_form_submission_spec.rb
@@ -89,7 +89,8 @@ RSpec.describe "Form submission for migrating cytoskeletal", type: :system, mock
       click_on "Curator Controlled"
       fill_in "doi", with: doi
       fill_in "ark", with: ark
-      click_on "Create"
+      click_on "Migrate"
+      expect(page).to have_button("Migrate Dataspace Files")
       expect(page).to have_content "marked as Draft"
       expect(page).to have_content "Creative Commons Attribution 4.0 International"
       click_on "Complete"

--- a/spec/system/data_migration/design_arrangment_form_submission_spec.rb
+++ b/spec/system/data_migration/design_arrangment_form_submission_spec.rb
@@ -74,7 +74,8 @@ Consult the file README.txt for a more detailed description of the contents."
       select group, from: "group_id"
       fill_in "doi", with: doi
       fill_in "ark", with: ark
-      click_on "Create"
+      click_on "Migrate"
+      expect(page).to have_button("Migrate Dataspace Files")
       expect(page).to have_content "marked as Draft"
       expect(page).to have_content "Creative Commons Attribution 4.0 International"
       click_on "Complete"

--- a/spec/system/data_migration/dynamic_tension_form_submission_spec.rb
+++ b/spec/system/data_migration/dynamic_tension_form_submission_spec.rb
@@ -72,7 +72,8 @@ RSpec.describe "Form submission for migrating dynamic-tension", type: :system, m
       select group, from: "group_id"
       fill_in "doi", with: doi
       fill_in "ark", with: ark
-      click_on "Create"
+      click_on "Migrate"
+      expect(page).to have_button("Migrate Dataspace Files")
       expect(page).to have_content "marked as Draft"
       expect(page).to have_content "Creative Commons Attribution 4.0 International"
       click_on "Complete"

--- a/spec/system/data_migration/electromagnetic_form_submission_spec.rb
+++ b/spec/system/data_migration/electromagnetic_form_submission_spec.rb
@@ -74,7 +74,8 @@ This data set includes the data visualized in figures 2-7 in Electromagnetic tot
       select group, from: "group_id"
       fill_in "doi", with: doi
       fill_in "ark", with: ark
-      click_on "Create"
+      click_on "Migrate"
+      expect(page).to have_button("Migrate Dataspace Files")
       expect(page).to have_content "marked as Draft"
       expect(page).to have_content "Creative Commons Attribution 4.0 International"
       click_on "Complete"

--- a/spec/system/data_migration/femtosecond_form_submission_spec.rb
+++ b/spec/system/data_migration/femtosecond_form_submission_spec.rb
@@ -115,7 +115,8 @@ RSpec.describe "Form submission for migrating femtosecond", type: :system, mock_
       select "Research Data", from: "group_id"
       fill_in "doi", with: doi
       fill_in "ark", with: ark
-      click_on "Create"
+      click_on "Migrate"
+      expect(page).to have_button("Migrate Dataspace Files")
       expect(page).to have_content "marked as Draft"
       expect(page).to have_content "Creative Commons Attribution 4.0 International"
       click_on "Complete"

--- a/spec/system/data_migration/flume_form_submission_spec.rb
+++ b/spec/system/data_migration/flume_form_submission_spec.rb
@@ -46,7 +46,8 @@ The attached readme.txt file explains the data attributes"
       fill_in "doi", with: doi
       fill_in "ark", with: ark
       select "Research Data", from: "group_id"
-      click_on "Create"
+      click_on "Migrate"
+      expect(page).to have_button("Migrate Dataspace Files")
 
       expect(page).to have_content "marked as Draft"
       expect(page).to have_content "Creative Commons Attribution 4.0 International"

--- a/spec/system/data_migration/fusion_energy_form_submission_spec.rb
+++ b/spec/system/data_migration/fusion_energy_form_submission_spec.rb
@@ -55,7 +55,8 @@ RSpec.describe "Form submission for migrating fusion energy", type: :system, moc
       select group, from: "group_id"
       fill_in "doi", with: doi
       fill_in "ark", with: ark
-      click_on "Create"
+      click_on "Migrate"
+      expect(page).to have_button("Migrate Dataspace Files")
       expect(page).to have_content "marked as Draft"
       expect(page).to have_content "Creative Commons Attribution 4.0 International"
       click_on "Complete"

--- a/spec/system/data_migration/hybrid_drift_form_submission_spec.rb
+++ b/spec/system/data_migration/hybrid_drift_form_submission_spec.rb
@@ -131,7 +131,8 @@ RSpec.describe "Form submission for migrating Thomson Scattering", type: :system
 
       fill_in "doi", with: doi
       fill_in "ark", with: ark
-      click_on "Create"
+      click_on "Migrate"
+      expect(page).to have_button("Migrate Dataspace Files")
       expect(page).to have_content "marked as Draft"
       expect(page).to have_content "Creative Commons Attribution 4.0 International"
       click_on "Complete"

--- a/spec/system/data_migration/ion_orbital_form_submission_spec.rb
+++ b/spec/system/data_migration/ion_orbital_form_submission_spec.rb
@@ -74,7 +74,8 @@ RSpec.describe "Form submission for ion orbital", type: :system, mock_ezid_api: 
       select group, from: "group_id"
       fill_in "doi", with: doi
       fill_in "ark", with: ark
-      click_on "Create"
+      click_on "Migrate"
+      expect(page).to have_button("Migrate Dataspace Files")
       expect(page).to have_content "marked as Draft"
       expect(page).to have_content "Creative Commons Attribution 4.0 International"
       click_on "Complete"

--- a/spec/system/data_migration/non_axisymmetric_form_submission_spec.rb
+++ b/spec/system/data_migration/non_axisymmetric_form_submission_spec.rb
@@ -87,7 +87,8 @@ File name: SourceData.xlsx Description: source data for the 8 figures in the mai
       select group, from: "group_id"
       fill_in "doi", with: doi
       fill_in "ark", with: ark
-      click_on "Create"
+      click_on "Migrate"
+      expect(page).to have_button("Migrate Dataspace Files")
       expect(page).to have_content "marked as Draft"
       expect(page).to have_content "Creative Commons Attribution 4.0 International"
       click_on "Complete"

--- a/spec/system/data_migration/observation_axisymmetric_form_submission_spec.rb
+++ b/spec/system/data_migration/observation_axisymmetric_form_submission_spec.rb
@@ -79,7 +79,8 @@ Source data for Figure 2, Figure 4, Figure 5 and Figure 7 of the article Observa
       select group, from: "group_id"
       fill_in "doi", with: doi
       fill_in "ark", with: ark
-      click_on "Create"
+      click_on "Migrate"
+      expect(page).to have_button("Migrate Dataspace Files")
       expect(page).to have_content "marked as Draft"
       expect(page).to have_content "Creative Commons Attribution 4.0 International"
       click_on "Complete"

--- a/spec/system/data_migration/sowingseeds_form_submission_spec.rb
+++ b/spec/system/data_migration/sowingseeds_form_submission_spec.rb
@@ -60,7 +60,8 @@ Download the README.txt for a detailed description of this dataset's content."
       click_on "Additional Metadata"
       click_on "Curator Controlled"
       fill_in "ark", with: ark
-      click_on "Create"
+      click_on "Migrate"
+      expect(page).to have_button("Migrate Dataspace Files")
       click_on "Complete"
       click_on "Sowing the Seeds for More Usable Web Archives: A Usability Study of Archive-It"
 

--- a/spec/system/data_migration/spindle_form_submission_spec.rb
+++ b/spec/system/data_migration/spindle_form_submission_spec.rb
@@ -57,7 +57,8 @@ RSpec.describe "Form submission for migrating Sleeo spindle", type: :system, moc
       fill_in "doi", with: doi
       fill_in "ark", with: ark
       select group, from: "group_id"
-      click_on "Create"
+      click_on "Migrate"
+      expect(page).to have_button("Migrate Dataspace Files")
       expect(page).to have_content "marked as Draft"
       expect(page).to have_content "Creative Commons Attribution 4.0 International"
       click_on "Complete"

--- a/spec/system/data_migration/thomson_scattering_form_submission_spec.rb
+++ b/spec/system/data_migration/thomson_scattering_form_submission_spec.rb
@@ -114,7 +114,8 @@ Please consult the file README.txt for a description of the archive contents."
       select group, from: "group_id"
       fill_in "doi", with: doi
       fill_in "ark", with: ark
-      click_on "Create"
+      click_on "Migrate"
+      expect(page).to have_button("Migrate Dataspace Files")
       expect(page).to have_content "marked as Draft"
       expect(page).to have_content "Creative Commons Attribution 4.0 International"
       click_on "Complete"


### PR DESCRIPTION
This makes sure the edit goes to the non wizard version and the `Migrate Dataspace Files` button is present when the json is imported