### PR TITLE
Ensuring that the JSON-serialized Works render the embargo dates in the ISO 8601 format

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -447,12 +447,20 @@ class Work < ApplicationRecord
       }
     end
 
+    embargo_date_json = if embargo_date.present?
+                          embargo_datetime = embargo_date.to_datetime
+                          embargo_datetime.to_s
+                        else
+                          nil
+                        end
+
     # to_json returns a string of serialized JSON.
     # as_json returns the corresponding hash.
     {
       "resource" => resource.as_json,
       "files" => files,
-      "group" => group.as_json.except("id")
+      "group" => group.as_json.except("id"),
+      "embargo_date" => embargo_date_json
     }
   end
 

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -32,11 +32,12 @@ RSpec.describe Work, type: :model do
   end
 
   context "fixed time" do
+    let(:embargo_date) { Date.parse("2023-09-14") }
     before do
       allow(Time).to receive(:now).and_return(Time.parse("2022-01-01T00:00:00.000Z"))
     end
     it "captures everything needed for PDC Describe in JSON" do
-      work = Work.new(group: group, resource: FactoryBot.build(:tokamak_work))
+      work = Work.new(group: group, resource: FactoryBot.build(:tokamak_work), embargo_date: embargo_date)
       expect(JSON.parse(work.to_json)).to eq(
         {
           "resource" => {
@@ -69,7 +70,8 @@ RSpec.describe Work, type: :model do
             "code" => "RD",
             "created_at" => "2021-12-31T19:00:00.000-05:00",
             "updated_at" => "2021-12-31T19:00:00.000-05:00"
-          }
+          },
+          "embargo_date" => "2023-09-14T00:00:00+00:00"
         }
       )
     end


### PR DESCRIPTION
This is required in order to ensure that PDC Discovery can index the embargo dates into the Solr Documents. Advances #1491 