### PR TITLE
Fixing bug introduced by the rollback PR

### DIFF
--- a/app/models/version_footer.rb
+++ b/app/models/version_footer.rb
@@ -104,7 +104,7 @@ class VersionFooter
   def self.log_line(revisions_logfile)
     log_line = `tail -1 #{revisions_logfile}`
     if log_line.include?("rolled back")
-      grep_lines = `grep #{log_line.chomp.split(" ").last} spec/fixtures/revisions_rollback.log`.split("\n")
+      grep_lines = `grep #{log_line.chomp.split(" ").last} #{revisions_logfile}`.split("\n")
       log_line = grep_lines.first
     end
     log_line


### PR DESCRIPTION
Did not notice the file was hard coded to the spec

On this branch
```
irb(main):001:0> VersionFooter.log_line(Rails.root.join("..", "..", "revisions.log"))
=> "Branch main (at 4bd241ac537a93da81ccd49a4c6ce0c76b5a8670) deployed as release 20231106141433 by colec"
```

On Main branch
```
irb(main):003:0> VersionFooter.log_line(Rails.root.join("..", "..", "revisions.log"))
=> nil
```