### PR TITLE
Restructures the ApprovedFileMoveJob error logging for cases in which the ApprovedUploadSnapshot cannot be resolved

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,7 @@ Layout/LineLength:
 Metrics/AbcSize:
   Exclude:
     - app/models/work_activity.rb
+    - app/jobs/approved_file_move_job.rb
 
 Metrics/BlockLength:
   Exclude:


### PR DESCRIPTION
This is meant to improve error logging in order to advance #1607 