### PR TITLE
Remove misleading placeholders 

### DIFF
--- a/app/views/works/_related_objects_table.html.erb
+++ b/app/views/works/_related_objects_table.html.erb
@@ -14,15 +14,15 @@
         </tr>
       </thead>
       <tbody id="related-objects-table" class="sortable">
-        <% related_objects = if @work.nil? || @work.resource.related_objects.empty? 
+        <% related_objects = if @work.nil? || @work.resource.related_objects.empty?
           [nil]
         else
-          @work.resource.related_objects 
+          @work.resource.related_objects
         end %>
         <% related_objects.each do |related_object| %>
           <tr class="related-objects-table-row">
             <td>
-              <input name="related_objects[][related_identifier]" value="<%= related_object&.related_identifier %>" class="related_identifier-related_objects"  placeholder="0000-0000-0000-0000" />
+              <input name="related_objects[][related_identifier]" value="<%= related_object&.related_identifier %>" class="related_identifier-related_objects"  placeholder="" />
             </td>
             <td>
               <select name="related_objects[][related_identifier_type]">

--- a/app/views/works/_required_form.html.erb
+++ b/app/views/works/_required_form.html.erb
@@ -20,9 +20,8 @@
                                                        field_detail: "Please enter a brief summary of this item specifically - not identical to the abstract of a corresponding paper. The focus should be on the nature of the materials constituting the item (scope, purpose, methods, etc.), as opposed to substantive claims made in related publications.",
                                                       }
   %>
-  <textarea type="text" id="description" name="description" class="input-text-long" rows="5" cols="120"
-    placeholder="Please enter a brief summary describing the unique attributes of this submission. (e.g., The purpose, scope, methods, dependencies, etc. for the object(s) deposited to this submission.) It should be unique from a description or abstract used for a corresponding paper."
-  ><%= @work.resource.description %></textarea>
+  <textarea type="text" id="description" name="description" class="input-text-long"
+    rows="5" cols="120" placeholder=""><%= @work.resource.description %></textarea>
 </div>
 
 <!-- Rights Management field -->


### PR DESCRIPTION
Removes HTML placeholders that we misleading or redundant.

Closes #1288
![Screenshot 2023-06-23 at 4 38 33 PM](https://github.com/pulibrary/pdc_describe/assets/568286/1b533770-09ca-46bf-b0a2-ce2836373420)

Closes #1287 
![Screenshot 2023-06-23 at 4 38 47 PM](https://github.com/pulibrary/pdc_describe/assets/568286/b3019292-66ea-4045-a15f-fd8201883e95)


