### PR TITLE
Ensures that download URLs for Work assets prepend the "/describe" path

### DIFF
--- a/app/decorators/work_decorator.rb
+++ b/app/decorators/work_decorator.rb
@@ -50,6 +50,10 @@ class WorkDecorator
   def download_path
     return if @work.nil? || !@work.persisted?
 
-    work_download_path(@work.id)
+    if Rails.env.production? || Rails.env.staging?
+      "/describe" + work_download_path(@work.id)
+    else
+      work_download_path(@work.id)
+    end
   end
 end


### PR DESCRIPTION
(This fixes an urgent bug in production related to https://github.com/pulibrary/pdc_describe/issues/1665#issuecomment-2012430189)