### PR TITLE
Ensuring that the SCSS templates are not cached for the `development` environment

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -12,6 +12,9 @@ Rails.application.configure do
   # Do not eager load code on boot.
   config.eager_load = false
 
+  # Ensure that .scss files are not cached
+  config.sass.cache = false
+
   # Show full error reports.
   config.consider_all_requests_local = true
 


### PR DESCRIPTION
This was discovered while advancing #1491 