### PR TITLE
Making the migration snapshot check for completed files correct

### DIFF
--- a/app/jobs/dspace_bitstream_copy_job.rb
+++ b/app/jobs/dspace_bitstream_copy_job.rb
@@ -16,7 +16,7 @@ class DspaceBitstreamCopyJob < ApplicationJob
     def migrate_file(dspace_file, migration_snapshot_id)
       # Allow a restart if there is an error with one file
       snapshot = MigrationUploadSnapshot.find(migration_snapshot_id)
-      return if snapshot.complete?(dspace_file)
+      return if file_complete?(snapshot, dspace_file)
 
       downloaded_file = download_dspace_file(dspace_file, migration_snapshot_id)
       return if downloaded_file.nil?
@@ -53,5 +53,11 @@ class DspaceBitstreamCopyJob < ApplicationJob
         yield migration_snapshot
         migration_snapshot.save!
       end
+    end
+
+    def file_complete?(migratoion_snapshot, dspace_file)
+      s3_file = dspace_file.clone
+      s3_file.filename = s3_file.filename_display
+      migratoion_snapshot.complete?(s3_file)
     end
 end

--- a/app/models/migration_upload_snapshot.rb
+++ b/app/models/migration_upload_snapshot.rb
@@ -30,9 +30,8 @@ class MigrationUploadSnapshot < UploadSnapshot
   end
 
   def complete?(s3_file)
-    index = find_file(s3_file.filename)
-    return false if index.nil?
-    files[index]["migrate_status"] == "complete" && files[index]["checksum"] == s3_file.checksum
+    index = find_complete_file(s3_file.filename, s3_file.checksum)
+    !index.nil?
   end
 
   def migration_complete?
@@ -71,5 +70,9 @@ class MigrationUploadSnapshot < UploadSnapshot
         Honeybadger.notify("Migrated a file that was not part of the orginal Migration: #{id} for work #{work_id}: #{filename}")
       end
       index
+    end
+
+    def find_complete_file(filename, checksum)
+      files.index { |file| (file["filename"] == filename) && (file["checksum"] == checksum) && (file["migrate_status"] == "complete") }
     end
 end

--- a/spec/jobs/dspace_bitstream_copy_job_spec.rb
+++ b/spec/jobs/dspace_bitstream_copy_job_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+require "rails_helper"
+require "sidekiq/testing/inline"
+
+RSpec.describe DspaceBitstreamCopyJob, type: :job do
+  include ActiveJob::TestHelper
+
+  let(:s3_files_json) do
+    "[{\"filename\":\"/tmp/dspace_download/#{work.id}/README.txt\",\"last_modified\":\"2023-09-08T09:15:26.744-04:00\",\"size\":-1,\"checksum\":\"/HFvG2uRk/3BBDRsYqfKaA==\"" \
+    ",\"work_id\":#{work.id},\"filename_display\":\"10.34770/tbd/#{work.id}/README.txt\",\"url\":\"https://dataspace.princeton.edu/bitstream/88435/dsp01bc386n47h/1\"}]"
+  end
+  let(:s3_file) { S3File.from_json(JSON.parse(s3_files_json).first) }
+  let(:s3_aws_file) do
+    file = s3_file.clone
+    file.filename = file.filename_display
+    file
+  end
+  subject(:job) { described_class.perform_later(dspace_files_json: s3_files_json, work_id: work.id, migration_snapshot_id: migration_snapshot.id) }
+  let(:work) { FactoryBot.create :draft_work }
+  let(:migration_snapshot) do
+    MigrationUploadSnapshot.create(files: [{ "checksum" => "/HFvG2uRk/3BBDRsYqfKaA==", "filename" => "10.34770/tbd/#{work.id}/README.txt", "migrate_status" => "started" }], work: work,
+                                   url: "example.com")
+  end
+  let(:fake_s3_service) { instance_double(S3QueryService, bucket_name: "work-bucket", prefix: "abc/123/#{work.id}/") }
+  let(:etag) { "test-etag" }
+  let(:work_activity_json) { { migration_id: migration_snapshot.id, message: "test migration", file_count: 1, directory_count: 0 }.to_json }
+  let(:work_activity) { WorkActivity.add_work_activity(work.id, work_activity_json, work.created_by_user_id, activity_type: WorkActivity::MIGRATION_START) }
+  let(:fake_dpsace_connector) { instance_double(PULDspaceConnector, download_bitstreams: [s3_file]) }
+  let(:fake_aws_connector) { instance_double(PULDspaceAwsConnector, upload_to_s3: [{ key: s3_file.filename_display, file: s3_aws_file, error: nil }]) }
+
+  before do
+    allow(PULDspaceConnector).to receive(:new).and_return(fake_dpsace_connector)
+    allow(PULDspaceAwsConnector).to receive(:new).and_return(fake_aws_connector)
+    work_activity
+    allow(Work).to receive(:find).and_return(work)
+    allow(fake_s3_service).to receive(:upload_file).and_return(true)
+    allow(fake_s3_service).to receive(:get_s3_object_attributes).and_return({ etag: etag })
+    allow(work).to receive(:s3_query_service).and_return(fake_s3_service)
+    allow(s3_aws_file).to receive(:s3_query_service).and_return(fake_s3_service)
+    allow(Honeybadger).to receive(:notify)
+  end
+
+  it "runs an aws upload" do
+    perform_enqueued_jobs { job }
+    expect(fake_dpsace_connector).to have_received(:download_bitstreams)
+    expect(fake_aws_connector).to have_received(:upload_to_s3)
+    migration_snapshot.reload
+    expect(migration_snapshot).to be_migration_complete
+    expect(Honeybadger).not_to have_received(:notify)
+  end
+
+  context "when the file has already been migrated" do
+    let(:migration_snapshot) do
+      MigrationUploadSnapshot.create(files: [{ "checksum" => "/HFvG2uRk/3BBDRsYqfKaA==", "filename" => "10.34770/tbd/#{work.id}/README.txt", "migrate_status" => "complete" }], work: work,
+                                     url: "example.com")
+    end
+
+    it "does not run an aws upload" do
+      perform_enqueued_jobs { job }
+      expect(fake_dpsace_connector).not_to have_received(:download_bitstreams)
+      expect(fake_s3_service).not_to have_received(:upload_file).with(hash_including(filename: "README.txt", md5_digest: "/HFvG2uRk/3BBDRsYqfKaA==", size: 4946))
+      expect(Honeybadger).not_to have_received(:notify)
+    end
+  end
+end

--- a/spec/models/migration_upload_snapshot_spec.rb
+++ b/spec/models/migration_upload_snapshot_spec.rb
@@ -79,12 +79,16 @@ XML
       migration_upload_snapshot.store_files([s3_file1, s3_file2])
       expect(work.work_activity.count).to eq(0)
       migration_upload_snapshot.mark_complete(s3_file2)
+      s3_file2.checksum = migration_upload_snapshot.files[1]["checksum"]
+      expect(migration_upload_snapshot.complete?(s3_file2)).to be_truthy
       expect(work.work_activity.count).to eq(0)
       expect(migration_upload_snapshot.files).to eq([{ "filename" => "fileone", "checksum" => "aaabbb111222", "migrate_status" => "started" },
                                                      { "filename" => "filetwo", "checksum" => s3_etag, "migrate_status" => "complete" }])
       expect(migration_upload_snapshot.migration_complete?).to be_falsey
       expect(migration_upload_snapshot.existing_files).to eq([{ "filename" => "filetwo", "checksum" => s3_etag, "migrate_status" => "complete" }])
       migration_upload_snapshot.mark_complete(s3_file1)
+      s3_file1.checksum = migration_upload_snapshot.files[0]["checksum"]
+      expect(migration_upload_snapshot.complete?(s3_file1)).to be_truthy
       expect(migration_upload_snapshot.migration_complete?).to be_truthy
       expect(migration_upload_snapshot.existing_files).to eq([{ "filename" => "fileone", "checksum" => s3_etag, "migrate_status" => "complete" },
                                                               { "filename" => "filetwo", "checksum" => s3_etag, "migrate_status" => "complete" }])


### PR DESCRIPTION
Because of the status check for "started" or "error" in find file, the `complete?` method was never returning true 

Also checks the filename_display for dspace files as those are the only ones that will match. The /tmp/dspace... will never match the s3 file location

fixes #1478