### PR TITLE
Following recommendation to send mail just a bit later

### DIFF
--- a/app/models/work_activity_notification.rb
+++ b/app/models/work_activity_notification.rb
@@ -8,7 +8,7 @@ class WorkActivityNotification < ApplicationRecord
     if send_message?
       mailer = NotificationMailer.with(user: user, work_activity: work_activity)
       message = mailer.build_message
-      message.deliver_later
+      message.deliver_later(wait: 10.seconds)
     end
   end
 


### PR DESCRIPTION
from this [stack overflow](https://stackoverflow.com/questions/40672232/activejobdeserializationerror-error-while-trying-to-deserialize-arguments) we are adding a wait to send the mail a bit later after we are sure postgres will have comitted the changes refs #1504

Mail is still being sent with this update:
![Screenshot 2023-09-18 at 10 25 26 AM](https://github.com/pulibrary/pdc_describe/assets/1599081/a411fece-4aa0-4882-aae2-0c171851baaa)
