### PR TITLE
Remove test parallelizing until it works

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,6 @@ jobs:
           POSTGRES_USER: rails_template_user
           POSTGRES_DB: test_db
           POSTGRES_HOST_AUTH_METHOD: trust
-    parallelism: 2
     steps:
       - attach_workspace:
           at: *root
@@ -90,9 +89,7 @@ jobs:
       - run: bundle exec rake db:migrate RAILS_ENV=test
       - run:
           name: Run Rspec
-          command: |
-            bundle exec rspec --profile 10 --format RspecJunitFormatter --out test_results/rspec.xml
-            $(circleci tests glob “spec/**/*_spec.rb” | circleci tests split --split-by=timings --timings-type=classname)
+          command: bundle exec rspec
       - persist_to_workspace:
           root: *root
           paths: 'coverage'

--- a/Gemfile
+++ b/Gemfile
@@ -101,7 +101,6 @@ group :test do
   # Used for detecting what a controller rendered
   gem "rails-controller-testing"
   gem "rspec-html-matchers"
-  gem "rspec_junit_formatter"
   gem "sinatra"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -401,8 +401,6 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.11.0)
-    rspec_junit_formatter (0.6.0)
-      rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (1.28.2)
       parallel (~> 1.10)
       parser (>= 3.1.0.0)
@@ -595,7 +593,6 @@ DEPENDENCIES
   rolify
   rspec-html-matchers
   rspec-rails (~> 5.0.0)
-  rspec_junit_formatter
   sass-rails (>= 6)
   selenium-webdriver
   sidekiq (~> 7.1)


### PR DESCRIPTION
I thought parallelizing the tests was going to be an easy win for faster CI. I am sorely disappointed. 