### PR TITLE
Introduces a "Migration" mode for new Datasets

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -41,7 +41,7 @@ class WorksController < ApplicationController
   def create
     @work = Work.new(created_by_user_id: current_user.id, group_id: params_group_id, user_entered_doi: params["doi"].present?)
     @work.resource = FormToResourceService.convert(params, @work)
-    @work.resource.migrated = (params[:submit] == "Migrate")
+    @work.resource.migrated = migrated?
     if @work.valid?
       @work.draft!(current_user)
       upload_service = WorkUploadsEditService.new(@work, current_user)
@@ -302,6 +302,13 @@ class WorksController < ApplicationController
     end
   end
 
+  def migrating?
+    return false unless @work&.resource && params.key?(:migrate)
+
+    params[:migrate]
+  end
+  helper_method :migrating?
+
   private
 
     def work_params
@@ -414,6 +421,12 @@ class WorksController < ApplicationController
         end
         group_id
       end
+    end
+
+    def migrated?
+      return false unless params.key?(:submit)
+
+      params[:submit] == "Migrate"
     end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/views/shared/_user_actions.html.erb
+++ b/app/views/shared/_user_actions.html.erb
@@ -7,6 +7,7 @@
     <%= link_to "My Profile", edit_user_path(current_user), class: "dropdown-item my-profile", role: "menuitem" %>
     <% if current_user.moderator? %>
       <%= link_to "Create Dataset", new_work_path, class: "dropdown-item", role: "menuitem" %>
+      <%= link_to "Migrate Dataset", new_work_path(migrate: true), class: "dropdown-item", role: "menuitem" %>
     <% end %>
     <%= link_to "Notifications", work_activity_notifications_path, class: "dropdown-item my-profile", role: "menuitem" %>
     <%= link_to "Log Out", main_app.destroy_user_session_path, class: 'dropdown-item log-out', role: "menuitem" %>

--- a/app/views/works/_form.html.erb
+++ b/app/views/works/_form.html.erb
@@ -67,8 +67,7 @@
         <% if @work.persisted? %>
           <%= form.submit "Save Work", class: "btn btn-primary wizard-next-button", id: "btn-submit" %>
         <% else %>
-          <%= form.submit "Create", class: "btn btn-primary wizard-next-button", id: "btn-submit", name: "submit" %>
-          <%= form.submit "Migrate", class: "btn btn-secondary migrate-button", id: "btn-submit", name: "submit" %>
+          <%= form.submit (migrating? ? "Migrate" : "Create"), class: "btn btn-primary wizard-next-button", id: "btn-submit", name: "submit" %>
         <% end %>
       </div>
 

--- a/app/views/works/new.html.erb
+++ b/app/views/works/new.html.erb
@@ -24,7 +24,7 @@
 </style>
 
 <div class="wizard-area">
-  <h1>Create a Dataset</h1>
+  <h1><%= migrating? ? "Migrate" : "Create" %> a Dataset</h1>
   <%= render 'form' %>
 </div>
 

--- a/spec/system/data_migration/attention_form_submission_spec.rb
+++ b/spec/system/data_migration/attention_form_submission_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Form submission for migrating attention", type: :system, mock_ez
   context "migrate record from dataspace" do
     it "produces and saves a valid datacite record" do
       sign_in user
-      visit "/works/new"
+      visit "/works/new?migrate=true"
       fill_in "title_main", with: title
       fill_in "description", with: description
       select "Creative Commons Attribution 4.0 International", from: "rights_identifiers"

--- a/spec/system/data_migration/baldwin_form_submission_spec.rb
+++ b/spec/system/data_migration/baldwin_form_submission_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Form submission for migrating baldwin", type: :system, mock_ezid
   context "migrate record from dataspace" do
     it "produces and saves a valid datacite record" do
       sign_in user
-      visit "/works/new"
+      visit "/works/new?migrate=true"
       fill_in "title_main", with: title
       fill_in "description", with: description
       select "Creative Commons Attribution 4.0 International", from: "rights_identifiers"

--- a/spec/system/data_migration/bitklavier_form_submission_spec.rb
+++ b/spec/system/data_migration/bitklavier_form_submission_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Form submission for migrating bitklavier", type: :system, mock_e
   context "migrate record from dataspace" do
     it "produces and saves a valid datacite record" do
       sign_in user
-      visit "/works/new"
+      visit "/works/new?migrate=true"
       fill_in "title_main", with: title
       fill_in "description", with: description
       select "Creative Commons Attribution 4.0 International", from: "rights_identifiers"

--- a/spec/system/data_migration/bitklavierimage_form_submission_spec.rb
+++ b/spec/system/data_migration/bitklavierimage_form_submission_spec.rb
@@ -25,7 +25,7 @@ Piano Bar: Earthworks—omni-directionals. This microphone system suspends omnid
   context "migrate record from dataspace" do
     it "produces and saves a valid datacite record" do
       sign_in user
-      visit "/works/new"
+      visit "/works/new?migrate=true"
       fill_in "title_main", with: title
       fill_in "description", with: description
       select "Creative Commons Attribution 4.0 International", from: "rights_identifiers"

--- a/spec/system/data_migration/cklibrary_form_submission_spec.rb
+++ b/spec/system/data_migration/cklibrary_form_submission_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Form submission for migrating cklibrary", type: :system, mock_ez
   context "migrate record from dataspace" do
     it "produces and saves a valid datacite record" do
       sign_in user
-      visit "/works/new"
+      visit "/works/new?migrate=true"
       fill_in "title_main", with: title
       click_on "btn-add-title"
       fill_in "new_title_1", with: alternative_title

--- a/spec/system/data_migration/cytoskeletal_form_submission_spec.rb
+++ b/spec/system/data_migration/cytoskeletal_form_submission_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Form submission for migrating cytoskeletal", type: :system, mock
   context "migrate record from dataspace" do
     it "produces and saves a valid datacite record" do
       sign_in user
-      visit "/works/new"
+      visit "/works/new?migrate=true"
       fill_in "title_main", with: title
       fill_in "description", with: description
       select "Creative Commons Attribution 4.0 International", from: "rights_identifiers"

--- a/spec/system/data_migration/design_arrangment_form_submission_spec.rb
+++ b/spec/system/data_migration/design_arrangment_form_submission_spec.rb
@@ -25,7 +25,7 @@ Consult the file README.txt for a more detailed description of the contents."
   context "migrate record from dataspace" do
     it "produces and saves a valid datacite record" do
       sign_in user
-      visit "/works/new"
+      visit "/works/new?migrate=true"
       fill_in "title_main", with: title
       fill_in "description", with: description
       select "Creative Commons Attribution 4.0 International", from: "rights_identifiers"

--- a/spec/system/data_migration/dynamic_tension_form_submission_spec.rb
+++ b/spec/system/data_migration/dynamic_tension_form_submission_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Form submission for migrating dynamic-tension", type: :system, m
   context "migrate record from dataspace" do
     it "produces and saves a valid datacite record" do
       sign_in user
-      visit "/works/new"
+      visit "/works/new?migrate=true"
       fill_in "title_main", with: title
       fill_in "description", with: description
       select "Creative Commons Attribution 4.0 International", from: "rights_identifiers"

--- a/spec/system/data_migration/electromagnetic_form_submission_spec.rb
+++ b/spec/system/data_migration/electromagnetic_form_submission_spec.rb
@@ -25,7 +25,7 @@ This data set includes the data visualized in figures 2-7 in Electromagnetic tot
   context "migrate record from dataspace" do
     it "produces and saves a valid datacite record" do
       sign_in user
-      visit "/works/new"
+      visit "/works/new?migrate=true"
       fill_in "title_main", with: title
       fill_in "description", with: description
       select "Creative Commons Attribution 4.0 International", from: "rights_identifiers"

--- a/spec/system/data_migration/femtosecond_form_submission_spec.rb
+++ b/spec/system/data_migration/femtosecond_form_submission_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Form submission for migrating femtosecond", type: :system, mock_
   context "migrate record from dataspace" do
     it "produces and saves a valid datacite record" do
       sign_in user
-      visit "/works/new"
+      visit "/works/new?migrate=true"
       fill_in "title_main", with: title
       fill_in "description", with: description
       select "Creative Commons Attribution 4.0 International", from: "rights_identifiers"

--- a/spec/system/data_migration/flume_form_submission_spec.rb
+++ b/spec/system/data_migration/flume_form_submission_spec.rb
@@ -23,7 +23,7 @@ The attached readme.txt file explains the data attributes"
   context "migrate record from dataspace" do
     it "produces and saves a valid datacite record" do
       sign_in user
-      visit "/works/new"
+      visit "/works/new?migrate=true"
       fill_in "title_main", with: title
       fill_in "description", with: description
       select "Creative Commons Attribution 4.0 International", from: "rights_identifiers"

--- a/spec/system/data_migration/fusion_energy_form_submission_spec.rb
+++ b/spec/system/data_migration/fusion_energy_form_submission_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Form submission for migrating fusion energy", type: :system, moc
   context "migrate record from dataspace" do
     it "produces and saves a valid datacite record" do
       sign_in user
-      visit "/works/new"
+      visit "/works/new?migrate=true"
       fill_in "title_main", with: title
       fill_in "description", with: description
       select "Creative Commons Attribution 4.0 International", from: "rights_identifiers"

--- a/spec/system/data_migration/hybrid_drift_form_submission_spec.rb
+++ b/spec/system/data_migration/hybrid_drift_form_submission_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Form submission for migrating Thomson Scattering", type: :system
   context "migrate record from dataspace" do
     it "produces and saves a valid datacite record" do
       sign_in user
-      visit "/works/new"
+      visit "/works/new?migrate=true"
       fill_in "title_main", with: title
       fill_in "description", with: description
       select "Creative Commons Attribution 4.0 International", from: "rights_identifiers"

--- a/spec/system/data_migration/ion_orbital_form_submission_spec.rb
+++ b/spec/system/data_migration/ion_orbital_form_submission_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Form submission for ion orbital", type: :system, mock_ezid_api: 
   context "migrate record from dataspace" do
     it "produces and saves a valid datacite record" do
       sign_in user
-      visit "/works/new"
+      visit "/works/new?migrate=true"
       fill_in "title_main", with: title
       fill_in "description", with: description
       select "Creative Commons Attribution 4.0 International", from: "rights_identifiers"

--- a/spec/system/data_migration/non_axisymmetric_form_submission_spec.rb
+++ b/spec/system/data_migration/non_axisymmetric_form_submission_spec.rb
@@ -27,7 +27,7 @@ File name: SourceData.xlsx Description: source data for the 8 figures in the mai
   context "migrate record from dataspace" do
     it "produces and saves a valid datacite record" do
       sign_in user
-      visit "/works/new"
+      visit "/works/new?migrate=true"
       fill_in "title_main", with: title
       fill_in "description", with: description
       select "Creative Commons Attribution 4.0 International", from: "rights_identifiers"

--- a/spec/system/data_migration/observation_axisymmetric_form_submission_spec.rb
+++ b/spec/system/data_migration/observation_axisymmetric_form_submission_spec.rb
@@ -27,7 +27,7 @@ Source data for Figure 2, Figure 4, Figure 5 and Figure 7 of the article Observa
   context "migrate record from dataspace" do
     it "produces and saves a valid datacite record" do
       sign_in user
-      visit "/works/new"
+      visit "/works/new?migrate=true"
       fill_in "title_main", with: title
       fill_in "description", with: description
       select "Creative Commons Attribution 4.0 International", from: "rights_identifiers"

--- a/spec/system/data_migration/sowingseeds_form_submission_spec.rb
+++ b/spec/system/data_migration/sowingseeds_form_submission_spec.rb
@@ -30,7 +30,7 @@ Download the README.txt for a detailed description of this dataset's content."
       stub_s3
       sign_in user
       # we need to use the wizard because this work does not have a doi and it needs one to be registered
-      visit "/works/new"
+      visit "/works/new?migrate=true"
       fill_in "title_main", with: title
       find("tr:last-child input[name='creators[][orcid]']").set ""
       find("tr:last-child input[name='creators[][given_name]']").set "Samantha"

--- a/spec/system/data_migration/spindle_form_submission_spec.rb
+++ b/spec/system/data_migration/spindle_form_submission_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Form submission for migrating Sleeo spindle", type: :system, moc
   context "migrate record from dataspace" do
     it "produces and saves a valid datacite record" do
       sign_in user
-      visit "/works/new"
+      visit "/works/new?migrate=true"
       fill_in "title_main", with: title
       fill_in "description", with: description
       select "Creative Commons Attribution 4.0 International", from: "rights_identifiers"

--- a/spec/system/data_migration/thomson_scattering_form_submission_spec.rb
+++ b/spec/system/data_migration/thomson_scattering_form_submission_spec.rb
@@ -28,7 +28,7 @@ Please consult the file README.txt for a description of the archive contents."
   context "migrate record from dataspace" do
     it "produces and saves a valid datacite record" do
       sign_in user
-      visit "/works/new"
+      visit "/works/new?migrate=true"
       fill_in "title_main", with: title
       fill_in "description", with: description
       select "Creative Commons Attribution 4.0 International", from: "rights_identifiers"

--- a/spec/system/migrate_submission_spec.rb
+++ b/spec/system/migrate_submission_spec.rb
@@ -81,8 +81,8 @@ RSpec.describe "Form submission for a legacy dataset", type: :system, mock_ezid_
       sign_in user
       visit user_path(user)
       click_on(user.uid)
-      expect(page).to have_link("Create Dataset")
-      click_on "Create Dataset"
+      expect(page).to have_link("Migrate Dataset")
+      click_on "Migrate Dataset"
       fill_in "title_main", with: title
       fill_in "creators[][given_name]", with: "Samantha"
       fill_in "creators[][family_name]", with: "Abrams"


### PR DESCRIPTION
Introducing two modes for new Datasets: creation and migration. This ensures that uses who access the new Dataset form using the migration mode are forced to migrate from an existing Dataset resource.

Advances #1396, as @carolyncole has identified that users may be unknowingly trigger this behavior should they unintentionally overlook the proper `Migrate` button on the form.

![image](https://github.com/pulibrary/pdc_describe/assets/1443986/f6a9b041-a351-46b6-996b-def1dcbdfec2)
![image](https://github.com/pulibrary/pdc_describe/assets/1443986/8a9d5ad2-81a4-4265-97c2-ce19380d5f15)
![image](https://github.com/pulibrary/pdc_describe/assets/1443986/207098c4-0c10-4413-99c9-0b6daeee0ac6)

