### PR TITLE
Extending the Work model and form to support setting embargo dates

### DIFF
--- a/app/assets/stylesheets/components/works/_form.scss
+++ b/app/assets/stylesheets/components/works/_form.scss
@@ -8,4 +8,10 @@
       margin-left: 0.2rem;
     }
   }
+
+  .form-control {
+    &__date {
+      width: max-content;
+    }
+  }
 }

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -413,9 +413,23 @@ class WorksController < ApplicationController
       process_updates
     end
 
+    def embargo_date_param
+      params["embargo-date"]
+    end
+
+    def embargo_date
+      return nil if embargo_date_param.blank?
+
+      Date.parse(embargo_date_param)
+    rescue Date::Error
+      Rails.logger.error("Failed to parse the embargo date #{embargo_date_param} for Work #{@work.id}")
+      nil
+    end
+
     def update_params
       {
         group_id: params_group_id,
+        embargo_date: embargo_date,
         resource: FormToResourceService.convert(params, @work)
       }
     end

--- a/app/services/form_to_resource_service.rb
+++ b/app/services/form_to_resource_service.rb
@@ -7,6 +7,9 @@ class FormToResourceService
     #  @param [Work] work params will be applied to. Utilizes the work for old values if needed.
     #
     # @return [PDCMetadata::Resource] Fully formed resource containing updates from the user
+    #
+    # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/AbcSize
     def convert(params, work)
       resource = reset_resource_to_work(work)
 
@@ -27,6 +30,8 @@ class FormToResourceService
 
       resource
     end
+    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/MethodLength
 
     private
 

--- a/app/views/works/_curator_controlled_form.html.erb
+++ b/app/views/works/_curator_controlled_form.html.erb
@@ -73,6 +73,12 @@
   </select>
 </div>
 
+<!-- Date field (for setting an embargo on the Work) -->
+<div class="field">
+  <label class="form-label" for="start"><%= t('works.form.embargo_date') %><span class="text-muted field-hint">: (date until which the work is embargoed)</span></label>
+  <input class="form-control form-control__date" type="date" id="embargo-date" name="embargo-date" min="2018-01-01" />
+</div>
+
 <!-- Collection Tags field -->
 <div class="field">
   <%= t('works.form.collection_tags') %>: <span class="text-muted field-hint">(enter tags that identify the collect in a comma separated list, e.g. Humanities, Life Sciences)</span><br>

--- a/db/migrate/20230912203022_add_embargo_date_to_works.rb
+++ b/db/migrate/20230912203022_add_embargo_date_to_works.rb
@@ -1,0 +1,5 @@
+class AddEmbargoDateToWorks < ActiveRecord::Migration[6.1]
+  def change
+    add_column :works, :embargo_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_08_10_125820) do
+ActiveRecord::Schema.define(version: 2023_09_12_203022) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -152,6 +152,7 @@ ActiveRecord::Schema.define(version: 2023_08_10_125820) do
     t.text "submission_notes"
     t.string "files_location"
     t.integer "curator_user_id"
+    t.date "embargo_date"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/spec/requests/works_spec.rb
+++ b/spec/requests/works_spec.rb
@@ -65,6 +65,11 @@ RSpec.describe "/works", type: :request do
         stub_s3
       end
 
+      context "when an embargo date is specified" do
+        it "updates the embargo date" do
+        end
+      end
+
       context "when files are added to the Work" do
         let(:work) { FactoryBot.create(:tokamak_work, group: group, created_by_user_id: user.id, state: "draft") }
 
@@ -183,6 +188,46 @@ RSpec.describe "/works", type: :request do
 
           expect(response.code).to eq "200"
           expect(response.body).to include("Files Replaced: 1")
+        end
+      end
+
+      context "when an embargo date is specified" do
+        let(:embargo_date_param) { "2023-09-06" }
+        let(:params) do
+          {
+            "title_main" => "test dataset updated",
+            "creators" => [{ "orcid" => "", "given_name" => "Jane", "family_name" => "Smith" }],
+            "embargo-date" => embargo_date_param
+          }
+        end
+        let(:embargo_date) { Date.parse(embargo_date_param) }
+
+        before do
+          stub_ark
+        end
+
+        it "updates the embargo date" do
+          patch work_url(work), params: params
+          work.reload
+
+          expect(work.embargo_date).not_to be nil
+          expect(work.embargo_date).to eq(embargo_date)
+        end
+
+        context "when an invalid embargo date is specified" do
+          let(:embargo_date_param) { "invalid" }
+
+          before do
+            allow(Rails.logger).to receive(:error)
+          end
+
+          it "sets the embargo date to nil and logs an error" do
+            patch work_url(work), params: params
+            work.reload
+
+            expect(work.embargo_date).to be nil
+            expect(Rails.logger).to have_received(:error).with("Failed to parse the embargo date invalid for Work #{work.id}").at_least(:once)
+          end
         end
       end
     end


### PR DESCRIPTION
Advances #1491. Additional pull requests shall be required in order to ensure the following:

- Attempting to access Works under active embargo without proper authorization will result in a 301 redirect response for unauthenticated users
- Attempting to access Works under active embargo without proper authorization will result in a 403 error for authenticated users
- Implementing support for lifting embargoes synchronously