### PR TITLE
Force README files to sort to the top.

### DIFF
--- a/app/views/works/_s3_resources.html.erb
+++ b/app/views/works/_s3_resources.html.erb
@@ -83,8 +83,10 @@
             if (type == "display") {
               var html;
               if (row.filename_display.startsWith("*")) {
+                // On edit mode, file is marked to be deleted display strikethrough
                 html = `<span><s>${row.filename_display.substring(1)}</s></span>`;
               } else {
+                // Display as a hyperlink with the download icon
                 html = `<span>
                   <i class="bi bi-file-arrow-down"></i>
                   <a href="<%= @work.id %>/download?filename=${data}" target="_blank">${row.filename_display}</a>
@@ -92,7 +94,15 @@
               }
               return html;
             }
-            return data;
+
+            // Force any readme file to sort to the top
+            var sortValue;
+            if (data.toLowerCase().includes("readme")) {
+              sortValue = "A" + data;
+            } else {
+              sortValue = "Z" + data;
+            }
+            return sortValue;
           },
           targets: 0,
         },
@@ -110,10 +120,11 @@
           render: function (data, type, row) {
             // size
             if (type == "display") {
-              // with commas
-              return data.toLocaleString("en-US");
+              // human readable (e.g. 34 KB)
+              return row.display_size;
             }
-            return data;
+            // raw bytes
+            return row.size;
           },
           targets: 2,
           className: 'dt-right'


### PR DESCRIPTION
Forces any file with the word "README" to be sorted first.

We also fixed an issue with the sort by size.

Closes #1643 
