### PR TITLE
Updating the database to store if a user enables or disables group messaging

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -99,9 +99,9 @@ class UsersController < ApplicationController
           selected_group = Group.find_by(id: group_id)
 
           if parameter_enables_messaging?(param)
-            @user.enable_messages_from(group: selected_group)
+            selected_group.enable_messages_for(user: @user)
           else
-            @user.disable_messages_from(group: selected_group)
+            selected_group.disable_messages_for(user: @user)
           end
         end
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -222,36 +222,13 @@ class User < ApplicationRecord
   def assign_default_role
     @just_created = true
     add_role(:submitter, default_group) unless has_role?(:submitter, default_group)
-    enable_messages_from(group: default_group)
+    default_group.enable_messages_for(user: self)
   end
 
   # Returns true if the user has notification e-mails enabled
   # @return [Boolean]
   def email_messages_enabled?
     email_messages_enabled
-  end
-
-  # Permit this user to receive notification messages for members of a given Group
-  # @param group [Group]
-  def enable_messages_from(group:)
-    raise(ArgumentError, "User #{uid} is not an administrator or depositor for the group #{group.title}") unless can_admin?(group) || can_submit?(group)
-    group_messaging_options << GroupOption.new(option_type: GroupOption::EMAIL_MESSAGES, user: self, group: group)
-  end
-
-  # Disable this user from receiving notification messages for members of a given Group
-  # @param group [Group]
-  def disable_messages_from(group:)
-    raise(ArgumentError, "User #{uid} is not an administrator or depositor for the group #{group.title}") unless can_admin?(group) || can_submit?(group)
-    groups_with_messaging.destroy(group)
-  end
-
-  # Returns true if the user has notification e-mails enabled for a given group
-  # @param group [Group]
-  # @return [Boolean]
-  def messages_enabled_from?(group:)
-    found = group_messaging_options.find_by(group: group)
-
-    !found.nil?
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -15,7 +15,7 @@
           <% @user.submitter_or_admin_groups.each do |group| %>
             <legend><%= group.title %></legend>
             <div class="form-check">
-              <%= form.check_box("[groups_with_messaging][#{group.id}]", { id: "group_messaging_#{group.id}", checked: user.messages_enabled_from?(group: group), class: ["form-check-input"] }) %>
+              <%= form.check_box("[groups_with_messaging][#{group.id}]", { id: "group_messaging_#{group.id}", checked: group.messages_enabled_for?(user: user), class: ["form-check-input"] }) %>
               <%= form.label("[groups_with_messaging][#{group.id}]", t("users.form.email_messages_enabled"), class: ["form-check-label"]) %>
             </div>
           <% end %>

--- a/db/migrate/20230810125820_add_enabled_and_subcommunity_to_group_option.rb
+++ b/db/migrate/20230810125820_add_enabled_and_subcommunity_to_group_option.rb
@@ -1,0 +1,10 @@
+class AddEnabledAndSubcommunityToGroupOption < ActiveRecord::Migration[6.1]
+  def up
+    add_column :group_options, :enabled, 'boolean', default: true
+    add_column :group_options, :subcommunity, 'string', default: nil
+  end
+  def down
+    remove_column :group_options, :enabled, 'boolean'
+    remove_column :group_options, :subcommunity, 'string'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_07_19_173219) do
+ActiveRecord::Schema.define(version: 2023_08_10_125820) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,8 @@ ActiveRecord::Schema.define(version: 2023_07_19_173219) do
     t.integer "option_value"
     t.bigint "group_id"
     t.bigint "user_id"
+    t.boolean "enabled", default: true
+    t.string "subcommunity"
     t.index ["group_id"], name: "index_group_options_on_group_id"
     t.index ["user_id"], name: "index_group_options_on_user_id"
   end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -63,23 +63,14 @@ RSpec.describe Group, type: :model do
       let(:user) { User.new_super_admin("test-admin") }
 
       it "disables email messages for notifications for a User" do
-        # Initially messages are disabled for the user
+        # Initially messages are enabled for the user
         state = group.messages_enabled_for?(user: user)
-        expect(state).to be false
+        expect(state).to be true
 
-        group.enable_messages_for(user: user)
-        group.save!
-        group.reload
-
-        # After enabling messages for the user, that they are enabled is verified
-        enabled_state = group.messages_enabled_for?(user: user)
-        expect(enabled_state).to be true
-
+        # After disabling messages for the user, that they are disabled is verified
         group.disable_messages_for(user: user)
         group.save!
         group.reload
-
-        # After disabling messages for the user, that they are disabled is verified
         disabled_state = group.messages_enabled_for?(user: user)
         expect(disabled_state).to be false
       end
@@ -92,17 +83,9 @@ RSpec.describe Group, type: :model do
       end
 
       it "disables email messages for notifications for a User" do
-        # Initially messages are disabled for the user
+        # Initially messages are enabled for the user
         state = group.messages_enabled_for?(user: user)
-        expect(state).to be false
-
-        group.enable_messages_for(user: user)
-        group.save!
-        group.reload
-
-        # After enabling messages for the user, that they are enabled is verified
-        enabled_state = group.messages_enabled_for?(user: user)
-        expect(enabled_state).to be true
+        expect(state).to be true
 
         group.disable_messages_for(user: user)
         group.save!
@@ -116,9 +99,9 @@ RSpec.describe Group, type: :model do
 
     it "raises an ArgumentError" do
       state = group.messages_enabled_for?(user: user)
-      expect(state).to be false
+      expect(state).to be true
 
-      expect { group.disable_messages_for(user: user) }.to raise_error(ArgumentError, "User #{user.uid} is not an administrator for this group #{group.title}")
+      expect { group.disable_messages_for(user: user) }.to raise_error(ArgumentError, "User #{user.uid} is not an administrator or submitter for this group #{group.title}")
     end
   end
 end

--- a/spec/models/work_activity_notification_spec.rb
+++ b/spec/models/work_activity_notification_spec.rb
@@ -23,7 +23,7 @@ describe WorkActivityNotification, type: :model do
 
     context "when e-mail notifications are disabled for the Group" do
       before do
-        user.disable_messages_from(group: group)
+        group.disable_messages_for(user: user)
       end
 
       it "does not enqueue an e-mail message to be delivered for the notification" do

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -136,14 +136,14 @@ RSpec.describe "/users", type: :request do
       end
 
       it "updates the notification settings for multiple groups" do
-        expect(user.messages_enabled_from?(group: group1)).to be true
-        expect(user.messages_enabled_from?(group: group2)).to be true
+        expect(group1.messages_enabled_for?(user: user)).to be true
+        expect(group2.messages_enabled_for?(user: user)).to be true
 
         patch user_url(user), params: { user: updated_attributes2 }
         user.reload
 
-        expect(user.messages_enabled_from?(group: group1)).to be false
-        expect(user.messages_enabled_from?(group: group2)).to be false
+        expect(group1.messages_enabled_for?(user: user)).to be false
+        expect(group2.messages_enabled_for?(user: user)).to be false
       end
     end
 

--- a/spec/system/user_edit_spec.rb
+++ b/spec/system/user_edit_spec.rb
@@ -47,32 +47,41 @@ RSpec.describe "Editing users", type: :system do
       visit edit_user_path(user)
       expect(page).to have_field("user_given_name", with: user.given_name)
       expect(page).to have_content "My Profile Settings"
-      expect(page).to have_unchecked_field "group_messaging_#{pppl_group.id}"
+      expect(page).to have_checked_field "group_messaging_#{pppl_group.id}"
       expect(page).to have_checked_field "group_messaging_#{rd_group.id}"
       expect(page).not_to have_field "group_messaging_#{random_group.id}"
-      check "group_messaging_#{pppl_group.id}"
+      uncheck "group_messaging_#{pppl_group.id}"
       click_on "Update"
       visit edit_user_path(user)
-      expect(page).to have_checked_field "group_messaging_#{pppl_group.id}"
+      expect(page).to have_unchecked_field "group_messaging_#{pppl_group.id}"
       expect(page).to have_checked_field "group_messaging_#{rd_group.id}"
     end
 
     context "User is super admin" do
       let(:user) { FactoryBot.create :super_admin_user }
 
-      it "shows the form with all the collections and only the default group is checked" do
+      it "shows the form with all the collections and all the groups are checked" do
         visit edit_user_path(user)
         expect(page).to have_field("user_given_name", with: user.given_name)
         expect(page).to have_content "My Profile Settings"
-        expect(page).to have_unchecked_field "group_messaging_#{pppl_group.id}"
+        expect(page).to have_checked_field "group_messaging_#{pppl_group.id}"
         expect(page).to have_checked_field "group_messaging_#{rd_group.id}"
-        expect(page).to have_unchecked_field "group_messaging_#{random_group.id}"
+        expect(page).to have_checked_field "group_messaging_#{random_group.id}"
         uncheck "group_messaging_#{rd_group.id}"
+        uncheck "group_messaging_#{pppl_group.id}"
+        uncheck "group_messaging_#{random_group.id}"
         click_on "Update"
         visit edit_user_path(user)
         expect(page).to have_unchecked_field "group_messaging_#{pppl_group.id}"
         expect(page).to have_unchecked_field "group_messaging_#{rd_group.id}"
         expect(page).to have_unchecked_field "group_messaging_#{random_group.id}"
+        check "group_messaging_#{rd_group.id}"
+        check "group_messaging_#{random_group.id}"
+        click_on "Update"
+        visit edit_user_path(user)
+        expect(page).to have_unchecked_field "group_messaging_#{pppl_group.id}"
+        expect(page).to have_checked_field "group_messaging_#{rd_group.id}"
+        expect(page).to have_checked_field "group_messaging_#{random_group.id}"
       end
     end
   end

--- a/spec/system/work_comment_spec.rb
+++ b/spec/system/work_comment_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Commenting on works sends emails or not", type: :system, js: tru
 
   context "when the user has emails disabled" do
     before do
-      user2.disable_messages_from(group: work.group)
+      work.group.disable_messages_for(user: user2)
     end
 
     it "Allows the user to comment and tag a curator and it sends an email becuase it is a direct message" do
@@ -49,7 +49,7 @@ RSpec.describe "Commenting on works sends emails or not", type: :system, js: tru
 
     context "when the curator has emails disabled" do
       before do
-        user2.disable_messages_from(group: work.group)
+        work.group.disable_messages_for(user: user2)
       end
 
       it "Allows the user to comment and tag a curator and it sends an email becuase it is a direct message" do


### PR DESCRIPTION
This allows us to default to true if nothing is found. 

Also added the sub-community field to the database so we can turn the group options on and off for a sub-community too in a later PR

refs #1383 