### PR TITLE
Sharing node_modules directory between deploys to make yarn install faster

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -3,7 +3,7 @@
 set :application, "pdc_describe"
 set :repo_url, "https://github.com/pulibrary/pdc_describe.git"
 
-set :linked_dirs, %w[log public/system public/assets]
+set :linked_dirs, %w[log public/system public/assets node_modules]
 
 # Default branch is :main
 set :branch, ENV["BRANCH"] || "main"


### PR DESCRIPTION

refs https://github.com/pulibrary/orcid_princeton/issues/57
![Screenshot 2023-11-01 at 9 16 01 AM](https://github.com/pulibrary/pdc_describe/assets/1599081/9e3a04be-8803-424e-870c-f1c528147ec5)
