### PR TITLE
Capturing AASM errors during the new_submission action

### DIFF
--- a/app/views/works/new_submission.html.erb
+++ b/app/views/works/new_submission.html.erb
@@ -28,6 +28,12 @@
 </style>
 
 <div class="wizard-area">
+  
+  # in theory the new submission should never submit without a title or creators, becuase the javascript should prevent it
+  #  In reality we are occasionally having issues with the javascript failing and the button submitting anyway.
+  #  In that case we want to show the error to the user so they cna fix it
+  <%= render 'form_errors' %>
+
   <h1>New Submission</h1>
   <%= render "wizard_progress", wizard_step: 0 %>
 

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -69,6 +69,20 @@ RSpec.describe WorksController do
       expect(response.location.start_with?("http://test.host/works/")).to be true
     end
 
+    # in theory we should never get to the new submission without a title, becuase the javascript should prevent it
+    #  In reality we are occasionally having issues with the javascript failing and the button submitting anyway.
+    it "renders the edit page when creating a new dataset without a title" do
+      params = {
+        "group_id" => work.group.id,
+        "creators" => [{ "orcid" => "", "given_name" => "Jane", "family_name" => "Smith" }]
+      }
+      sign_in user
+      post :new_submission, params: params
+      expect(response.status).to be 422
+      expect(assigns[:errors]).to eq(["Cannot Draft: Must provide a title"])
+      expect(response).to render_template :new_submission
+    end
+
     it "handles the update page" do
       params = {
         "title_main" => "test dataset updated",


### PR DESCRIPTION
This allows the javascript to fail and the user to see a real error vs an exception fixes #1196