### PR TITLE
Make sure the error gets noted by returning false

### DIFF
--- a/app/services/s3_query_service.rb
+++ b/app/services/s3_query_service.rb
@@ -275,6 +275,7 @@ class S3QueryService
     false
   rescue Aws::Errors::ServiceError => aws_service_error
     Rails.logger.error("An error was encountered when requesting to create the AWS S3 Object in the bucket #{bucket_name} with the key #{key}: #{aws_service_error}")
+    false
   end
 
   def check_file(bucket:, key:)

--- a/spec/services/s3_query_service_spec.rb
+++ b/spec/services/s3_query_service_spec.rb
@@ -605,7 +605,7 @@ XML
       it "logs the error" do
         s3_query_service = described_class.new(work)
         result = s3_query_service.upload_file(io: file, filename: filename)
-        expect(result).to be nil
+        expect(result).to be false
         # rubocop:disable Layout/LineLength
         expect(Rails.logger).to have_received(:error).with("An error was encountered when requesting to create the AWS S3 Object in the bucket example-bucket with the key #{prefix}README.txt: test AWS service error")
         # rubocop:enable Layout/LineLength


### PR DESCRIPTION
When a nil was returned that passed through the if check on the key and the error that occured when uploading a large file was logged, but missed by the code