### PR TITLE
Allow asset compile on a capistrano roll back

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -12,6 +12,7 @@ set :deploy_to, "/opt/pdc_describe"
 
 # Workaround for this issue: https://github.com/capistrano/rails/issues/235
 Rake::Task["deploy:assets:backup_manifest"].clear_actions
+Rake::Task["deploy:assets:restore_manifest"].clear_actions
 
 namespace :sidekiq do
   task :restart do
@@ -59,5 +60,7 @@ namespace :mailcatcher do
     end
   end
 end
+
+before "deploy:reverted", "deploy:assets:precompile"
 
 # rubocop:enable Rails/Output


### PR DESCRIPTION
@tpendragon pointed out [this issue](https://github.com/capistrano/npm/issues/7).  We are not doing an npm install, but that occurs when we do a asset:precompile so we are doing that task on rollback.

Also needed to clear `deploy:assets:restore_manifest` becuase we are no longer utilizing sprokets