### PR TITLE
Moving the controller to utilize the new deleted_file_* format

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -359,7 +359,7 @@ class WorksController < ApplicationController
       @wizard_mode = wizard_mode?
       upload_service = WorkUploadsEditService.new(@work, current_user)
       if @work.approved?
-        upload_keys = work_params[:deleted_uploads] || []
+        upload_keys = deleted_files_param || []
         deleted_uploads = upload_service.find_post_curation_uploads(upload_keys: upload_keys)
 
         return head(:forbidden) unless deleted_uploads.empty?


### PR DESCRIPTION
The old format was still being done for the check to not allow files to be deleted on approved works.  Since the UI does not allow edits on approved works this was not tested in a system test.  When I added the expectation to the test for delete_s3_object to have been called I noticed the bug in the test, which lead me to the bug in the code