### PR TITLE
Set last name when importing users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -85,8 +85,9 @@ class User < ApplicationRecord
   def self.new_from_csv_params(csv_params)
     email = "#{csv_params['Net ID']}@princeton.edu"
     uid = csv_params["Net ID"]
-    full_name = "#{csv_params['First Name']} #{csv_params['Last Name']}"
     given_name = csv_params["First Name"]
+    family_name = csv_params["Last Name"]
+    full_name = "#{given_name} #{family_name}"
     orcid = csv_params["ORCID ID"]
     user = User.where(email: email).first_or_create
     params_hash = {
@@ -94,6 +95,7 @@ class User < ApplicationRecord
       uid: uid,
       orcid: orcid,
       full_name: (full_name if user.full_name.blank?),
+      family_name: (family_name if user.family_name.blank?),
       given_name: (given_name if user.given_name.blank?)
     }.compact
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -133,6 +133,8 @@ RSpec.describe User, type: :model do
       users = described_class.create_users_from_csv(csv)
       expect(users.length).to eq 3
       expect(users.first.full_name).to eq "Jackie Alvarez"
+      expect(users.first.given_name).to eq "Jackie"
+      expect(users.first.family_name).to eq "Alvarez"
       expect(users.last.full_name).to eq "Kent Jenson"
     end
   end


### PR DESCRIPTION
Make sure the last name (family name) is set when importing users from a CSV file.

Closes #1272 