### PR TITLE
Ensuring that empty S3 files are not moved between S3 Buckets when a Work is published

### DIFF
--- a/spec/fixtures/s3_list_bucket_empty_result.xml
+++ b/spec/fixtures/s3_list_bucket_empty_result.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Name>pdc-describe-test1</Name>
+  <Prefix>10-34770/pe9w-x904</Prefix>
+  <KeyCount>4</KeyCount>
+  <MaxKeys>1000</MaxKeys>
+  <IsTruncated>false</IsTruncated>
+  <Contents>
+    <Key>10-34770/pe9w-x904/SCoData_combined_v1_2020-07_README.txt</Key>
+    <LastModified>2022-04-21T18:29:40.000Z</LastModified>
+    <ETag>&quot;008eec11c39e7038409739c0160a793a&quot;</ETag>
+    <Size>10759</Size>
+    <StorageClass>STANDARD</StorageClass>
+  </Contents>
+  <Contents>
+    <Key>10-34770/pe9w-x904/SCoData_combined_v1_2020-07_README.empty.txt</Key>
+    <LastModified>2022-04-21T18:29:40.000Z</LastModified>
+    <ETag>&quot;008eec11c39e7038409739c0160a793b&quot;</ETag>
+    <Size>0</Size>
+    <StorageClass>STANDARD</StorageClass>
+  </Contents>
+  <Contents>
+    <Key>10-34770/pe9w-x904/SCoData_combined_v1_2020-07_datapackage.json</Key>
+    <LastModified>2022-04-21T18:30:07.000Z</LastModified>
+    <ETag>&quot;7bd3d4339c034ebc663b990657714688&quot;</ETag>
+    <Size>12739</Size>
+    <StorageClass>STANDARD</StorageClass>
+  </Contents>
+  <Contents>
+    <Key>10-34770/pe9w-x904/foo/</Key>
+    <LastModified>2022-04-21T18:29:40.000Z</LastModified>
+    <ETag>&quot;008eec11c39e7038409739c0160a793c&quot;</ETag>
+    <Size>0</Size>
+    <StorageClass>STANDARD</StorageClass>
+  </Contents>
+</ListBucketResult>


### PR DESCRIPTION
Resolves #1580 