### PR TITLE
Displaying Affiliation and ROR on the show page of the work for the creator

### DIFF
--- a/app/views/works/_orcid_link.html.erb
+++ b/app/views/works/_orcid_link.html.erb
@@ -13,3 +13,13 @@
     <%= given_name -%>
   <% end %>
 </span>
+<% if person.affiliation.present? %>
+  &nbsp;from&nbsp;
+  <span class="affiliation">
+    <% if person.affiliation_ror.present? %>
+      <%= render("ror_link", ror_link: person.affiliation_ror, ror_name: person.affiliation) %>
+    <% else %>
+      <%= person.affiliation -%>
+    <% end %>
+  </span>
+<% end %>

--- a/app/views/works/_organization_link.html.erb
+++ b/app/views/works/_organization_link.html.erb
@@ -1,0 +1,14 @@
+<% display_name = capture do %>
+  <%= organization.value %>
+  <% if organization.type.present? %>
+    (<%= organization.type.titleize %>)
+  <% end %>
+<% end.strip %>
+
+<span class="author-name">
+  <% if organization.ror.present? %>
+    <%= render("ror_link", ror_link: organization.ror, ror_name: display_name) %>
+  <% else %>
+    <%= display_name -%>
+  <% end %>
+</span>

--- a/app/views/works/_ror_link.html.erb
+++ b/app/views/works/_ror_link.html.erb
@@ -1,17 +1,5 @@
-<% display_name = capture do %>
-  <%= organization.value %>
-  <% if organization.type.present? %>
-    (<%= organization.type.titleize %>)
-  <% end %>
-<% end.strip %>
-
-<span class="author-name">
-  <% if organization.ror.present? %>
-    <!-- Logo from https://ror.readme.io/docs/ror-id-display-guidelines-and-logos -->
-    <img alt="ROR logo" src="https://raw.githubusercontent.com/ror-community/ror-logos/main/ror-icon-rgb.svg" width="16" height="16" />
-    <!-- Canonical ROR is a URL, so do not include protocol or hostname. -->
-    <a href="<%= organization.ror %>" target="_blank"><%= display_name %></a>
-  <% else %>
-    <%= display_name -%>
-  <% end %>
-</span>
+  <!-- Canonical ROR is a URL, so do not include protocol or hostname. -->
+  <a href="<%= ror_link %>" target="_blank"><%= ror_name %>
+      <!-- Logo from https://ror.readme.io/docs/ror-id-display-guidelines-and-logos#inline-ror-id -->
+      <img alt="ROR Logo" src="https://raw.githubusercontent.com/ror-community/ror-logos/main/ror-icon-rgb.svg" height="24" />
+  </a>

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -207,7 +207,7 @@
       <% if @work.resource.organizational_contributors.count > 0 %>
         <dt>Organizational Contributors</dt>
         <dd>
-          <%= safe_join(@work.resource.organizational_contributors.map { |org| render("ror_link", organization: org) }, "; ") %>
+          <%= safe_join(@work.resource.organizational_contributors.map { |org| render("organization_link", organization: org) }, "; ") %>
         </dd>
       <% end %>
 


### PR DESCRIPTION
Moving ROR icon to the end of the url per [guidelines](https://ror.readme.io/docs/ror-id-display-guidelines-and-logos#inline-ror-id)

Also, moved organizational ROR to a partial specifically for the organization link and then used the ror_link partial to be a reusable partial for an ROR link
![Screenshot 2023-06-19 at 2 20 06 PM](https://github.com/pulibrary/pdc_describe/assets/1599081/ae02ae54-ee72-4d04-8f91-e432eb606817)

refs #959 