### PR TITLE
Moving work reload_snapshot from the show to a background job

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -58,7 +58,7 @@ class WorksController < ApplicationController
   # When requested as .json, return the internal json resource
   def show
     @work = Work.find(params[:id])
-    @work.reload_snapshots
+    UpdateSnapshotJob.perform_later(work_id: @work.id, last_snapshot_id: work.upload_snapshots.first&.id)
     @work_decorator = WorkDecorator.new(@work, current_user)
 
     respond_to do |format|

--- a/app/jobs/update_snapshot_job.rb
+++ b/app/jobs/update_snapshot_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+class UpdateSnapshotJob < ApplicationJob
+  queue_as :low
+
+  def perform(work_id:, last_snapshot_id:)
+    work = Work.find(work_id)
+
+    # do nothing if there was another snapshot saved to the work between when this one was queued and when it started
+    #   Becuse this job can take so long lets not keep running it every time someone looks at the work
+    #   Unless this is a completely new visit after the last queued job completed
+    return if work.upload_snapshots.first&.id != last_snapshot_id
+
+    work.reload_snapshots
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -6,4 +6,5 @@ production:
   :concurrency: 5
 :queues:
   - default
+  - low
 :max_retries: 25

--- a/spec/jobs/update_snapshot_job_spec.rb
+++ b/spec/jobs/update_snapshot_job_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe UpdateSnapshotJob, type: :job do
+  include ActiveJob::TestHelper
+
+  let(:user) { FactoryBot.create :user }
+
+  let(:s3_file) { FactoryBot.build :s3_file, work:, filename: "#{work.prefix}/test_key" }
+
+  describe "perform" do
+    subject(:job) do
+      described_class.perform_later(work_id: work.id, last_snapshot_id: nil)
+    end
+    let(:fake_s3_service) { stub_s3 prefix: "10.34770/ackh-7y71/#{work.id}", data: [s3_file] }
+    let(:work) { FactoryBot.create :approved_work, doi: "10.34770/ackh-7y71" }
+
+    before do
+      fake_s3_service
+    end
+
+    it "creates an upload snapshot" do
+      expect { perform_enqueued_jobs { job } }.to change { UploadSnapshot.count }.by(1)
+    end
+
+    context "when last snapshot is different" do
+      subject(:job) do
+        described_class.perform_later(work_id: work.id, last_snapshot_id: 123)
+      end
+
+      it "skips processing" do
+        expect { perform_enqueued_jobs { job } }.to change { UploadSnapshot.count }.by(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This should allow the page to display for very large sets of files and the prvenance to be updated later

Also putting this job on it's own queue since it could take a very long time we do not want it subverting other jobs

refs #1621