### PR TITLE
Move the WorkActivity::MIGRATION_START to before the dspace migration so that it can be completed successfully if there are no globus files

### DIFF
--- a/app/controllers/work_migration_controller.rb
+++ b/app/controllers/work_migration_controller.rb
@@ -20,12 +20,8 @@ class WorkMigrationController < ApplicationController
   private
 
     def run_migration(work)
-      dspace = PULDspaceMigrate.new(work)
+      dspace = PULDspaceMigrate.new(work, current_user)
       dspace.migrate
       flash[:notice] = dspace.migration_message
-      WorkActivity.add_work_activity(work.id, { migration_id: dspace.migration_snapshot.id,
-                                                message: dspace.migration_message, file_count: dspace.file_keys.count,
-                                                directory_count: dspace.directory_keys.count }.to_json,
-                                     current_user.id, activity_type: WorkActivity::MIGRATION_START)
     end
 end

--- a/spec/controllers/works_migration_controller_spec.rb
+++ b/spec/controllers/works_migration_controller_spec.rb
@@ -25,8 +25,10 @@ RSpec.describe WorkMigrationController do
       post :migrate, params: { id: work.id }
       expect(response).to redirect_to work_path(work)
       expect(flash[:notice]).to eq("Migration for 3 files was queued for processing")
-      expect(work.work_activity.count).to eq(1)
-      expect(work.work_activity.first.message).to eq("{\"migration_id\":null,\"message\":\"Migration for 3 files was queued for processing\",\"file_count\":2,\"directory_count\":2}")
+      # Since we are mocking the PULDspaceMigrate class and the work activity was moved into the class for better timing,
+      #  the work activity count is now zero
+      expect(work.work_activity.count).to eq(0)
+      expect(fake_dpsace_data).to have_received(:migrate)
     end
   end
 


### PR DESCRIPTION


fixes #1324