### PR TITLE
A UI to allow a user to choose which PPPL subcommunities are enabled for email

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -283,3 +283,26 @@ th {
 .submit-ordered-list {
   padding: 0em 3em;
 }
+
+div.form-subcommunities {
+  display: grid;
+
+  @media all and (max-width: 480px) {
+    grid-template-columns: 1fr;
+  }
+
+  @media all and (max-width: 765px) and (min-width: 481px) {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  @media all and (min-width: 765px) {
+    grid-template-columns: 1fr 1fr 1fr;
+  }
+
+}
+
+div.form-subcommunities .form-check{
+  padding: 0em 1rem;
+  margin-top: 0.5rem;
+  margin-bottom: 0;
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -95,13 +95,14 @@ class UsersController < ApplicationController
         extracted = user_params.extract!(:groups_with_messaging)
         groups_with_messaging = extracted[:groups_with_messaging]
 
-        groups_with_messaging.each_pair do |group_id, param|
+        groups_with_messaging.each_pair do |id, param|
+          group_id, subcommunity = id.split("_")
           selected_group = Group.find_by(id: group_id)
 
           if parameter_enables_messaging?(param)
-            selected_group.enable_messages_for(user: @user)
+            selected_group.enable_messages_for(user: @user, subcommunity: subcommunity)
           else
-            selected_group.disable_messages_for(user: @user)
+            selected_group.disable_messages_for(user: @user, subcommunity: subcommunity)
           end
         end
       end

--- a/app/javascript/entrypoints/pdc/email_change_all.es6
+++ b/app/javascript/entrypoints/pdc/email_change_all.es6
@@ -1,0 +1,34 @@
+/* eslint class-methods-use-this: ["error",
+  { "exceptMethods": ["change_all", "change_subcommunity", "change_parent_group"] }] */
+/* eslint-disable no-param-reassign */
+export default class EmailChangeAll {
+  attach_change() {
+    // Setup the DOI's COPY button to copy the DOI URL to the clipboard
+    document.querySelectorAll('.form-email-all').forEach((check) => check.addEventListener('change', (e) => { this.change_all(e); }));
+    document.querySelectorAll('.form-subcommunity-check').forEach((check) => check.addEventListener('change', (e) => { this.change_parent_group(e); }));
+    document.querySelectorAll('.form-group-check').forEach((check) => check.addEventListener('change', (e) => { this.change_subcommunity(e); }));
+  }
+
+  change_all(item) {
+    // Check all or uncheck all
+    document.querySelectorAll('.form-check-input').forEach((check) => { check.checked = item.currentTarget.checked; });
+  }
+
+  change_subcommunity(item) {
+    item.currentTarget.parentNode.querySelectorAll('.form-check-input').forEach((check) => { check.checked = item.currentTarget.checked; });
+
+    // make sure the all email is enabled if any sub group is enabled
+    if (item.currentTarget.checked) {
+      document.querySelector('.form-email-all').checked = item.currentTarget.checked;
+    }
+  }
+
+  change_parent_group(item) {
+    // make sure all email and = the parent group is enabled if any sub community is enabled
+    if (item.currentTarget.checked) {
+      item.currentTarget.parentNode.parentNode.parentNode.querySelectorAll('.form-group-check').forEach((check) => { check.checked = item.currentTarget.checked; });
+      document.querySelector('.form-email-all').checked = item.currentTarget.checked;
+    }
+  }
+}
+/* eslint-enable no-param-reassign */

--- a/app/javascript/entrypoints/pdc/pdc_ui_loader.es6
+++ b/app/javascript/entrypoints/pdc/pdc_ui_loader.es6
@@ -6,6 +6,7 @@ import WorkOrcid from './work_orcid.es6';
 import WorkRoR from './work_ror.es6';
 import EditTableActions from './edit_table_actions.es6';
 import WorkEditFileUpload from './work_edit_file_upload.es6';
+import EmailChangeAll from './email_change_all.es6';
 
 /* eslint class-methods-use-this: ["error", { "exceptMethods": ["setup_fileupload_validation"] }] */
 
@@ -15,16 +16,17 @@ export default class PdcUiLoader {
   }
 
   setup_fileupload_validation() {
-    (new MaximumFileUpload('patch_pre_curation_uploads', 'file-upload')).attach_validation();
-    (new MaximumFileUpload('pre_curation_uploads_added', 'btn-submit')).attach_validation();
     (new CopytoClipboard()).attach_copy();
     (new EditRequiredFields()).attach_validations();
+    (new EditTableActions()).attach_actions();
+    (new EmailChangeAll()).attach_change();
+    (new MaximumFileUpload('patch_pre_curation_uploads', 'file-upload')).attach_validation();
+    (new MaximumFileUpload('pre_curation_uploads_added', 'btn-submit')).attach_validation();
     (new ReadmeFileUpload('patch_readme_file', 'readme-upload')).attach_validation();
     (new WorkEditFileUpload('pre_curation_uploads_added', 'file-upload-list')).attach_validation();
     (new WorkOrcid('.orcid-entry-creator', 'creators[][given_name]', 'creators[][family_name]')).attach_validation();
     (new WorkOrcid('.orcid-entry-contributor', 'contributors[][given_name]', 'contributors[][family_name]')).attach_validation();
     (new WorkRoR(pdc.ror_url)).attach_query();
-    (new EditTableActions()).attach_actions();
     const datasetOptions = {
       searching: false, paging: true, info: false, order: [],
     };

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -41,18 +41,18 @@ class Group < ApplicationRecord
 
   # Permit a User to receive notification messages for members of this Group
   # @param user [User]
-  def enable_messages_for(user:)
+  def enable_messages_for(user:, subcommunity: nil)
     raise(ArgumentError, "User #{user.uid} is not an administrator or submitter for this group #{title}") unless user.can_admin?(self) || user.can_submit?(self)
-    group = GroupOption.find_or_initialize_by(option_type: GroupOption::EMAIL_MESSAGES, user: user, group: self)
+    group = GroupOption.find_or_initialize_by(option_type: GroupOption::EMAIL_MESSAGES, user: user, group: self, subcommunity: subcommunity)
     group.enabled = true
     group.save
   end
 
   # Disable a User from receiving notification messages for members of this Group
   # @param user [User]
-  def disable_messages_for(user:)
+  def disable_messages_for(user:, subcommunity: nil)
     raise(ArgumentError, "User #{user.uid} is not an administrator or submitter for this group #{title}") unless user.can_admin?(self) || user.can_submit?(self)
-    group = GroupOption.find_or_initialize_by(option_type: GroupOption::EMAIL_MESSAGES, user: user, group: self)
+    group = GroupOption.find_or_initialize_by(option_type: GroupOption::EMAIL_MESSAGES, user: user, group: self, subcommunity: subcommunity)
     group.enabled = false
     group.save
   end
@@ -60,8 +60,8 @@ class Group < ApplicationRecord
   # Returns true if a given user has notification e-mails enabled for this Group
   # @param user [User]
   # @return [Boolean]
-  def messages_enabled_for?(user:)
-    group_option = group_messaging_options.find_by(user: user, group: self)
+  def messages_enabled_for?(user:, subcommunity: nil)
+    group_option = group_messaging_options.find_by(user: user, group: self, subcommunity: subcommunity)
     group_option ||= GroupOption.new(enabled: true)
     group_option.enabled
   end

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -4,7 +4,7 @@
       <fieldset>
         <legend><%= t("users.form.email_messages") %></legend>
         <div class="form-check ">
-          <%= form.check_box(:email_messages_enabled, class: ["form-check-input"]) %>
+          <%= form.check_box(:email_messages_enabled, class: ["form-check-input","form-email-all"]) %>
           <%= label_tag(:email_messages_enabled, t("users.form.email_messages_enabled"), class: ["form-check-label"]) %>
         </div>
       </fieldset>
@@ -15,8 +15,17 @@
           <% @user.submitter_or_admin_groups.each do |group| %>
             <legend><%= group.title %></legend>
             <div class="form-check">
-              <%= form.check_box("[groups_with_messaging][#{group.id}]", { id: "group_messaging_#{group.id}", checked: group.messages_enabled_for?(user: user), class: ["form-check-input"] }) %>
+              <%= form.check_box("[groups_with_messaging][#{group.id}]", { id: "group_messaging_#{group.id}", checked: group.messages_enabled_for?(user: user), class: ["form-check-input", "form-group-check"] }) %>
               <%= form.label("[groups_with_messaging][#{group.id}]", t("users.form.email_messages_enabled"), class: ["form-check-label"]) %>
+
+              <div class="form-subcommunities">
+              <% group.subcommunities.each do |subcommunity| %>
+                <div class="form-check">
+                  <%= form.check_box("[groups_with_messaging][#{group.id}_#{subcommunity}]", { id: "group_messaging_#{group.id}_#{subcommunity}", checked: group.messages_enabled_for?(user: user, subcommunity: subcommunity), class: ["form-check-input", "form-subcommunity-check"] }) %>
+                  <%= form.label("[groups_with_messaging][#{group.id}_#{subcommunity}]", subcommunity, class: ["form-check-label"]) %>
+                </div>
+              <% end %>
+              </div>
             </div>
           <% end %>
         </fieldset>

--- a/spec/models/work_activity_notification_spec.rb
+++ b/spec/models/work_activity_notification_spec.rb
@@ -76,5 +76,86 @@ describe WorkActivityNotification, type: :model do
         end
       end
     end
+
+    context "A PPPL Submission" do
+      let(:group) { Group.plasma_laboratory }
+      let(:super_admin) { FactoryBot.create :super_admin_user }
+
+      before do
+        group.add_submitter(super_admin, user)
+      end
+
+      context "a messge notification" do
+        let(:work_activity) { FactoryBot.create(:work_activity_message, work: work, message: "direct message to @#{user.uid}") }
+
+        it "does enqueue an e-mail message to be delivered for the notification" do
+          described_class.create(user: user, work_activity: work_activity)
+          expect(message_delivery).to have_received(:deliver_later)
+        end
+      end
+
+      context "a messge notification without an @" do
+        let(:work_activity) { FactoryBot.create(:work_activity_message, work: work) }
+
+        it "does enqueue an e-mail message to be delivered for the notification" do
+          described_class.create(user: user, work_activity: work_activity)
+          expect(message_delivery).to have_received(:deliver_later)
+        end
+
+        context "when the group is disabled" do
+          before do
+            group.disable_messages_for(user: user)
+          end
+
+          it "does not enqueue an e-mail message to be delivered for the notification" do
+            described_class.create(user: user, work_activity: work_activity)
+            expect(message_delivery).not_to have_received(:deliver_later)
+          end
+        end
+
+        context "When a subcommunity is applied to the work" do
+          before do
+            work.resource.subcommunities = ["NTSXU"]
+            work.save!
+          end
+
+          it "does enqueue an e-mail message to be delivered for the notification" do
+            described_class.create(user: user, work_activity: work_activity)
+            expect(message_delivery).to have_received(:deliver_later)
+          end
+
+          it "does not enqueue an e-mail message to be delivered for the notification when the subcommunity is disabled" do
+            group.disable_messages_for(user: user, subcommunity: "NTSXU")
+            described_class.create(user: user, work_activity: work_activity)
+            expect(message_delivery).not_to have_received(:deliver_later)
+          end
+        end
+
+        context "When a multiple subcommunities are applied to the work" do
+          before do
+            work.resource.subcommunities = ["NTSXU", "MAST-U"]
+            work.save!
+          end
+
+          it "does enqueue an e-mail message to be delivered for the notification" do
+            described_class.create(user: user, work_activity: work_activity)
+            expect(message_delivery).to have_received(:deliver_later)
+          end
+
+          it "does not enqueue an e-mail message to be delivered for the notification when the subcommunities are disabled" do
+            group.disable_messages_for(user: user, subcommunity: "NTSXU")
+            group.disable_messages_for(user: user, subcommunity: "MAST-U")
+            described_class.create(user: user, work_activity: work_activity)
+            expect(message_delivery).not_to have_received(:deliver_later)
+          end
+
+          it "does enqueue an e-mail message to be delivered for the notification when only one subcommunity is disabled" do
+            group.disable_messages_for(user: user, subcommunity: "MAST-U")
+            described_class.create(user: user, work_activity: work_activity)
+            expect(message_delivery).to have_received(:deliver_later)
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/system/user_edit_spec.rb
+++ b/spec/system/user_edit_spec.rb
@@ -47,14 +47,47 @@ RSpec.describe "Editing users", type: :system do
       visit edit_user_path(user)
       expect(page).to have_field("user_given_name", with: user.given_name)
       expect(page).to have_content "My Profile Settings"
+      expect(page).to have_checked_field "user_email_messages_enabled"
       expect(page).to have_checked_field "group_messaging_#{pppl_group.id}"
       expect(page).to have_checked_field "group_messaging_#{rd_group.id}"
       expect(page).not_to have_field "group_messaging_#{random_group.id}"
+      expect(page).to have_checked_field "group_messaging_#{pppl_group.id}_Spherical Torus"
+      expect(page).to have_checked_field "group_messaging_#{pppl_group.id}_Advanced Projects"
+      expect(page).to have_checked_field "group_messaging_#{pppl_group.id}_ITER and Tokamaks"
+      expect(page).to have_checked_field "group_messaging_#{pppl_group.id}_Theory"
+      expect(page).to have_checked_field "group_messaging_#{pppl_group.id}_NSTX-U"
+      expect(page).to have_checked_field "group_messaging_#{pppl_group.id}_NSTX"
+      expect(page).to have_checked_field "group_messaging_#{pppl_group.id}_Plasma Science & Technology"
+      expect(page).to have_checked_field "group_messaging_#{pppl_group.id}_Theory and Computation"
+      expect(page).to have_checked_field "group_messaging_#{pppl_group.id}_Stellarators"
+      expect(page).to have_checked_field "group_messaging_#{pppl_group.id}_PPPL Collaborations"
+      expect(page).to have_checked_field "group_messaging_#{pppl_group.id}_MAST-U"
+      expect(page).to have_checked_field "group_messaging_#{pppl_group.id}_Other Projects"
+      expect(page).to have_checked_field "group_messaging_#{pppl_group.id}_System Studies"
       uncheck "group_messaging_#{pppl_group.id}"
       click_on "Update"
       visit edit_user_path(user)
+      expect(page).to have_checked_field "user_email_messages_enabled"
       expect(page).to have_unchecked_field "group_messaging_#{pppl_group.id}"
       expect(page).to have_checked_field "group_messaging_#{rd_group.id}"
+      expect(page).to have_unchecked_field "group_messaging_#{pppl_group.id}_MAST-U"
+      expect(page).to have_unchecked_field "group_messaging_#{pppl_group.id}_Other Projects"
+      check "group_messaging_#{pppl_group.id}_MAST-U"
+      click_on "Update"
+      visit edit_user_path(user)
+      expect(page).to have_checked_field "user_email_messages_enabled"
+      expect(page).to have_checked_field "group_messaging_#{pppl_group.id}"
+      expect(page).to have_checked_field "group_messaging_#{rd_group.id}"
+      expect(page).to have_checked_field "group_messaging_#{pppl_group.id}_MAST-U"
+      expect(page).to have_unchecked_field "group_messaging_#{pppl_group.id}_Other Projects"
+      uncheck "user_email_messages_enabled"
+      click_on "Update"
+      visit edit_user_path(user)
+      expect(page).to have_unchecked_field "user_email_messages_enabled"
+      expect(page).to have_unchecked_field "group_messaging_#{pppl_group.id}"
+      expect(page).to have_unchecked_field "group_messaging_#{rd_group.id}"
+      expect(page).to have_unchecked_field "group_messaging_#{pppl_group.id}_MAST-U"
+      expect(page).to have_unchecked_field "group_messaging_#{pppl_group.id}_Other Projects"
     end
 
     context "User is super admin" do


### PR DESCRIPTION
Javascript to check and uncheck all email checkboxes
A user must explicitly disable a subcommunity, as all emails a by default on until explicitly disabled

refs #1383