### PR TITLE
Adding a method to just count the files instead of fully processing them

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -472,6 +472,10 @@ class Work < ApplicationRecord
     embargo_date >= current_date
   end
 
+  def upload_count
+    @upload_count ||= s3_query_service.count_objects
+  end
+
   protected
 
     def work_validator

--- a/app/views/works/_s3_resources.html.erb
+++ b/app/views/works/_s3_resources.html.erb
@@ -2,7 +2,7 @@
   <div class="lux">
     <div class="card">
       <div class="files card-body">
-        <h3><%= "#{@work.uploads.count} #{'File'.pluralize(@work.uploads.count)}"%> in
+        <h3><%= "#{@work.upload_count} #{'File'.pluralize(@work.upload_count)} or #{'Directory'.pluralize(@work.upload_count)}"%> in
           <%= @work.approved? ? "post-curation" : "pre-curation" %> storage
         </h3>
         <table id="files-table" class="table">
@@ -15,7 +15,7 @@
             </tr>
           </thead>
           <tbody>
-            <% if @work.uploads.empty? %>
+            <% if @work.upload_count.zero? %>
               <tr class="files">
                 <td><span><%= t('works.form.curation_uploads.empty') %></span></td>
                 <td><span></span></td>

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -270,7 +270,7 @@
 
       <dt>Location</dt>
       <dd>
-        <% if @work.pre_curation_uploads_fast.present? %>
+        <% if @work.upload_count > 0 %>
           Amazon S3 Curation Storage
         <% elsif @work.files_location_cluster? %>
           PUL Research Cluster

--- a/spec/support/s3_query_service_specs.rb
+++ b/spec/support/s3_query_service_specs.rb
@@ -7,7 +7,7 @@ def stub_s3(data: [], bucket_url: nil, prefix: "10.34770/123-abc/1", bucket_name
   allow(@s3_client).to receive(:put_object)
 
   fake_s3_query = instance_double(S3QueryService, data_profile: { objects: data, ok: true }, client: @s3_client,
-                                                  client_s3_files: data, prefix:)
+                                                  client_s3_files: data, prefix:, count_objects: data.count)
   mock_methods(fake_s3_query, data, bucket_name)
   allow(S3QueryService).to receive(:new).and_return(fake_s3_query)
 

--- a/spec/system/provenance_note_spec.rb
+++ b/spec/system/provenance_note_spec.rb
@@ -2,6 +2,10 @@
 require "rails_helper"
 
 RSpec.describe "Adding a Provenance note", type: :system, js: true do
+  before do
+    stub_s3
+  end
+
   context "A user that does not have permissions to edit the provenance" do
     let(:any_user) { FactoryBot.create(:user) }
     let(:work) { FactoryBot.create(:draft_work, created_by_user_id: any_user.id) }


### PR DESCRIPTION
Note I am showing the number of files and directories in AWS vs just the number of files. I think having that total number will help to compare between AWS and the UI.  With small numbers of files that are not in a directory structure the number of files and the number of directories is the same.  With complex data like that number can be far off and be disconcerting. 

I found 3 theoretical ways to count the files.  The first is the way in this PR, the second is via the aws command line, and the third is our current approach.  I counted the 1.4 Million files in the dspace bucket in the 3 ways. The new way in this PR took about half the time.  Not great since it is a little less than 6 minutes, but better than 10
```
[5] pry(main)> start_dateTime = DateTime.now; puts work.s3_query_service.count_objects(bucket_name:, prefix:); end_dateTime = DateTime.now; end_dateTime.to_i-start_dateTime.to_i
1441329
=> 340
[6] pry(main)> start_dateTime = DateTime.now; puts `aws s3api list-objects --bucket #{bucket_name} --prefix #{prefix}  --query "[length(Contents[])]"`; end_dateTime = DateTime.now; end_dateTime.to_i-start_dateTime.to_i
[
    1441329
]
=> 485
[7] pry(main)> start_dateTime = DateTime.now; puts work.s3_query_service.client_s3_files(reload: true, bucket_name:, prefix:, ignore_directories: false).count; end_dateTime = DateTime.now; end_dateTime.to_i-start_dateTime.to_i
Loading S3 objects. Bucket: prds-dataspace. Prefix: 10-34770/8ecv-zm19/. Elapsed: 603.536179 seconds
1441329
=> 604
```