### PR TITLE
Adding group to the Migrate Dataset menu link

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -32,7 +32,8 @@ class WorksController < ApplicationController
 
   # Renders the "step 0" information page before creating a new dataset
   def new
-    @work = Work.new(created_by_user_id: current_user.id, group: current_user.default_group)
+    group = Group.find_by(code: params[:group_code]) || current_user.default_group
+    @work = Work.new(created_by_user_id: current_user.id, group: group)
     if wizard_mode?
       render "new_submission"
     end

--- a/app/views/shared/_user_actions.html.erb
+++ b/app/views/shared/_user_actions.html.erb
@@ -7,7 +7,12 @@
     <%= link_to "My Profile", edit_user_path(current_user), class: "dropdown-item my-profile", role: "menuitem" %>
     <% if current_user.moderator? %>
       <%= link_to "Create Dataset", new_work_path, class: "dropdown-item", role: "menuitem" %>
-      <%= link_to "Migrate Dataset", new_work_path(migrate: true), class: "dropdown-item", role: "menuitem" %>
+      <% if current_user.can_admin?(Group.research_data) %>
+        <%= link_to "Migrate PRDS Dataset", new_work_path(migrate: true, group_code: Group.research_data.code), class: "dropdown-item", role: "menuitem" %>
+      <% end %>
+      <% if current_user.can_admin?(Group.plasma_laboratory) %>
+        <%= link_to "Migrate PPPL Dataset", new_work_path(migrate: true, group_code: Group.plasma_laboratory.code), class: "dropdown-item", role: "menuitem" %>
+      <% end %>
     <% end %>
     <%= link_to "Notifications", work_activity_notifications_path, class: "dropdown-item my-profile", role: "menuitem" %>
     <%= link_to "Log Out", main_app.destroy_user_session_path, class: 'dropdown-item log-out', role: "menuitem" %>

--- a/spec/system/data_migration/attention_form_submission_spec.rb
+++ b/spec/system/data_migration/attention_form_submission_spec.rb
@@ -25,7 +25,10 @@ RSpec.describe "Form submission for migrating attention", type: :system, mock_ez
   context "migrate record from dataspace" do
     it "produces and saves a valid datacite record" do
       sign_in user
-      visit "/works/new?migrate=true"
+      visit "/"
+      click_on(user.uid)
+      expect(page).to have_link("Migrate PRDS Dataset")
+      click_on "Migrate PRDS Dataset"
       fill_in "title_main", with: title
       fill_in "description", with: description
       select "Creative Commons Attribution 4.0 International", from: "rights_identifiers"
@@ -67,6 +70,7 @@ RSpec.describe "Form submission for migrating attention", type: :system, mock_ez
       expect(page).to have_button("Migrate Dataspace Files")
       expect(page).to have_content "marked as Draft"
       expect(page).to have_content "Creative Commons Attribution 4.0 International"
+      expect(page).to have_content "Princeton Research Data Service (PRDS)"
       click_on "Complete"
       expect(page).to have_content "awaiting_approval"
       attention_work = Work.last

--- a/spec/system/data_migration/baldwin_form_submission_spec.rb
+++ b/spec/system/data_migration/baldwin_form_submission_spec.rb
@@ -20,7 +20,10 @@ RSpec.describe "Form submission for migrating baldwin", type: :system, mock_ezid
   context "migrate record from dataspace" do
     it "produces and saves a valid datacite record" do
       sign_in user
-      visit "/works/new?migrate=true"
+      visit "/"
+      click_on(user.uid)
+      expect(page).to have_link("Migrate PRDS Dataset")
+      click_on "Migrate PRDS Dataset"
       fill_in "title_main", with: title
       fill_in "description", with: description
       select "Creative Commons Attribution 4.0 International", from: "rights_identifiers"
@@ -62,6 +65,7 @@ RSpec.describe "Form submission for migrating baldwin", type: :system, mock_ezid
       expect(page).to have_button("Migrate Dataspace Files")
       expect(page).to have_content "marked as Draft"
       expect(page).to have_content "Creative Commons Attribution 4.0 International"
+      expect(page).to have_content "Princeton Research Data Service (PRDS)"
       click_on "Complete"
       expect(page).to have_content "awaiting_approval"
       baldwin_work = Work.last

--- a/spec/system/data_migration/bitklavier_form_submission_spec.rb
+++ b/spec/system/data_migration/bitklavier_form_submission_spec.rb
@@ -20,7 +20,10 @@ RSpec.describe "Form submission for migrating bitklavier", type: :system, mock_e
   context "migrate record from dataspace" do
     it "produces and saves a valid datacite record" do
       sign_in user
-      visit "/works/new?migrate=true"
+      visit "/"
+      click_on(user.uid)
+      expect(page).to have_link("Migrate PRDS Dataset")
+      click_on "Migrate PRDS Dataset"
       fill_in "title_main", with: title
       fill_in "description", with: description
       select "Creative Commons Attribution 4.0 International", from: "rights_identifiers"
@@ -53,6 +56,7 @@ RSpec.describe "Form submission for migrating bitklavier", type: :system, mock_e
       expect(page).to have_button("Migrate Dataspace Files")
       expect(page).to have_content "marked as Draft"
       expect(page).to have_content "Creative Commons Attribution 4.0 International"
+      expect(page).to have_content "Princeton Research Data Service (PRDS)"
       click_on "Complete"
       expect(page).to have_content "awaiting_approval"
       bitklavier_work = Work.last

--- a/spec/system/data_migration/bitklavierimage_form_submission_spec.rb
+++ b/spec/system/data_migration/bitklavierimage_form_submission_spec.rb
@@ -25,7 +25,10 @@ Piano Bar: Earthworks—omni-directionals. This microphone system suspends omnid
   context "migrate record from dataspace" do
     it "produces and saves a valid datacite record" do
       sign_in user
-      visit "/works/new?migrate=true"
+      visit "/"
+      click_on(user.uid)
+      expect(page).to have_link("Migrate PRDS Dataset")
+      click_on "Migrate PRDS Dataset"
       fill_in "title_main", with: title
       fill_in "description", with: description
       select "Creative Commons Attribution 4.0 International", from: "rights_identifiers"
@@ -67,6 +70,7 @@ Piano Bar: Earthworks—omni-directionals. This microphone system suspends omnid
       expect(page).to have_button("Migrate Dataspace Files")
       expect(page).to have_content "marked as Draft"
       expect(page).to have_content "Creative Commons Attribution 4.0 International"
+      expect(page).to have_content "Princeton Research Data Service (PRDS)"
       click_on "Complete"
       expect(page).to have_content "awaiting_approval"
       bitklavierimage_work = Work.last

--- a/spec/system/data_migration/cklibrary_form_submission_spec.rb
+++ b/spec/system/data_migration/cklibrary_form_submission_spec.rb
@@ -22,7 +22,10 @@ RSpec.describe "Form submission for migrating cklibrary", type: :system, mock_ez
   context "migrate record from dataspace" do
     it "produces and saves a valid datacite record" do
       sign_in user
-      visit "/works/new?migrate=true"
+      visit "/"
+      click_on(user.uid)
+      expect(page).to have_link("Migrate PRDS Dataset")
+      click_on "Migrate PRDS Dataset"
       fill_in "title_main", with: title
       click_on "btn-add-title"
       fill_in "new_title_1", with: alternative_title
@@ -52,6 +55,7 @@ RSpec.describe "Form submission for migrating cklibrary", type: :system, mock_ez
       expect(page).to have_button("Migrate Dataspace Files")
       expect(page).to have_content "marked as Draft"
       expect(page).to have_content "Creative Commons Attribution 4.0 International"
+      expect(page).to have_content "Princeton Research Data Service (PRDS)"
       click_on "Complete"
       expect(page).to have_content "awaiting_approval"
       cklibrary_work = Work.last

--- a/spec/system/data_migration/cytoskeletal_form_submission_spec.rb
+++ b/spec/system/data_migration/cytoskeletal_form_submission_spec.rb
@@ -23,7 +23,10 @@ RSpec.describe "Form submission for migrating cytoskeletal", type: :system, mock
   context "migrate record from dataspace" do
     it "produces and saves a valid datacite record" do
       sign_in user
-      visit "/works/new?migrate=true"
+      visit "/"
+      click_on(user.uid)
+      expect(page).to have_link("Migrate PRDS Dataset")
+      click_on "Migrate PRDS Dataset"
       fill_in "title_main", with: title
       fill_in "description", with: description
       select "Creative Commons Attribution 4.0 International", from: "rights_identifiers"
@@ -107,6 +110,7 @@ RSpec.describe "Form submission for migrating cytoskeletal", type: :system, mock
       expect(page).to have_button("Migrate Dataspace Files")
       expect(page).to have_content "marked as Draft"
       expect(page).to have_content "Creative Commons Attribution 4.0 International"
+      expect(page).to have_content "Princeton Research Data Service (PRDS)"
       click_on "Complete"
       expect(page).to have_content "awaiting_approval"
       cytoskeletal_work = Work.last

--- a/spec/system/data_migration/design_arrangment_form_submission_spec.rb
+++ b/spec/system/data_migration/design_arrangment_form_submission_spec.rb
@@ -25,7 +25,10 @@ Consult the file README.txt for a more detailed description of the contents."
   context "migrate record from dataspace" do
     it "produces and saves a valid datacite record" do
       sign_in user
-      visit "/works/new?migrate=true"
+      visit "/"
+      click_on(user.uid)
+      expect(page).to have_link("Migrate PPPL Dataset")
+      click_on "Migrate PPPL Dataset"
       fill_in "title_main", with: title
       fill_in "description", with: description
       select "Creative Commons Attribution 4.0 International", from: "rights_identifiers"
@@ -83,6 +86,7 @@ Consult the file README.txt for a more detailed description of the contents."
       expect(page).to have_button("Migrate Dataspace Files")
       expect(page).to have_content "marked as Draft"
       expect(page).to have_content "Creative Commons Attribution 4.0 International"
+      expect(page).to have_content "Princeton Plasma Physics Lab (PPPL)"
       click_on "Complete"
       expect(page).to have_content "awaiting_approval"
       design_arrangment_work = Work.last

--- a/spec/system/data_migration/dynamic_tension_form_submission_spec.rb
+++ b/spec/system/data_migration/dynamic_tension_form_submission_spec.rb
@@ -22,7 +22,10 @@ RSpec.describe "Form submission for migrating dynamic-tension", type: :system, m
   context "migrate record from dataspace" do
     it "produces and saves a valid datacite record" do
       sign_in user
-      visit "/works/new?migrate=true"
+      visit "/"
+      click_on(user.uid)
+      expect(page).to have_link("Migrate PPPL Dataset")
+      click_on "Migrate PPPL Dataset"
       fill_in "title_main", with: title
       fill_in "description", with: description
       select "Creative Commons Attribution 4.0 International", from: "rights_identifiers"
@@ -76,6 +79,7 @@ RSpec.describe "Form submission for migrating dynamic-tension", type: :system, m
       expect(page).to have_button("Migrate Dataspace Files")
       expect(page).to have_content "marked as Draft"
       expect(page).to have_content "Creative Commons Attribution 4.0 International"
+      expect(page).to have_content "Princeton Plasma Physics Lab (PPPL)"
       click_on "Complete"
       expect(page).to have_content "awaiting_approval"
       dynamic_tension_work = Work.last

--- a/spec/system/data_migration/electromagnetic_form_submission_spec.rb
+++ b/spec/system/data_migration/electromagnetic_form_submission_spec.rb
@@ -25,7 +25,10 @@ This data set includes the data visualized in figures 2-7 in Electromagnetic tot
   context "migrate record from dataspace" do
     it "produces and saves a valid datacite record" do
       sign_in user
-      visit "/works/new?migrate=true"
+      visit "/"
+      click_on(user.uid)
+      expect(page).to have_link("Migrate PPPL Dataset")
+      click_on "Migrate PPPL Dataset"
       fill_in "title_main", with: title
       fill_in "description", with: description
       select "Creative Commons Attribution 4.0 International", from: "rights_identifiers"
@@ -84,6 +87,7 @@ This data set includes the data visualized in figures 2-7 in Electromagnetic tot
       expect(page).to have_button("Migrate Dataspace Files")
       expect(page).to have_content "marked as Draft"
       expect(page).to have_content "Creative Commons Attribution 4.0 International"
+      expect(page).to have_content "Princeton Plasma Physics Lab (PPPL)"
       click_on "Complete"
       expect(page).to have_content "awaiting_approval"
       electromagnetic_work = Work.last

--- a/spec/system/data_migration/femtosecond_form_submission_spec.rb
+++ b/spec/system/data_migration/femtosecond_form_submission_spec.rb
@@ -21,7 +21,10 @@ RSpec.describe "Form submission for migrating femtosecond", type: :system, mock_
   context "migrate record from dataspace" do
     it "produces and saves a valid datacite record" do
       sign_in user
-      visit "/works/new?migrate=true"
+      visit "/"
+      click_on(user.uid)
+      expect(page).to have_link("Migrate PRDS Dataset")
+      click_on "Migrate PRDS Dataset"
       fill_in "title_main", with: title
       fill_in "description", with: description
       select "Creative Commons Attribution 4.0 International", from: "rights_identifiers"
@@ -138,6 +141,7 @@ RSpec.describe "Form submission for migrating femtosecond", type: :system, mock_
       expect(page).to have_button("Migrate Dataspace Files")
       expect(page).to have_content "marked as Draft"
       expect(page).to have_content "Creative Commons Attribution 4.0 International"
+      expect(page).to have_content "Princeton Research Data Service (PRDS)"
       click_on "Complete"
       expect(page).to have_content "awaiting_approval"
       femtosecond_work = Work.last

--- a/spec/system/data_migration/flume_form_submission_spec.rb
+++ b/spec/system/data_migration/flume_form_submission_spec.rb
@@ -23,7 +23,10 @@ The attached readme.txt file explains the data attributes"
   context "migrate record from dataspace" do
     it "produces and saves a valid datacite record" do
       sign_in user
-      visit "/works/new?migrate=true"
+      visit "/"
+      click_on(user.uid)
+      expect(page).to have_link("Migrate PRDS Dataset")
+      click_on "Migrate PRDS Dataset"
       fill_in "title_main", with: title
       fill_in "description", with: description
       select "Creative Commons Attribution 4.0 International", from: "rights_identifiers"
@@ -55,6 +58,7 @@ The attached readme.txt file explains the data attributes"
 
       expect(page).to have_content "marked as Draft"
       expect(page).to have_content "Creative Commons Attribution 4.0 International"
+      expect(page).to have_content "Princeton Research Data Service (PRDS)"
       click_on "Complete"
       expect(page).to have_content "awaiting_approval"
       flume_work = Work.last

--- a/spec/system/migrate_submission_spec.rb
+++ b/spec/system/migrate_submission_spec.rb
@@ -81,8 +81,8 @@ RSpec.describe "Form submission for a legacy dataset", type: :system, mock_ezid_
       sign_in user
       visit user_path(user)
       click_on(user.uid)
-      expect(page).to have_link("Migrate Dataset")
-      click_on "Migrate Dataset"
+      expect(page).to have_link("Migrate PRDS Dataset")
+      click_on "Migrate PRDS Dataset"
       fill_in "title_main", with: title
       fill_in "creators[][given_name]", with: "Samantha"
       fill_in "creators[][family_name]", with: "Abrams"
@@ -97,6 +97,7 @@ RSpec.describe "Form submission for a legacy dataset", type: :system, mock_ezid_
       expect(resource.creators.last.given_name).to have_content("Samantha")
       expect(resource.creators.last.family_name).to have_content("Abrams")
       expect(resource.migrated).to be_truthy
+      expect(Work.last.group).to eq(Group.research_data)
       expect(page).to have_button("Migrate Dataspace Files")
       click_on "Complete"
       expect(page).to have_content "awaiting_approval"


### PR DESCRIPTION
This allows the migrator to determine which group the item is migrating to before starting the form. Then there is not a need to change the group in the form because it is already set.

fixes #1439