### PR TITLE
Adding an UploadSnapshot to the readme process

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -284,7 +284,7 @@ class WorksController < ApplicationController
 
   def readme_select
     @work = Work.find(params[:id])
-    readme = Readme.new(@work)
+    readme = Readme.new(@work, current_user)
     @readme = readme.file_name
     @wizard = true
   end
@@ -292,7 +292,7 @@ class WorksController < ApplicationController
   def readme_uploaded
     @work = Work.find(params[:id])
     @wizard = true
-    readme = Readme.new(@work)
+    readme = Readme.new(@work, current_user)
     readme_error = readme.attach(readme_file_param)
     if readme_error.nil?
       redirect_to work_attachment_select_url(@work)

--- a/app/services/s3_query_service.rb
+++ b/app/services/s3_query_service.rb
@@ -19,7 +19,7 @@ class S3QueryService
     configuration.post_curation
   end
 
-  attr_reader :part_size
+  attr_reader :part_size, :last_response
 
   ##
   # @param [Work] model
@@ -30,6 +30,7 @@ class S3QueryService
     @doi = model.doi
     @pre_curation = pre_curation
     @part_size = 5_368_709_120 # 5GB is the maximum part size for AWS
+    @last_response = nil
   end
 
   def config
@@ -213,7 +214,7 @@ class S3QueryService
     # upload file from io in a single request, may not exceed 5GB
     md5_digest ||= md5(io: io)
     key = "#{prefix}#{filename}"
-    client.put_object(bucket: bucket_name, key: key, body: io, content_md5: md5_digest)
+    @last_response = client.put_object(bucket: bucket_name, key: key, body: io, content_md5: md5_digest)
     key
   rescue Aws::S3::Errors::SignatureDoesNotMatch => e
     Honeybadger.notify("Error Uploading file #{filename} for object: #{s3_address} Signature did not match! error: #{e}")

--- a/spec/models/readme_spec.rb
+++ b/spec/models/readme_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 RSpec.describe Readme, type: :model do
   let(:work) { FactoryBot.create :draft_work }
   let(:s3_files) { [FactoryBot.build(:s3_file, work: work), FactoryBot.build(:s3_file, filename: "filename-2.txt", work: work)] }
-  let(:readme) { described_class.new(work) }
+  let(:readme) { described_class.new(work, User.find(work.created_by_user_id)) }
   let(:fake_s3_service) { stub_s3 data: s3_files }
 
   before do
@@ -34,7 +34,7 @@ RSpec.describe Readme, type: :model do
     end
 
     it "attaches the file and renames to to README" do
-      expect(readme.attach(uploaded_file)).to be_nil
+      expect { expect(readme.attach(uploaded_file)).to be_nil }.to change { UploadSnapshot.count }.by 1
       expect(fake_s3_service).to have_received(:upload_file).with(io: uploaded_file.to_io, filename: "README.csv")
     end
 
@@ -50,7 +50,7 @@ RSpec.describe Readme, type: :model do
         let(:s3_files) { [FactoryBot.build(:s3_file, work: work), FactoryBot.build(:s3_readme, work: work)] }
 
         it "returns no error message" do
-          expect(readme.attach(uploaded_file)).to be_nil
+          expect { expect(readme.attach(uploaded_file)).to be_nil }.to change { UploadSnapshot.count }.by 0
           expect(fake_s3_service).not_to have_received(:upload_file)
         end
       end
@@ -71,7 +71,7 @@ RSpec.describe Readme, type: :model do
       let(:s3_files) { [FactoryBot.build(:s3_file, work: work), FactoryBot.build(:s3_readme, work: work)] }
 
       it "returns no error message" do
-        expect(readme.attach(uploaded_file)).to be_nil
+        expect { expect(readme.attach(uploaded_file)).to be_nil }.to change { UploadSnapshot.count }.by 1
         expect(fake_s3_service).to have_received(:upload_file).with(io: uploaded_file.to_io, filename: "README.csv")
         expect(fake_s3_service).to have_received(:delete_s3_object).with(s3_files.last.key)
       end

--- a/spec/support/s3_query_service_specs.rb
+++ b/spec/support/s3_query_service_specs.rb
@@ -24,6 +24,7 @@ def mock_methods(fake_s3_query, data)
   allow(fake_s3_query).to receive(:publish_files).and_return([])
   allow(fake_s3_query).to receive(:upload_file).and_return(true)
   allow(fake_s3_query).to receive(:md5).and_return(nil)
+  allow(fake_s3_query).to receive(:last_response).and_return Aws::S3::Types::PutObjectOutput.new(etag: "\"abc123\"")
 end
 
 def mock_bucket(bucket_url)


### PR DESCRIPTION
This allows the readme to be show as uploaded by the correct user 
Had to change the model to allow for the current_user to be passed in 
Also needed access to the checksum from the S3 upload so added a last response attribute onto the S3QueryService

refs #1329