### PR TITLE
Added a BackgroundUploadSnapshot to link all the uploaded files to a single activity

### DIFF
--- a/app/jobs/attach_file_to_work_job.rb
+++ b/app/jobs/attach_file_to_work_job.rb
@@ -3,27 +3,33 @@
 class AttachFileToWorkJob < ApplicationJob
   queue_as :default
 
-  def perform(work_id:, user_id:, file_path:, file_name:, size:)
-    @work_id = work_id
-    @user_id = user_id
-
+  def perform(file_path:, file_name:, size:, background_upload_snapshot_id:)
     @file_path = file_path
     @file_name = file_name
     @size = size
+
+    @background_upload_snapshot_id = background_upload_snapshot_id
 
     File.open(file_path) do |file|
       unless work.s3_query_service.upload_file(io: file.to_io, filename: file_name)
         raise "An error uploading #{file_name} was encountered for work #{work}"
       end
     end
+    File.delete(file_path)
 
-    work.track_change(:added, @file_name)
-    work.log_file_changes(@user_id)
+    background_upload_snapshot.with_lock do
+      background_upload_snapshot.mark_complete(file_name, work.s3_query_service.last_response.etag.delete('"'))
+      background_upload_snapshot.save!
+    end
   end
 
   private
 
+    def background_upload_snapshot
+      @background_upload_snapshot ||= BackgroundUploadSnapshot.find(@background_upload_snapshot_id)
+    end
+
     def work
-      @work ||= Work.find(@work_id)
+      @work ||= background_upload_snapshot.work
     end
 end

--- a/app/models/background_upload_snapshot.rb
+++ b/app/models/background_upload_snapshot.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+class BackgroundUploadSnapshot < UploadSnapshot
+  def store_files(uploaded_files, pre_existing_files: [], current_user: nil)
+    save # needed so I can point to this snapshot in the files to distinguish new files from existing ones froma past snapshot
+    self.files = uploaded_files.map do |file|
+      { "filename" => prefix_filename(file.original_filename),
+        "upload_status" => "started", user_id: current_user&.id, snapshot_id: id }
+    end
+    files.concat pre_existing_files if pre_existing_files.present?
+  end
+
+  def mark_complete(filename, checksum)
+    index = files.index { |file| file["filename"] == prefix_filename(filename) }
+    if index.nil?
+      Rails.logger.error("Uploaded a file that was not part of the orginal Upload: #{id} for work #{work_id}: #{filename}")
+      Honeybadger.notify("Uploaded a file that was not part of the orginal Upload: #{id} for work #{work_id}: #{filename}")
+    else
+      files[index]["upload_status"] = "complete"
+      files[index]["checksum"] = checksum
+    end
+    finalize_upload if upload_complete?
+    save
+  end
+
+  def upload_complete?
+    files.select { |file| file.keys.include?("upload_status") }.map { |file| file["upload_status"] }.uniq == ["complete"]
+  end
+
+  def existing_files
+    super.select { |file| file["upload_status"].nil? || file["upload_status"] == "complete" }
+  end
+
+  def new_files
+    files.select { |file| file["snapshot_id"] == id }
+  end
+
+  def finalize_upload
+    new_files.each do |file|
+      work.track_change(:added, file["filename"])
+    end
+    work.log_file_changes(new_files.first["user_id"])
+  end
+
+  def prefix_filename(filename)
+    "#{work.prefix}#{filename}"
+  end
+end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -436,7 +436,7 @@ class Work < ApplicationRecord
     s3_query_service.client
   end
 
-  delegate :bucket_name, to: :s3_query_service
+  delegate :bucket_name, :prefix, to: :s3_query_service
 
   # Generates the S3 Object key
   # @return [String]

--- a/spec/models/background_upload_snapshot_spec.rb
+++ b/spec/models/background_upload_snapshot_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe BackgroundUploadSnapshot, type: :model do
+  subject(:background_upload_snapshot) { described_class.create(files: [], url: "example.com", work: work, id: 123) }
+  let(:work) { FactoryBot.create(:approved_work) }
+  let(:uploaded_file1) { fixture_file_upload("us_covid_2019.csv", "text/csv") }
+  let(:uploaded_file2) { fixture_file_upload("us_covid_2020.csv", "text/csv") }
+
+  describe "#count" do
+    it "only counts the bacground uploads" do
+      background_upload_snapshot
+      UploadSnapshot.create(files: [], url: "example", work: work)
+      expect(BackgroundUploadSnapshot.count).to eq(1)
+    end
+  end
+
+  describe "#store_files" do
+    it "lists filenames associated with the snapshot" do
+      background_upload_snapshot.store_files([uploaded_file1, uploaded_file2])
+      expect(background_upload_snapshot.files).to eq([{ "filename" => "#{work.prefix}us_covid_2019.csv", "upload_status" => "started", "user_id" => nil, "snapshot_id" => 123 },
+                                                      { "filename" => "#{work.prefix}us_covid_2020.csv", "upload_status" => "started", "user_id" => nil, "snapshot_id" => 123 }])
+      expect(background_upload_snapshot.existing_files).to eq([])
+      expect(background_upload_snapshot.upload_complete?).to be_falsey
+    end
+
+    context "with a user" do
+      let(:user) { FactoryBot.create :user }
+      it "lists filenames and user associated with the snapshot" do
+        background_upload_snapshot.store_files([uploaded_file1, uploaded_file2], current_user: user)
+        expect(background_upload_snapshot.files).to eq([{ "filename" => "#{work.prefix}us_covid_2019.csv", "upload_status" => "started", "user_id" => user.id, "snapshot_id" => 123 },
+                                                        { "filename" => "#{work.prefix}us_covid_2020.csv", "upload_status" => "started", "user_id" => user.id, "snapshot_id" => 123 }])
+        expect(background_upload_snapshot.existing_files).to eq([])
+        expect(background_upload_snapshot.upload_complete?).to be_falsey
+      end
+    end
+  end
+
+  describe "#mark_complete" do
+    it "changes the status" do
+      allow(Honeybadger).to receive(:notify)
+      background_upload_snapshot.store_files([uploaded_file1, uploaded_file2])
+      expect(work.work_activity.count).to eq(0)
+      background_upload_snapshot.mark_complete(uploaded_file2.original_filename, "checksumabc123")
+      expect(work.work_activity.count).to eq(0)
+      expect(background_upload_snapshot.files).to eq([{ "filename" => "#{work.prefix}us_covid_2019.csv", "upload_status" => "started", "user_id" => nil, "snapshot_id" => 123 },
+                                                      { "filename" => "#{work.prefix}us_covid_2020.csv", "upload_status" => "complete", "user_id" => nil, "checksum" => "checksumabc123",
+                                                        "snapshot_id" => 123 }])
+      expect(background_upload_snapshot.upload_complete?).to be_falsey
+      expect(background_upload_snapshot.existing_files).to eq([{ "filename" => "#{work.prefix}us_covid_2020.csv", "upload_status" => "complete", "user_id" => nil, "checksum" => "checksumabc123",
+                                                                 "snapshot_id" => 123 }])
+      background_upload_snapshot.mark_complete(uploaded_file1.original_filename, "checksumdef456")
+      expect(background_upload_snapshot.upload_complete?).to be_truthy
+      expect(background_upload_snapshot.existing_files).to eq([{ "filename" => "#{work.prefix}us_covid_2019.csv", "upload_status" => "complete",
+                                                                 "user_id" => nil, "checksum" => "checksumdef456", "snapshot_id" => 123 },
+                                                               { "filename" => "#{work.prefix}us_covid_2020.csv", "upload_status" => "complete", "user_id" => nil, "checksum" => "checksumabc123",
+                                                                 "snapshot_id" => 123 }])
+      expect(work.work_activity.count).to eq(1)
+      expect(work.work_activity.first.message).to eq("[{\"action\":\"added\",\"filename\":\"#{work.prefix}us_covid_2019.csv\"}"\
+      ",{\"action\":\"added\",\"filename\":\"#{work.prefix}us_covid_2020.csv\"}]")
+      expect(work.work_activity.first.created_by_user_id).to eq(nil)
+    end
+  end
+end

--- a/spec/requests/works_spec.rb
+++ b/spec/requests/works_spec.rb
@@ -114,16 +114,17 @@ RSpec.describe "/works", type: :request do
           get work_url(work)
 
           expect(response.code).to eq "200"
+          background_snapshot = BackgroundUploadSnapshot.last
+          expect(background_snapshot.work).to eq(work)
+          expect(background_snapshot.files.map { |file| file["user_id"] }.uniq).to eq([user.id])
           expect(AttachFileToWorkJob).to have_received(:perform_later).with(
-            user_id: user.id,
-            work_id: work.id,
+            background_upload_snapshot_id: background_snapshot.id,
             size: 92,
             file_name: "us_covid_2019.csv",
             file_path: anything
           )
           expect(AttachFileToWorkJob).to have_received(:perform_later).with(
-            user_id: user.id,
-            work_id: work.id,
+            background_upload_snapshot_id: background_snapshot.id,
             size: 114,
             file_name: "us_covid_2020.csv",
             file_path: anything


### PR DESCRIPTION
Tied it into WorkUploadsEditService and AttachFileToWork job to make the additions occur in a single activity

Additionally fixed the bug where the temp file gets deleted before the background job can process it: `Error performing AttachFileToWorkJob (Job ID: 342410b4-b9bb-4b04-b0f6-3a2ca2747c6c) from Inline(default) in 397.6ms: ActiveStorage::FileNotFoundError (ActiveStorage::FileNotFoundError)`

The above error was being created when the temp file was unlinked before it could be attached.

See https://pdc-describe-staging.princeton.edu/describe/works/439 for a successful run in which all files uploaded attached and got marked as being attached by me...