### PR TITLE
Adding target=_blank to download link so that the page remains in the correct spot

### DIFF
--- a/app/views/works/_s3_resources.html.erb
+++ b/app/views/works/_s3_resources.html.erb
@@ -66,7 +66,7 @@
               } else {
                 html = `<span>
                   <i class="bi bi-file-arrow-down"></i>
-                  <a href="<%= @work.id %>/download?filename=${data}">${row.filename_display}</a>
+                  <a href="<%= @work.id %>/download?filename=${data}" target="_blank">${row.filename_display}</a>
                 </span>`;
               }
               return html;

--- a/spec/system/view_data_in_s3_spec.rb
+++ b/spec/system/view_data_in_s3_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe "View status of data in S3", mock_ezid_api: true, js: true do
 
         visit work_path(work)
         expect(page).to have_link file1.filename_display, href: "#{work.id}/download?filename=#{file1.filename}"
+        expect(find_link(file1.filename_display)[:target]).to eq("_blank")
         expect(page).not_to have_button("Edit")
       end
 


### PR DESCRIPTION

fixes #1152