### PR TITLE
Update messaging when uploading files during edit

### DIFF
--- a/app/javascript/entrypoints/pdc/pdc_ui_loader.es6
+++ b/app/javascript/entrypoints/pdc/pdc_ui_loader.es6
@@ -5,6 +5,7 @@ import ReadmeFileUpload from './readme_file_upload.es6';
 import WorkOrcid from './work_orcid.es6';
 import WorkRoR from './work_ror.es6';
 import EditTableActions from './edit_table_actions.es6';
+import WorkEditFileUpload from './work_edit_file_upload.es6';
 
 /* eslint class-methods-use-this: ["error", { "exceptMethods": ["setup_fileupload_validation"] }] */
 
@@ -19,6 +20,7 @@ export default class PdcUiLoader {
     (new CopytoClipboard()).attach_copy();
     (new EditRequiredFields()).attach_validations();
     (new ReadmeFileUpload('patch_readme_file', 'readme-upload')).attach_validation();
+    (new WorkEditFileUpload('pre_curation_uploads_added', 'file-upload-list')).attach_validation();
     (new WorkOrcid('.orcid-entry-creator', 'creators[][given_name]', 'creators[][family_name]')).attach_validation();
     (new WorkOrcid('.orcid-entry-contributor', 'contributors[][given_name]', 'contributors[][family_name]')).attach_validation();
     (new WorkRoR(pdc.ror_url)).attach_query();

--- a/app/javascript/entrypoints/pdc/work_edit_file_upload.es6
+++ b/app/javascript/entrypoints/pdc/work_edit_file_upload.es6
@@ -1,0 +1,26 @@
+export default class WorkEditFileUpload {
+  constructor(fileUploadId, fileListId) {
+    this.file_upload_element = $(`#${fileUploadId}`);
+    this.file_list_element = $(`#${fileListId}`);
+  }
+
+  attach_validation() {
+    this.file_upload_element.on('change', this.validate.bind(this));
+  }
+
+  validate() {
+    const files = this.file_upload_element[0].files;
+    if (files.length <= 1) {
+      // Zero or 1 files: let the browser display the default information
+      this.file_list_element.html('');
+    } else {
+      // More than one file: display a list of files
+      var html = '<ul>';
+      for(var i=0; i<files.length; i++) {
+        html += `<li>${files[i].name}`
+      }
+      html += '</ul>'
+      this.file_list_element.html(html);
+    }
+  }
+}

--- a/app/javascript/entrypoints/pdc/work_edit_file_upload.es6
+++ b/app/javascript/entrypoints/pdc/work_edit_file_upload.es6
@@ -9,17 +9,18 @@ export default class WorkEditFileUpload {
   }
 
   validate() {
-    const files = this.file_upload_element[0].files;
+    let html;
+    const files = this.file_upload_element[0];
     if (files.length <= 1) {
       // Zero or 1 files: let the browser display the default information
       this.file_list_element.html('');
     } else {
       // More than one file: display a list of files
-      var html = '<ul>';
-      for(var i=0; i<files.length; i++) {
-        html += `<li>${files[i].name}`
+      html = '<ul>';
+      for (let i = 0; i < files.length; i += 1) {
+        html += `<li>${files[i].name}`;
       }
-      html += '</ul>'
+      html += '</ul>';
       this.file_list_element.html(html);
     }
   }

--- a/app/views/works/_form.html.erb
+++ b/app/views/works/_form.html.erb
@@ -52,8 +52,10 @@
             </section>
             <div class="container-fluid deposit-uploads">
               <div id="file-error" class="error_box"></div>
-              <%= form.label("Add more files", for: :pre_curation_uploads_added) %>
+              <%= form.label("Choose files to attach to this work", for: :pre_curation_uploads_added) %>
               <%= form.file_field(:pre_curation_uploads_added, id: "pre_curation_uploads_added", multiple: true) %>
+              <!-- We populate this via JavaScript as the user selected files to upload -->
+              <div id="file-upload-list"></div>
             </div>
           <% end %>
         </div>


### PR DESCRIPTION
Updated the message to make it clear to the user which files they are adding. 

I added some extra functionality via JavaScript to list the specific files selected. By default the browser displays the name of the file to upload *when it is only one file*, when more than one file is selected (say 3) it just displays "3 files selected". With the new JavaScript it always list the names of the files to upload and therefore it should be clear(er) to the user what they are doing.

![Screenshot 2023-06-28 at 5 25 50 PM](https://github.com/pulibrary/pdc_describe/assets/568286/fc36c664-f11b-4293-93f7-9c178e6969fd)

Closes #1157 