### PR TITLE
Fixes issue fetching ORCID values

### DIFF
--- a/app/javascript/entrypoints/pdc/work_orcid.es6
+++ b/app/javascript/entrypoints/pdc/work_orcid.es6
@@ -22,14 +22,14 @@ export default class WorkOrcid {
     if (this.isOrcidFormat(orcidValue)) {
       $.ajax({
         url: `${pdc.orcid_url}/${orcidValue}`,
-        beforeSend: function( xhr ) {
+        beforeSend(xhr) {
           // The ORCID API is very finicky and does not reliably work if the
           // "`Accept: application/json" request header is not present.
           //
           // These two ORCIDS are examples that only work if the Accept header is
           // present: 0000-0002-8201-2528 and 0000-0002-7348-7142
-          xhr.setRequestHeader( "Accept", "application/json" );
-        }
+          xhr.setRequestHeader('Accept', 'application/json');
+        },
       })
         .done((data) => {
           const givenName = data.person.name['given-names'].value;

--- a/app/javascript/entrypoints/pdc/work_orcid.es6
+++ b/app/javascript/entrypoints/pdc/work_orcid.es6
@@ -22,7 +22,14 @@ export default class WorkOrcid {
     if (this.isOrcidFormat(orcidValue)) {
       $.ajax({
         url: `${pdc.orcid_url}/${orcidValue}`,
-        dataType: 'jsonp',
+        beforeSend: function( xhr ) {
+          // The ORCID API is very finicky and does not reliably work if the
+          // "`Accept: application/json" request header is not present.
+          //
+          // These two ORCIDS are examples that only work if the Accept header is
+          // present: 0000-0002-8201-2528 and 0000-0002-7348-7142
+          xhr.setRequestHeader( "Accept", "application/json" );
+        }
       })
         .done((data) => {
           const givenName = data.person.name['given-names'].value;
@@ -30,8 +37,8 @@ export default class WorkOrcid {
           $(givenNameId).val(givenName);
           $(familyNameId).val(familyName);
         })
-        .fail((XMLHttpRequest, textStatus, errorThrown) => {
-          console.error(`Error fetching ORCID for ${errorThrown}`);
+        .fail((_XMLHttpRequest, _textStatus, errorThrown) => {
+          console.error(`Error fetching ORCID ${orcidValue}: ${errorThrown}`);
         });
     }
   }

--- a/spec/support/external_identifier_specs.rb
+++ b/spec/support/external_identifier_specs.rb
@@ -82,12 +82,10 @@ class FakeIdentifierIntegration < Sinatra::Base
   # rubocop:enable Metrics/MethodLength
 
   get "/orcid/:orcid" do |orcid|
-
     # Notice that we force "application/json" on the JavaScript call and therefore
     # we must use `content_type :json` in our response as well.
     content_type(:json)
 
-    callback = params[:callback]
     data = {
       "orcid-identifier" => {
         "uri" => "http://orcid.org/#{orcid}",

--- a/spec/support/external_identifier_specs.rb
+++ b/spec/support/external_identifier_specs.rb
@@ -82,7 +82,11 @@ class FakeIdentifierIntegration < Sinatra::Base
   # rubocop:enable Metrics/MethodLength
 
   get "/orcid/:orcid" do |orcid|
-    content_type(:js)
+
+    # Notice that we force "application/json" on the JavaScript call and therefore
+    # we must use `content_type :json` in our response as well.
+    content_type(:json)
+
     callback = params[:callback]
     data = {
       "orcid-identifier" => {
@@ -107,7 +111,7 @@ class FakeIdentifierIntegration < Sinatra::Base
       data["person"]["name"]["family-name"]["value"] = "Loya"
     end
 
-    "#{callback}(#{data.to_json});"
+    data.to_json
   end
 end
 


### PR DESCRIPTION
Forces the request to the ORCID API to pass `application/json` on the HTTP headers. This fixes the problem where a few requests return a response that jQuery cannot parse -- even though the majority of the calls work OK with the previous configuration using JSONP via `dataType: 'jsonp'`

Closes #1271 
