### PR TITLE
Adding a method to discover empty files to the s3query service

### DIFF
--- a/app/models/s3_file.rb
+++ b/app/models/s3_file.rb
@@ -43,6 +43,10 @@ class S3File
     size == 0
   end
 
+  def empty?
+    size == 0
+  end
+
   def globus_url
     encoded_filename = filename.split("/").map { |name| ERB::Util.url_encode(name) }.join("/")
     File.join(Rails.configuration.globus["post_curation_base_url"], encoded_filename)

--- a/spec/services/s3_query_service_spec.rb
+++ b/spec/services/s3_query_service_spec.rb
@@ -709,7 +709,7 @@ XML
     end
   end
 
-  describe "#client_s3_empyt_files" do
+  describe "#client_s3_empty_files" do
     let(:fake_aws_client) { double(Aws::S3::Client) }
     let(:s3_size2) { 0 }
 


### PR DESCRIPTION
refs #1580

Should allow us to see if there are any empty files when we transfer files on approval.