### PR TITLE
Allow the Group Administrator to set the DOI

### DIFF
--- a/app/views/works/_form_hidden_fields.html.erb
+++ b/app/views/works/_form_hidden_fields.html.erb
@@ -12,7 +12,7 @@
   <input type="text" id="deleted_files_count" name="work[deleted_files_count]" value="0" class="hidden" />
 
   <% if @wizard_mode || ( @work&.doi&.present? &&  @work.persisted?) %>
-    <input type="text" id="doi" name="doi" value="<%= @work&.resource&.doi %>" class="hidden" />
+    <input type="text" id="doi_read_only" name="doi_read_only" value="<%= @work&.resource&.doi %>" class="hidden" />
   <% end %>
 
   <% if @wizard_mode %>

--- a/app/views/works/_required_form.html.erb
+++ b/app/views/works/_required_form.html.erb
@@ -6,7 +6,7 @@
     This unique identifier will become searchable at the completion of this process.
   </p>
   <% if @wizard_mode %>
-    <input id="doi" name="doi" value="<%= @work.resource.doi %>" readonly/>
+    <input id="doi_read_only" name="doi_read_only" value="<%= @work.resource.doi %>" readonly/>
   <% else %>
     <p>DOI: <%= @work.resource.doi %></p>
   <% end %>

--- a/spec/system/work_edit_spec.rb
+++ b/spec/system/work_edit_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe "Creating and updating works", type: :system, js: true do
   #   end
   # end
 
-  context "as a user without curator privileges" do
+  context "as a user without group admin privileges" do
     let(:work) { FactoryBot.create(:distinct_cytoskeletal_proteins_work) }
     let(:user) { work.created_by_user }
 
@@ -319,6 +319,33 @@ RSpec.describe "Creating and updating works", type: :system, js: true do
 
       # The +1 in here is to account for the control for file list page size that DataTables adds to the file list
       expect(page.all("select[disabled]").count + 1).to eq(page.all("select").count) # all selects inputs on curator controlled metadata should be disabled
+    end
+  end
+
+  context "as a user with group admin privileges" do
+    let(:work) { FactoryBot.create(:distinct_cytoskeletal_proteins_work) }
+    let(:user) { FactoryBot.create :research_data_moderator }
+
+    it "renders the curator controlled metadata as read-only" do
+      sign_in user
+      visit edit_work_path(work)
+      click_on "Curator Controlled"
+
+      fill_in "publisher", with: "New Publisher"
+      fill_in "publication_year", with: "1996"
+      fill_in "doi", with: "10.34770/123"
+      fill_in "ark", with: "ark:/11111/abc12345678901"
+      fill_in "resource_type", with: "Something"
+      fill_in "collection_tags", with: "tag1, tag2"
+      click_on "Save"
+
+      work.reload
+      expect(work.resource.publisher).to eq("New Publisher")
+      expect(work.resource.publication_year).to eq("1996")
+      expect(work.doi).to eq("10.34770/123")
+      expect(work.ark).to eq("ark:/11111/abc12345678901")
+      expect(work.resource.resource_type).to eq("Something")
+      expect(work.resource.collection_tags).to eq(["tag1", "tag2"])
     end
   end
 end


### PR DESCRIPTION
refs #1325
Although we would not expect the administrator to blank the DOI, we would expect the administrator to have the ability to set the DOI to a new value.  The DOI being show on another part of the form was overriding the DOI on the curator controlled metadata form