### PR TITLE
Removing errors related to the ActiveStorage JavaScript library (this is not used)

### DIFF
--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -11,7 +11,6 @@
 
 import Rails from '@rails/ujs';
 import Turbolinks from 'turbolinks';
-import ActiveStorage from '@rails/activestorage';
 // Provides @mention functionality in textboxes (adds to jQuery UI autocomplete)
 import './vendor/jquery-ui-triggeredAutocomplete';
 
@@ -42,7 +41,6 @@ if (typeof (window._rails_loaded) === 'undefined' || window._rails_loaded == nul
   Rails.start();
 }
 Turbolinks.start();
-ActiveStorage.start();
 
 function ready() {
   const loader = new PdcUiLoader();


### PR DESCRIPTION
This was discovered while advancing #1491 