### PR TITLE
Allow empty row in the creator and contributor tables to be ignored

### DIFF
--- a/app/javascript/entrypoints/pdc/edit_required_fields.es6
+++ b/app/javascript/entrypoints/pdc/edit_required_fields.es6
@@ -79,12 +79,14 @@ export default class EditRequiredFields {
     let validCreators = true;
     const rows = $('.creators-table-row');
     for (i = 0; i < rows.length; i += 1) {
-      if (!this.valid_required_field(rows[i], '.given-entry-creator', '.given-name-required-message')) {
-        validCreators = false;
-      }
+      if (!(new TableRow(rows[i])).is_empty()) {
+        if (!this.valid_required_field(rows[i], '.given-entry-creator', '.given-name-required-message')) {
+          validCreators = false;
+        }
 
-      if (!this.valid_required_field(rows[i], '.family-entry-creator', '.family-name-required-message')) {
-        validCreators = false;
+        if (!this.valid_required_field(rows[i], '.family-entry-creator', '.family-name-required-message')) {
+          validCreators = false;
+        }
       }
     }
     return validCreators;
@@ -107,8 +109,10 @@ export default class EditRequiredFields {
     let validContributors = true;
     const rows = $('.contributors-table-row');
     for (i = 0; i < rows.length; i += 1) {
-      if (!this.valid_required_field(rows[i], '.type-entry-contributor', '.type-required-message')) {
-        validContributors = false;
+      if (!(new TableRow(rows[i])).is_empty()) {
+        if (!this.valid_required_field(rows[i], '.type-entry-contributor', '.type-required-message')) {
+          validContributors = false;
+        }
       }
     }
     return validContributors;

--- a/spec/system/work_create_spec.rb
+++ b/spec/system/work_create_spec.rb
@@ -76,7 +76,8 @@ RSpec.describe "Form submission for a legacy dataset", type: :system do
       expect(find("tr:last-child input[name='creators[][family_name]']").value).to eq(user.family_name)
       expect(find("tr:last-child input[name='creators[][affiliation]']").value).to eq("")
       expect(page).to have_button("Add me as a Creator", disabled: true)
-
+      # make sure an empty creator row does not stop the form submission
+      click_on "Add Another Creator"
       click_on "Create New"
       expect(Work.all).not_to be_empty
       work = Work.last
@@ -111,7 +112,7 @@ RSpec.describe "Form submission for a legacy dataset", type: :system do
         find("tr:last-child input[name='creators[][family_name]']").set "Abrams"
         click_on "Add Another Creator"
         click_on "Create New"
-        expect(page).to have_content("Must provide a family name")
+        expect(page).to have_content("Must provide a given name")
       end
     end
 

--- a/spec/system/work_edit_spec.rb
+++ b/spec/system/work_edit_spec.rb
@@ -334,6 +334,8 @@ RSpec.describe "Creating and updating works", type: :system, js: true do
         click_on "Save Work"
         expect(page).to have_content("Must provide a role")
         find("tr:last-child select[name='contributors[][role]']").select "Contact Person"
+        # make sure an empty contributor row does not stop the form submission
+        click_on "Add Another Individual Contributor"
         click_on "Save Work"
         expect(page).to have_content("Work was successfully updated.")
         click_on "Edit"


### PR DESCRIPTION
Also fixes a bug in the test, which is filling in the Family name and the expecting it to also be blank.  This no longer occurs because we are ignoring empty rows, but did occur in the past because the empty row was causing the family name issue.

fixes #1628