### PR TITLE
Ensure that group administrators who are non-depositor users for any given Work are still authorized to mark the Work as complete

### DIFF
--- a/app/decorators/work_decorator.rb
+++ b/app/decorators/work_decorator.rb
@@ -13,16 +13,20 @@ class WorkDecorator
     @can_curate = current_user&.can_admin?(group)
   end
 
+  def current_user_is_admin?
+    current_user.has_role?(:group_admin, group)
+  end
+
   def show_approve_button?
-    work.awaiting_approval? && current_user.has_role?(:group_admin, group)
+    work.awaiting_approval? && current_user_is_admin?
   end
 
   def show_complete_button?
-    draft? && work.created_by_user_id == current_user.id
+    draft? && (work.created_by_user_id == current_user.id || current_user_is_admin?)
   end
 
   def show_migrate_button?
-    draft? && migrated && current_user.has_role?(:group_admin, group)
+    draft? && migrated && current_user_is_admin?
   end
 
   def wizard_mode?

--- a/spec/decorators/work_decorator_spec.rb
+++ b/spec/decorators/work_decorator_spec.rb
@@ -6,11 +6,48 @@ describe WorkDecorator, type: :model do
   let(:user) { FactoryBot.create(:user) }
   let(:work) { FactoryBot.create(:draft_work) }
 
-  it "delgate methods" do
+  it "delegate methods" do
     expect(decorator.group).to eq(work.group)
     expect(decorator.resource).to eq(work.resource)
     expect(decorator.migrated).to be_falsey
     work.resource.migrated = true
     expect(decorator.migrated).to be_truthy
+  end
+
+  describe "#show_complete_button?" do
+    let(:group) { Group.default }
+    let(:user) { FactoryBot.create(:user) }
+    let(:depositor) { FactoryBot.create(:user) }
+    let(:work) { FactoryBot.create(:draft_work, created_by_user_id: depositor.id, group: user.default_group) }
+
+    before do
+      Group.create_defaults
+      user
+    end
+
+    context "when the work is not in the draft state" do
+      let(:work) { FactoryBot.create(:approved_work, created_by_user_id: depositor.id, group: user.default_group) }
+
+      it "does not allow the current user to mark the item complete" do
+        expect(decorator.group).to eq(work.group)
+        expect(decorator.show_complete_button?).to be false
+      end
+    end
+
+    context "when the work belongs to a group" do
+      context "and the current user is an admin for the group" do
+        let(:user) { FactoryBot.create(:user, groups_to_admin: [group]) }
+
+        it "allows the current user to mark the item complete" do
+          expect(decorator.group).to eq(work.group)
+          expect(decorator.show_complete_button?).to be true
+        end
+      end
+
+      it "does not allow the current user to mark the item complete" do
+        expect(decorator.group).to eq(work.group)
+        expect(decorator.show_complete_button?).to be false
+      end
+    end
   end
 end


### PR DESCRIPTION
Resolves #1313 