### PR TITLE
Removing controller action for file cluster

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -151,8 +151,6 @@ class WorksController < ApplicationController
     next_url = case @work.files_location
                when "file_upload"
                  work_file_upload_url(@work)
-               when "file_cluster"
-                 work_file_cluster_url(@work)
                else
                  work_file_other_url(@work)
                end
@@ -179,11 +177,6 @@ class WorksController < ApplicationController
     flash[:notice] = "Failed to attach the file uploads for the work #{@work.doi}: #{active_storage_error}. Please contact rdss@princeton.edu for assistance."
 
     redirect_to work_file_upload_path(@work)
-  end
-
-  # Allow user to indicate where their files are located in the PUL Research Cluster
-  def file_cluster
-    @work = Work.find(params[:id])
   end
 
   # Allow user to indicate where their files are located in the WWW

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,6 @@ Rails.application.routes.draw do
   post "works/:id/attachment-select", to: "works#attachment_selected", as: :work_attachment_selected
   patch "works/:id/file-upload", to: "works#file_uploaded", as: :work_file_uploaded
   get "works/:id/file-upload", to: "works#file_upload", as: :work_file_upload
-  get "works/:id/file-cluster", to: "works#file_cluster", as: :work_file_cluster
   get "works/:id/file-other", to: "works#file_other", as: :work_file_other
   get "works/:id/review", to: "works#review", as: :work_review
   post "works/:id/review", to: "works#review"

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -700,16 +700,6 @@ RSpec.describe WorksController do
         expect(fake_s3_service).not_to have_received(:create_directory)
       end
 
-      context "when type is file_cluster" do
-        let(:attachment_type) { "file_cluster" }
-
-        it "redirects to file-cluster" do
-          expect(response.status).to be 302
-          expect(response.location).to eq "http://test.host/works/#{work.id}/file-cluster"
-          expect(fake_s3_service).to have_received(:create_directory)
-        end
-      end
-
       context "when type is file_other" do
         let(:attachment_type) { "file_other" }
 


### PR DESCRIPTION
The option was removed from the wizard.  We should also remove it from the controller