### PR TITLE
Adding migration for work activity provenance notes to new format

### DIFF
--- a/db/migrate/20231025155725_provenance_note_format.rb
+++ b/db/migrate/20231025155725_provenance_note_format.rb
@@ -1,0 +1,10 @@
+class ProvenanceNoteFormat < ActiveRecord::Migration[6.1]
+  def change
+    WorkActivity.where(activity_type: WorkActivity::PROVENANCE_NOTES).each do |note|
+      unless note.message.starts_with?("{\"note\":")
+        note.message = { note: note.message, change_label: "" }.to_json
+        note.save
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_09_12_203022) do
+ActiveRecord::Schema.define(version: 2023_10_25_155725) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,10 +75,10 @@ ActiveRecord::Schema.define(version: 2023_09_12_203022) do
 
   create_table "upload_snapshots", force: :cascade do |t|
     t.string "url"
-    t.bigint "version"
     t.bigint "work_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "version"
     t.jsonb "files"
     t.string "type"
     t.index ["work_id"], name: "index_upload_snapshots_on_work_id"


### PR DESCRIPTION
Before the migration ran there was an error with a work that had the old format
![Screenshot 2023-10-25 at 12 16 14 PM](https://github.com/pulibrary/pdc_describe/assets/1599081/32a82dce-9323-4748-8276-abb78aedb048)

After the migration ran the work loads correctly
![Screenshot 2023-10-25 at 12 16 59 PM](https://github.com/pulibrary/pdc_describe/assets/1599081/c86ecedf-25a5-4a75-ad10-5f4723c7d4b5)

fixes #1546