### PR TITLE
Changing the directory to match with the DOI

### DIFF
--- a/app/services/pul_dspace_migrate.rb
+++ b/app/services/pul_dspace_migrate.rb
@@ -55,8 +55,8 @@ class PULDspaceMigrate
 
     def remove_overlap_and_combine
       dpsace_update_display_to_final_key
+      aws_update_display_to_final_key(aws_files_and_directories)
       aws_files_only = aws_files_and_directories.reject(&:directory?)
-      aws_update_display_to_final_key(aws_files_only)
       aws_file_names = aws_files_only.map(&:filename_display)
       files_to_remove = []
       dspace_files.each do |s3_file|

--- a/spec/services/pul_dspace_migrate_spec.rb
+++ b/spec/services/pul_dspace_migrate_spec.rb
@@ -100,6 +100,8 @@ RSpec.describe PULDspaceMigrate, type: :model do
         expect(work_activity.message).to eq("{\"migration_id\":#{MigrationUploadSnapshot.last.id},\"message\":\"Migration for 5 files and 1 directory\",\"file_count\":5,\"directory_count\":1}")
 
         expect(enqueued_jobs.size).to eq(4)
+        directory_json = JSON.parse(enqueued_jobs.last[:args][0]["s3_file_json"])
+        expect(directory_json["filename_display"]).to eq("abc/123/test_directory_key")
         expect(MigrationUploadSnapshot.last.files).to eq([{ "checksum" => "AI7sEcOecDhAlznAFgp5Og==", "filename" => "abc/123/data_space_SCoData_combined_v1_2020-07_README.txt",
                                                             "migrate_status" => "started" },
                                                           { "checksum" => "e9PUM5wDTrxmO5kGV3FGiA==", "filename" => "abc/123/SCoData_combined_v1_2020-07_datapackage.json",


### PR DESCRIPTION
stop the mysterious 10-34770/ directories in AWS

fixes #1409 