### PR TITLE
Only migrate the dspace files from the ORIGINAL bundle

### DIFF
--- a/app/services/pul_dspace_connector.rb
+++ b/app/services/pul_dspace_connector.rb
@@ -46,7 +46,7 @@ class PULDspaceConnector
 
   def list_bitsteams
     @list_bitsteams ||=
-      bitstreams.map do |bitstream|
+      original_bitstreams.map do |bitstream|
         path = File.join(Rails.configuration.dspace.download_file_path, "dspace_download", work.id.to_s)
         filename = File.join(path, bitstream["name"])
         if bitstream["checkSum"]["checkSumAlgorithm"] != "MD5"
@@ -131,5 +131,9 @@ class PULDspaceConnector
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
       http
+    end
+
+    def original_bitstreams
+      bitstreams.select { |bitstream| bitstream["bundleName"] == "ORIGINAL" }
     end
 end

--- a/spec/services/pul_dspace_connector_spec.rb
+++ b/spec/services/pul_dspace_connector_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe PULDspaceConnector, type: :model do
 
     it "downloads the bitstreams" do
       allow(Honeybadger).to receive(:notify)
-      expect(dspace_data.download_bitstreams(dspace_data.list_bitsteams).count).to eq(3)
+      expect(dspace_data.download_bitstreams(dspace_data.list_bitsteams).count).to eq(2)
       expect(Honeybadger).not_to have_received(:notify)
     end
 
@@ -73,7 +73,7 @@ RSpec.describe PULDspaceConnector, type: :model do
 
       it "downloads the bitstreams" do
         allow(Honeybadger).to receive(:notify)
-        expect(dspace_data.download_bitstreams(dspace_data.list_bitsteams).count).to eq(3)
+        expect(dspace_data.download_bitstreams(dspace_data.list_bitsteams).count).to eq(2)
         expect(Honeybadger).to have_received(:notify).with(/Mismatching checksum .* for work: #{work.id} doi: #{work.doi} ark: #{work.ark}/)
       end
     end

--- a/spec/system/migrate_submission_spec.rb
+++ b/spec/system/migrate_submission_spec.rb
@@ -268,7 +268,7 @@ RSpec.describe "Form submission for a legacy dataset", type: :system, mock_ezid_
       activity = start_activities.first
       expect(activity.activity_type).to eq(WorkActivity::MIGRATION_START)
       expect(activity.created_by_user_id).to eq(user.id)
-      expect(page).to have_content("Migration for 4 files and 1 directory")
+      expect(page).to have_content("Migration for 3 files and 1 directory")
 
       perform_enqueued_jobs
       end_activities = WorkActivity.activities_for_work(work.id, WorkActivity::MIGRATION_COMPLETE)
@@ -277,7 +277,7 @@ RSpec.describe "Form submission for a legacy dataset", type: :system, mock_ezid_
       expect(activity.activity_type).to eq(WorkActivity::MIGRATION_COMPLETE)
       expect(activity.created_by_user_id).to eq(user.id)
       visit(work_path(work))
-      expect(page).to have_content("4 files and 1 directory have migrated from Dataspace.")
+      expect(page).to have_content("3 files and 1 directory have migrated from Dataspace.")
     end
   end
 end


### PR DESCRIPTION
This will ignore the license and extracted text

fixes #1452