### PR TITLE
Validate the name of the uploaded readme file

### DIFF
--- a/app/javascript/entrypoints/pdc/readme_file_upload.es6
+++ b/app/javascript/entrypoints/pdc/readme_file_upload.es6
@@ -14,8 +14,14 @@ export default class ReadmeFileUpload {
       this.save_element.disabled = true;
       this.error_element.innerText = 'You must select a README file';
     } else {
-      this.save_element.disabled = false;
-      this.error_element.innerText = '';
+      const filename = this.upload_element[0].files[0].name.toLowerCase();
+      if (filename.includes("readme") == true) {
+        this.save_element.disabled = false;
+        this.error_element.innerText = '';
+      } else {
+        this.save_element.disabled = true;
+        this.error_element.innerText = 'You must select a file that includes the word README in the name (lowercase or uppercase is accepted)';
+      }
     }
   }
 }

--- a/app/javascript/entrypoints/pdc/readme_file_upload.es6
+++ b/app/javascript/entrypoints/pdc/readme_file_upload.es6
@@ -15,7 +15,7 @@ export default class ReadmeFileUpload {
       this.error_element.innerText = 'You must select a README file';
     } else {
       const filename = this.upload_element[0].files[0].name.toLowerCase();
-      if (filename.includes("readme") == true) {
+      if (filename.includes('readme') === true) {
         this.save_element.disabled = false;
         this.error_element.innerText = '';
       } else {

--- a/app/views/works/readme_select.html.erb
+++ b/app/views/works/readme_select.html.erb
@@ -2,7 +2,7 @@
   <h1><%= t('works.form.file_upload.heading', work_title: @work.title) %></h1>
   <%= render "wizard_progress", wizard_step: 2 %>
   <%= form_with(model: @work, scope: :patch, url: work_readme_uploaded_path(id: @work.id)) do |f| %>
-    
+
     <h2>All submissions must include a README file. READMEs:</h2>
     <ul>
       <li>Are necessary so others can understand and use your data/code;</li>
@@ -20,7 +20,8 @@
       <% if @readme.present? %>
         <p><%= @readme %> was previously uploaded.  You will replace it if you select a different file. </p>
       <% end %>
-      <%= f.file_field(:readme_file, multiple: false) %>
+      <!-- See https://stackoverflow.com/a/11834872/446681 for info on the `accept` attribute -->
+      <%= f.file_field(:readme_file, multiple: false, accept: '.txt,.md') %>
     </div>
 
     <div class="actions">

--- a/spec/fixtures/files/readme.txt
+++ b/spec/fixtures/files/readme.txt
@@ -1,0 +1,1 @@
+This is a sample read me file

--- a/spec/system/authz_submitter_spec.rb
+++ b/spec/system/authz_submitter_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Authz for submitters", type: :system, js: true do
       click_on "Curator Controlled"
       expect(page).to have_content "Research Data"
       click_on "Save Work"
-      path = Rails.root.join("spec", "fixtures", "files", "orcid.csv")
+      path = Rails.root.join("spec", "fixtures", "files", "readme.txt")
       attach_file(path) do
         page.find("#patch_readme_file").click
       end

--- a/spec/system/authz_super_admin_spec.rb
+++ b/spec/system/authz_super_admin_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Authz for super admins", type: :system, js: true do
       click_on "Curator Controlled"
       expect(page).to have_content "Research Data"
       click_on "Save Work"
-      path = Rails.root.join("spec", "fixtures", "files", "orcid.csv")
+      path = Rails.root.join("spec", "fixtures", "files", "readme.txt")
       attach_file(path) do
         page.find("#patch_readme_file").click
       end

--- a/spec/system/external_ids_spec.rb
+++ b/spec/system/external_ids_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "External Identifiers", type: :system, mock_ezid_api: true, js: t
     fill_in "description", with: "test description"
     select "GNU General Public License", from: "rights_identifier"
     click_on "Save Work"
-    path = Rails.root.join("spec", "fixtures", "files", "orcid.csv")
+    path = Rails.root.join("spec", "fixtures", "files", "readme.txt")
     attach_file(path) do
       page.find("#patch_readme_file").click
     end

--- a/spec/system/work_create_spec.rb
+++ b/spec/system/work_create_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe "Form submission for a legacy dataset", type: :system do
       end
       # ...and we expect and error message to be displayed and the button to continue to remain disabled
       expect(page).to have_content("You must select a file that includes the word README in the name")
-      expect(page).to have_button('Continue', disabled: true)
+      expect(page).to have_button("Continue", disabled: true)
     end
   end
 end

--- a/spec/system/work_create_spec.rb
+++ b/spec/system/work_create_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe "Form submission for a legacy dataset", type: :system do
       click_on "Save Work"
       expect(page).to have_content("Please upload the README")
       expect(page).to have_button("Continue", disabled: true)
-      path = Rails.root.join("spec", "fixtures", "files", "orcid.csv")
+      path = Rails.root.join("spec", "fixtures", "files", "readme.txt")
       attach_file(path) do
         page.find("#patch_readme_file").click
       end
@@ -163,6 +163,37 @@ RSpec.describe "Form submission for a legacy dataset", type: :system do
       within("#unfinished_datasets span.badge.rounded-pill.bg-primary") do
         expect(page).to have_content "2"
       end
+    end
+  end
+
+  context "invalid readme" do
+    it "prevents the user from continuing when the readme file is not valid", js: true do
+      sign_in user
+      visit new_work_path(params: { wizard: true })
+      click_on "Create New"
+      fill_in "title_main", with: title
+
+      find("tr:last-child input[name='creators[][given_name]']").set "Samantha"
+      find("tr:last-child input[name='creators[][family_name]']").set "Abrams"
+      click_on "Create New"
+
+      fill_in "description", with: description
+      click_on "Save Work"
+
+      expect(page).to have_content("Please upload the README")
+      expect(page).to have_button("Continue", disabled: true)
+
+      # Make sure we limit the file extensions a user can select
+      expect(page.html.include?('accept=".txt,.md"')).to be true
+
+      # We on purpose upload a non-read me file...
+      path = Rails.root.join("spec", "fixtures", "files", "orcid.csv")
+      attach_file(path) do
+        page.find("#patch_readme_file").click
+      end
+      # ...and we expect and error message to be displayed and the button to continue to remain disabled
+      expect(page).to have_content("You must select a file that includes the word README in the name")
+      expect(page).to have_button('Continue', disabled: true)
     end
   end
 end


### PR DESCRIPTION
Configures the upload file in the browser to limit the files that a user can select as a readme to only those with extensions `txt` or `md` and also validates that the file selected has the word "readme" somewhere in the name (case insensitive.)

## Browser Dialog
![browser_dialog](https://github.com/pulibrary/pdc_describe/assets/568286/27e7c945-16d1-4ddc-9180-e324f902f0e7)

## JavaScript Validation
We validate the actual name of the file via JavaScript because we cannot make the name restriction directly on the Browser Dialog.
![javascript-validation](https://github.com/pulibrary/pdc_describe/assets/568286/26b09f88-a3c8-42fa-b757-9a23d167aac3)

Closes #1139

