### PR TITLE
Setting the user's default group to the current group when they are created as a submitter

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -47,7 +47,8 @@ class GroupsController < ApplicationController
   # This is a JSON only endpoint
   def add_submitter
     @group = Group.find(params[:id])
-    @group.add_submitter(current_user, User.new_for_uid(params[:uid]))
+    user = @group.default_user(params[:uid])
+    @group.add_submitter(current_user, user)
     check_and_render
   end
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -203,5 +203,14 @@ class Group < ApplicationRecord
   def default_community
     return communities.first if code == "PPPL"
   end
+
+  def default_user(uid)
+    user = User.find_by(uid:)
+    return user if user.present?
+
+    user = User.new(uid:, default_group_id: id)
+    user.save!
+    user
+  end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -60,7 +60,7 @@ class User < ApplicationRecord
     self.given_name = access_token.extra.givenname || access_token.uid # Harriet
     self.family_name = access_token.extra.sn || access_token.uid # Tubman
     self.full_name = access_token.extra.displayname || access_token.uid # "Harriet Tubman"
-    self.default_group_id = Group.default_for_department(access_token.extra.departmentnumber)&.id
+    self.default_group_id ||= Group.default_for_department(access_token.extra.departmentnumber)&.id
     save!
   end
 

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -115,4 +115,17 @@ RSpec.describe Group, type: :model do
       expect { group.disable_messages_for(user:) }.to raise_error(ArgumentError, "User #{user.uid} is not an administrator or submitter for this group #{group.title}")
     end
   end
+
+  describe "#default_user" do
+    it "creates a new user with the current group as the deafult" do
+      user = Group.plasma_laboratory.default_user("abc123")
+      expect(user.default_group).to eq(Group.plasma_laboratory)
+    end
+
+    it "allows an existing user to keep it's original group" do
+      user = User.new_for_uid("abc123")
+      Group.plasma_laboratory.default_user("abc123")
+      expect(user.reload.default_group).to eq(Group.research_data)
+    end
+  end
 end

--- a/spec/system/authz_admin_spec.rb
+++ b/spec/system/authz_admin_spec.rb
@@ -43,6 +43,19 @@ RSpec.describe "Authz for curators", type: :system, js: true do
         expect(new_submitter.can_submit?(Group.research_data)).to eq true
       end
 
+      it "can add submitters to a group that are not current users" do
+        login_as pppl_moderator
+        expect(pppl_moderator.can_admin?(Group.plasma_laboratory)).to eq true
+        expect(User.where(uid: "test1").count).to eq(0)
+        visit edit_group_path(Group.plasma_laboratory)
+        fill_in "submitter-uid-to-add", with: "test1"
+        click_on "Add Submitter"
+        expect(page).to have_content "test1"
+        new_submitter = User.last
+        expect(new_submitter.can_submit?(Group.plasma_laboratory)).to eq true
+        expect(new_submitter.default_group).to eq(Group.plasma_laboratory)
+      end
+
       it "can add admins to the group" do
         login_as research_data_moderator
         expect(research_data_moderator.can_admin?(Group.research_data)).to eq true


### PR DESCRIPTION
fixes #1659