### PR TITLE
Updating the notification email to make the message html safe

### DIFF
--- a/app/views/notification_mailer/build_message.html.erb
+++ b/app/views/notification_mailer/build_message.html.erb
@@ -7,13 +7,13 @@
     <section>
       <p>
         <span>Hello <%= @user.given_name %>,</span>
-        <span>This message is to notify you of a new notification for your account with PDC Describe:</span>
-        <span><%= @message_html %></span>
+        <p>You have a new notification for your account with PDC Describe:</p>
+        <p><%= @message_html.html_safe %></p>
       </p>
     </section>
     <section>
       <p>
-        <span>To view the notification, please browse to <%= @url %>.</span>
+        <span>To view the notification, please browse <a href='<%= @url %>'>here<a>.</span>
         <span>Thank you very much for your support and time.</span>
       </p>
     </section>

--- a/app/views/notification_mailer/build_message.text.erb
+++ b/app/views/notification_mailer/build_message.text.erb
@@ -1,6 +1,7 @@
 Hello <%= @user.given_name %>,
 
-This message is to notify you of a new notification for your account with PDC Describe:
+You have a new notification for your account with PDC Describe:
+
 <%= @message %>
 
 ===============================================

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -28,7 +28,7 @@ describe NotificationMailer, type: :mailer do
       expect(message.body.parts.last.content_type).to eq("text/html; charset=UTF-8")
       expect(message.body.encoded).to include("Hello #{user.given_name},")
       expect(message.body.encoded).to include(work_activity.message)
-      expect(message.body.encoded).to include("To view the notification, please browse to http://www.example.com/works/#{work.id}.")
+      expect(message.body.encoded).to include("To view the notification, please browse <a href='http://www.example.com/works/#{work.id}'>here<a>.")
     end
 
     context "when the mesage has markdown" do
@@ -45,8 +45,8 @@ describe NotificationMailer, type: :mailer do
         expect(text_part.content_type).to eq("text/plain; charset=UTF-8")
         expect(html_part.content_type).to eq("text/html; charset=UTF-8")
         expect(html_part.encoded).to include("Hello #{user.given_name},")
-        expect(html_part.encoded).to include("To view the notification, please browse to http://www.example.com/works/#{work.id}.")
-        expect(html_part.encoded).to include("I like to send &lt;a href=&quot;https://www.google.com&quot;&gt;links&lt;/a&gt;")
+        expect(html_part.encoded).to include("To view the notification, please browse <a href='http://www.example.com/works/#{work.id}'>here<a>.")
+        expect(html_part.encoded).to include("I like to send <a href=\"https://www.google.com\">links</a>")
         expect(text_part.encoded).to include(work_activity.message)
         expect(text_part.encoded).to include("Hello #{user.given_name},")
         expect(text_part.encoded).to include("To view the notification, please browse to http://www.example.com/works/#{work.id}.")


### PR DESCRIPTION
This causes the html in the message to be displayed as parsed html instead of straight html text 

Also updated the wording to be a bit less repetitive 

fixes #1165

Original notification format:
![Screenshot 2023-07-13 at 10 31 44 AM](https://github.com/pulibrary/pdc_describe/assets/1599081/0bb28059-69cb-494f-8be6-1c2f20a2ab42)

New Format after PR:


![Screenshot 2023-07-13 at 10 35 12 AM](https://github.com/pulibrary/pdc_describe/assets/1599081/fdec7e2e-3f1c-4e06-a045-0435abe0d6f4)
