### PR TITLE
Adding datacite validation to valid_to_submit so users know any errors in the metadata before submitting to the curators

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -267,14 +267,10 @@ class WorksController < ApplicationController
   def datacite_validate
     @errors = []
     @work = Work.find(params[:id])
-    datacite_serialization = work.resource.datacite_serialization
-    datacite_serialization.valid?
-    @errors = datacite_serialization.errors
-  rescue ArgumentError => error
-    argument_path = error.backtrace_locations.first.path
-    argument_file = argument_path.split("/").last
-    argument_name = argument_file.split(".").first
-    @errors << "#{argument_name.titleize}: #{error.message}"
+    validator = WorkValidator.new(@work)
+    unless validator.valid_datacite?
+      @errors = @work.errors.full_messages
+    end
   end
 
   def readme_select

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -20,7 +20,7 @@ class Work < ApplicationRecord
 
   alias state_history user_work
 
-  delegate :valid_to_submit, :valid_to_draft, to: :work_validator
+  delegate :valid_to_submit, :valid_to_draft, :valid_to_approve, to: :work_validator
 
   include AASM
 
@@ -143,20 +143,6 @@ class Work < ApplicationRecord
     # Force `resource` to be reloaded
     @resource = nil
     self
-  end
-
-  def valid_to_approve(user)
-    work_validator.valid_to_submit
-    if resource.doi.blank?
-      errors.add :base, "DOI must be present for a work to be approved"
-    end
-    unless user.has_role? :group_admin, group
-      errors.add :base, "Unauthorized to Approve"
-    end
-    if pre_curation_uploads_fast.empty? && post_curation_uploads.empty?
-      errors.add :base, "Uploads must be present for a work to be approved"
-    end
-    errors.count == 0
   end
 
   def title

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -1255,7 +1255,7 @@ RSpec.describe WorksController do
 
         context "a submitter trying to update the curator conrolled fields" do
           before do
-            new_params = params.merge(doi: "new-doi")
+            new_params = params.merge(doi: "10.34770/new-doi")
                                .merge(ark: "new-ark")
                                .merge(collection_tags: "new-collection-tags")
                                .merge(resource_type: "digitized video")
@@ -1264,7 +1264,7 @@ RSpec.describe WorksController do
           end
 
           it "also saves the curator controlled fields", mock_ezid_api: true do
-            expect(work.reload.doi).to eq("new-doi")
+            expect(work.reload.doi).to eq("10.34770/new-doi")
             expect(work.ark).to eq("new-ark")
             expect(work.resource.collection_tags).to eq(["new-collection-tags"])
           end
@@ -1273,7 +1273,7 @@ RSpec.describe WorksController do
         context "a group admin trying to update curator controlled fields" do
           let(:user) { FactoryBot.create :research_data_moderator }
           before do
-            new_params = params.merge(doi: "new-doi")
+            new_params = params.merge(doi: "10.34770/new-doi")
                                .merge(ark: "new-ark")
                                .merge(collection_tags: "new-colletion-tag1, new-collection-tag2")
                                .merge(resource_type: "digitized video")
@@ -1283,7 +1283,7 @@ RSpec.describe WorksController do
           end
 
           it "updates the curator controlled fields", mock_ezid_api: true do
-            expect(work.reload.doi).to eq("new-doi")
+            expect(work.reload.doi).to eq("10.34770/new-doi")
             expect(work.ark).to eq("new-ark")
             expect(work.resource.collection_tags).to eq(["new-colletion-tag1", "new-collection-tag2"])
             expect(work.resource_type).to eq("digitized video")
@@ -1337,7 +1337,7 @@ RSpec.describe WorksController do
 
     context "the work is approved" do
       let(:work) { FactoryBot.create :approved_work }
-      let(:new_params) { params.merge(doi: "new-doi").merge(ark: "ark:/99999/new-ark").merge(collection_tags: "new-colletion-tag1, new-collection-tag2") }
+      let(:new_params) { params.merge(doi: "10.34770/new-doi").merge(ark: "ark:/99999/new-ark").merge(collection_tags: "new-colletion-tag1, new-collection-tag2") }
 
       context "the submitter" do
         let(:user) { work.created_by_user }
@@ -1363,7 +1363,7 @@ RSpec.describe WorksController do
           stub_s3
           sign_in user
           patch :update, params: new_params
-          expect(work.reload.doi).to eq("new-doi")
+          expect(work.reload.doi).to eq("10.34770/new-doi")
           expect(work.ark).to eq("ark:/99999/new-ark")
           expect(work.resource.collection_tags).to eq(["new-colletion-tag1", "new-collection-tag2"])
         end
@@ -1375,7 +1375,7 @@ RSpec.describe WorksController do
         it "renders the edit page on edit" do
           sign_in curator
           patch :update, params: new_params
-          expect(work.reload.doi).to eq("new-doi")
+          expect(work.reload.doi).to eq("10.34770/new-doi")
           expect(work.ark).to eq("ark:/99999/new-ark")
           expect(work.resource.collection_tags).to eq(["new-colletion-tag1", "new-collection-tag2"])
         end
@@ -1386,7 +1386,7 @@ RSpec.describe WorksController do
           stub_s3
           sign_in user
           patch :update, params: new_params
-          expect(work.reload.doi).to eq("new-doi")
+          expect(work.reload.doi).to eq("10.34770/new-doi")
           expect(work.ark).to eq("ark:/99999/new-ark")
           expect(work.resource.collection_tags).to eq(["new-colletion-tag1", "new-collection-tag2"])
         end

--- a/spec/services/work_validator_spec.rb
+++ b/spec/services/work_validator_spec.rb
@@ -43,4 +43,20 @@ RSpec.describe Work, type: :model do
       end
     end
   end
+
+  context "datacite xml is invalid" do
+    let(:work) do
+      work = FactoryBot.create :draft_work
+      work.resource.individual_contributors = [PDCMetadata::Creator.new_individual_contributor("Sally", "Smith", "", "", 0)]
+      work.save
+      work
+    end
+
+    it "is not valid" do
+      validator = WorkValidator.new(work)
+      expect(validator.valid?).to be_truthy # we can still save, we just can not transition to submitted
+      expect(validator.valid_to_submit).to be_falsey
+      expect(work.errors.full_messages).to eq(["Contributor: Type cannot be nil"])
+    end
+  end
 end


### PR DESCRIPTION
Additionally moves the validation out of the work without modifying the logic (with the exception of adding Datacite validation).

I'm trying to make this a minimal change, so I did not migrate the validation tests from the work spec.  `valid?`  takes advantage of the WorkValidator, so the work should behave the same when the Datacite is valid.

refs #1613