### PR TITLE
Ignoring the bucket in the AWS Key count

### DIFF
--- a/app/services/s3_query_service.rb
+++ b/app/services/s3_query_service.rb
@@ -331,7 +331,8 @@ class S3QueryService
 
   def count_objects(bucket_name: self.bucket_name, prefix: self.prefix)
     responses = s3_responses(bucket_name:, prefix:)
-    responses.reduce(0) { |total, resp| total + resp.key_count }
+    total_key_count = responses.reduce(0) { |total, resp| total + resp.key_count }
+    total_key_count - 1 # s3 always sends back the bucket key as the first response, so we should not count it
   end
 
   private

--- a/spec/services/s3_query_service_spec.rb
+++ b/spec/services/s3_query_service_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe S3QueryService do
 
   subject(:s3_query_service) { described_class.new(work) }
   let(:work) { FactoryBot.create :draft_work, doi: }
-  let(:s3_key1) { "10.34770/pe9w-x904/#{work.id}/SCoData_combined_v1_2020-07_README.txt" }
-  let(:s3_key2) { "10.34770/pe9w-x904/#{work.id}/SCoData_combined_v1_2020-07_datapackage.json" }
+  let(:s3_bucket_key) { "10.34770/pe9w-x904/#{work.id}/" }
+  let(:s3_key1) { "#{s3_bucket_key}SCoData_combined_v1_2020-07_README.txt" }
+  let(:s3_key2) { "#{s3_bucket_key}SCoData_combined_v1_2020-07_datapackage.json" }
   let(:s3_last_modified1) { Time.parse("2022-04-21T18:29:40.000Z") }
   let(:s3_last_modified2) { Time.parse("2022-04-21T18:30:07.000Z") }
   let(:s3_size1) { 5_368_709_122 }
@@ -17,6 +18,13 @@ RSpec.describe S3QueryService do
     {
       is_truncated: false,
       contents: [
+        {
+          etag: "\"#{s3_etag1}\"",
+          key: s3_bucket_key,
+          last_modified: s3_last_modified1,
+          size: 0,
+          storage_class: "STANDARD"
+        },
         {
           etag: "\"#{s3_etag1}\"",
           key: s3_key1,
@@ -390,7 +398,7 @@ XML
           fake_s3_resp.stub(:next_continuation_token).and_return("abc")
         end
         it "returns all the objects" do
-          expect(s3_query_service.count_objects).to eq(6)
+          expect(s3_query_service.count_objects).to eq(7) # do not count the bucket the first time
         end
       end
     end
@@ -730,13 +738,15 @@ XML
 
     it "retrieves the directories if requested" do
       files = s3_query_service.client_s3_files(reload: true, bucket_name: "other-bucket", prefix: "new-prefix", ignore_directories: false)
-      expect(files.count).to eq 6
-      expect(files.first.filename).to match(/README/)
-      expect(files[1].filename).to match(/SCoData_combined_v1_2020-07_datapackage.json/)
-      expect(files[2].filename).to match(/directory/)
-      expect(files[3].filename).to match(/README/)
-      expect(files[4].filename).to match(/SCoData_combined_v1_2020-07_datapackage.json/)
-      expect(files[5].filename).to match(/directory/)
+      expect(files.count).to eq 8
+      expect(files.first.filename).to match(/#{s3_bucket_key}/)
+      expect(files[1].filename).to match(/README/)
+      expect(files[2].filename).to match(/SCoData_combined_v1_2020-07_datapackage.json/)
+      expect(files[3].filename).to match(/directory/)
+      expect(files[4].filename).to match(/#{s3_bucket_key}/)
+      expect(files[5].filename).to match(/README/)
+      expect(files[6].filename).to match(/SCoData_combined_v1_2020-07_datapackage.json/)
+      expect(files[7].filename).to match(/directory/)
       expect(fake_aws_client).to have_received(:list_objects_v2).with(bucket: "other-bucket", max_keys: 1000, prefix: "new-prefix")
       expect(fake_aws_client).to have_received(:list_objects_v2).with(bucket: "other-bucket", continuation_token: "abc123", max_keys: 1000, prefix: "new-prefix")
     end


### PR DESCRIPTION
It turns out the response for the AWS bucket listing always include the bucket as the first response Updated the fake response to reflect that fact and then updated the code to ignore that entry.

fixes #1651

`Aws::S3::Types::Object key="10.34770/tbd/1/"` is the bucket in the response below:
```
[
#<struct Aws::S3::Types::Object key="10.34770/tbd/1/", last_modified=2023-09-19 19:48:45 UTC, etag="\"d41d8cd98f00b204e9800998ecf8427e\"", checksum_algorithm=[], size=0, storage_class="STANDARD", owner=nil>, 
#<struct Aws::S3::Types::Object key="10.34770/tbd/1/Copy of HTML _ Accessibility Checkpoint Project.docx", last_modified=2023-10-23 18:32:28 UTC, etag="\"91010724f6b805fd2d1952c8e263f799\"", checksum_algorithm=[], size=93342, storage_class="STANDARD", owner=nil>, 
#<struct Aws::S3::Types::Object key="10.34770/tbd/1/Dry He 0.5mm 10kV le=1.2mJ RH 50%.csv", last_modified=2023-09-13 20:45:47 UTC, etag="\"872fb8c15612b59c58691c680d870a94\"", checksum_algorithm=[], size=677, storage_class="STANDARD", owner=nil>, 
#<struct Aws::S3::Types::Object key="10.34770/tbd/1/Dry He 0.5mm 15kV le=1.2mJ RH 50%.csv", last_modified=2023-09-13 20:45:48 UTC, etag="\"c7aea9fd7dccf69cfefbc54eb9b5efc0\"", checksum_algorithm=[], size=681, storage_class="STANDARD", owner=nil>, 
#<struct Aws::S3::Types::Object key="10.34770/tbd/1/Dry He 0.5mm 20kV le=1.8mJ RH 50%.csv", last_modified=2023-09-13 20:45:48 UTC, etag="\"97de08a7a04914c21a15afb0290a15fd\"", checksum_algorithm=[], size=683, storage_class="STANDARD", owner=nil>, 
#<struct Aws::S3::Types::Object key="10.34770/tbd/1/Dry He 1mm 10kV le=1.2mJ RH 50%.csv", last_modified=2023-09-13 20:45:49 UTC, etag="\"e634df78f3916fccf9b3fa705df05eb7\"", checksum_algorithm=[], size=646, storage_class="STANDARD", owner=nil>, 
#<struct Aws::S3::Types::Object key="10.34770/tbd/1/Dry He 1mm 15kV le=1.2mJ RH 50%.csv", last_modified=2023-09-13 20:45:50 UTC, etag="\"3f0427261733efd933f5dbbe64fe8f4c\"", checksum_algorithm=[], size=665, storage_class="STANDARD", owner=nil>, 
#<struct Aws::S3::Types::Object key="10.34770/tbd/1/Dry He 1mm 20kV le=1.2mJ RH 50%.csv", last_modified=2023-09-13 20:45:51 UTC, etag="\"06b0b4eeb3230a78094a679e556ecee3\"", checksum_algorithm=[], size=668, storage_class="STANDARD", owner=nil>, 
#<struct Aws::S3::Types::Object key="10.34770/tbd/1/Dry He 2mm 10kV le=0.8mJ RH 50%.csv", last_modified=2023-09-13 20:45:42 UTC, etag="\"e2c52cfb61a418f3c51e08f263736c3f\"", checksum_algorithm=[], size=660, storage_class="STANDARD", owner=nil>, 
#<struct Aws::S3::Types::Object key="10.34770/tbd/1/Dry He 2mm 15kV le=0.8mJ RH 50%.csv", last_modified=2023-09-13 20:45:43 UTC, etag="\"79dedd60c83864186dd29e342f65e619\"", checksum_algorithm=[], size=662, storage_class="STANDARD", owner=nil>, 
#<struct Aws::S3::Types::Object key="10.34770/tbd/1/Dry He 2mm 20kV le=0.8mJ RH 50%.csv", last_modified=2023-09-13 20:45:43 UTC, etag="\"9d8d0f22676870521f7d4bb4a00229a0\"", checksum_algorithm=[], size=680, storage_class="STANDARD", owner=nil>, 
#<struct Aws::S3::Types::Object key="10.34770/tbd/1/Dry He 3mm 10kV le=1.2mJ RH 50%.csv", last_modified=2023-09-13 20:45:44 UTC, etag="\"6f99afe829a4d56cc465f51f531b8f42\"", checksum_algorithm=[], size=649, storage_class="STANDARD", owner=nil>, 
#<struct Aws::S3::Types::Object key="10.34770/tbd/1/Dry He 3mm 15kV le=1.2mJ RH 50%.csv", last_modified=2023-09-13 20:45:45 UTC, etag="\"7a20aa2d82a3f5221d9da7fd7766f396\"", checksum_algorithm=[], size=660, storage_class="STANDARD", owner=nil>, 
#<struct Aws::S3::Types::Object key="10.34770/tbd/1/Dry He 3mm 20kV le=1.2mJ RH 50%.csv", last_modified=2023-09-13 20:45:46 UTC, etag="\"9c6c51061219439b826a7b0b6fe5d395\"", checksum_algorithm=[], size=676, storage_class="STANDARD", owner=nil>, 
#<struct Aws::S3::Types::Object key="10.34770/tbd/1/README.txt", last_modified=2023-10-23 18:31:34 UTC, etag="\"098f6bcd4621d373cade4e832627b4f6\"", checksum_algorithm=[], size=4, storage_class="STANDARD", owner=nil>, 
#<struct Aws::S3::Types::Object key="10.34770/tbd/1/all OH LIF decays.xlsx", last_modified=2023-09-13 20:45:41 UTC, etag="\"a02a2fc95e574fe8cd32c0db5293ffc4\"", checksum_algorithm=[], size=19406, storage_class="STANDARD", owner=nil>, 
#<struct Aws::S3::Types::Object key="10.34770/tbd/1/example (3).pdf", last_modified=2023-09-18 13:48:18 UTC, etag="\"2942bfabb3d05332b66eb128e0842cff\"", checksum_algorithm=[], size=13264, storage_class="STANDARD", owner=nil>, 
#<struct Aws::S3::Types::Object key="10.34770/tbd/1/laser width.xlsx", last_modified=2023-09-13 20:45:40 UTC, etag="\"746161f9fe429f089f3e5121913d409a\"", checksum_algorithm=[], size=29194, storage_class="STANDARD", owner=nil>, 
#<struct Aws::S3::Types::Object key="10.34770/tbd/1/old-san-juan.jpg", last_modified=2023-09-26 15:49:46 UTC, etag="\"bda5e94228b165fbd7260ea96da14b05\"", checksum_algorithm=[], size=3103293, storage_class="STANDARD", owner=nil>, 
#<struct Aws::S3::Types::Object key="10.34770/tbd/1/research_data_and_figures.zip", last_modified=2023-09-18 19:21:20 UTC, etag="\"5b1079005f8ae790a347cd453892c281\"", checksum_algorithm=[], size=43086, storage_class="STANDARD", owner=nil>, 
#<struct Aws::S3::Types::Object key="10.34770/tbd/1/service-status-ok.png", last_modified=2023-10-23 15:27:18 UTC, etag="\"5feed06fb35c3505892ef7dd229c3c0f\"", checksum_algorithm=[], size=2305348, storage_class="STANDARD", owner=nil>, 
#<struct Aws::S3::Types::Object key="10.34770/tbd/1/this_is_a_readme_file.txt", last_modified=2024-01-09 17:23:51 UTC, etag="\"f776a8707d6045c0b32811f900f5fe2a\"", checksum_algorithm=[], size=23, storage_class="STANDARD", owner=nil>
]
```