### PR TITLE
Show the PDC Discovery url on the work show page

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -541,6 +541,10 @@ class Work < ApplicationRecord
     resource.rights_many.index { |rights| rights.identifier == rights_id } != nil
   end
 
+  def doi_attribute_url
+    "https://datacommons.princeton.edu/discovery/doi/#{doi}"
+  end
+
   protected
 
     # This must be protected, NOT private for ActiveRecord to work properly with this attribute.
@@ -677,10 +681,6 @@ class Work < ApplicationRecord
     rescue Faraday::ConnectionFailed
       sleep 1
       retry
-    end
-
-    def doi_attribute_url
-      "https://datacommons.princeton.edu/discovery/doi/#{doi}"
     end
 
     def doi_attribute_resource

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -197,6 +197,13 @@
         <dd><%= link_to(@work.resource.ark, ark_url(@work.resource.ark)) %></dd>
       <% end %>
 
+      <% if @work.resource.doi %>
+        <dt>Discovery URL</dt>
+        <dd>
+          <%= link_to(@work.doi_attribute_url, @work.doi_attribute_url) %>
+        </dd>
+      <% end %>
+
       <% if @work.resource.individual_contributors.count > 0 %>
         <dt>Individual Contributors</dt>
         <dd>

--- a/spec/system/work_show_spec.rb
+++ b/spec/system/work_show_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Creating and updating works", type: :system, js: true do
     end
   end
 
-  it "foo" do
+  it "uses datatables for easy navigation" do
     sign_in user
     visit work_path(work)
 
@@ -57,6 +57,12 @@ RSpec.describe "Creating and updating works", type: :system, js: true do
     expect(page).to have_css(".dataTables_filter")
     page.driver.go_back
     page.driver.go_forward
+  end
+
+  it "shows the PDC Discovery URL" do
+    sign_in user
+    visit work_path(work)
+    expect(page).to have_link("https://datacommons.princeton.edu/discovery/doi/10.34770/r2dz-ys12")
   end
 
   it "copies DOI to the clipboard" do


### PR DESCRIPTION
This will let us more easily check whether the work has yet appeared in PDC Discovery, separate from whether the ARK and DOI redirection have worked as expected.

Ref #1399 