### PR TITLE
Uses Uppy for uploads in the Work edit screen

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -225,6 +225,9 @@ class WorksController < ApplicationController
 
   def upload_files
     byebug
+    upload_service = WorkUploadsEditService.new(@work, current_user)
+    files = params["files"]
+    upload_service.update_precurated_file_list(files, [])
   end
 
   private

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -119,7 +119,7 @@ class WorksController < ApplicationController
   # GET /works/1/edit
   # only non wizard mode
   def edit
-    @new_uploader = true
+    @new_uploader = params[:new_uploader] == "true"
     @work = Work.find(params[:id])
     @work_decorator = WorkDecorator.new(@work, current_user)
     if handle_modification_permissions

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -119,6 +119,7 @@ class WorksController < ApplicationController
   # GET /works/1/edit
   # only non wizard mode
   def edit
+    @new_uploader = true
     @work = Work.find(params[:id])
     @work_decorator = WorkDecorator.new(@work, current_user)
     if handle_modification_permissions
@@ -224,10 +225,9 @@ class WorksController < ApplicationController
   end
 
   def upload_files
-    byebug
+    @work = Work.find(params[:id])
     upload_service = WorkUploadsEditService.new(@work, current_user)
-    files = params["files"]
-    upload_service.update_precurated_file_list(files, [])
+    upload_service.update_precurated_file_list(params["files"], [])
   end
 
   private

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -223,6 +223,10 @@ class WorksController < ApplicationController
     send_data bibtex, filename: "#{citation.bibtex_id}.bibtex", type: "text/plain", disposition: "attachment"
   end
 
+  def upload_files
+    byebug
+  end
+
   private
 
     # Extract the Work ID parameter

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -108,7 +108,8 @@ class WorksController < ApplicationController
   # GET /works/1/edit
   # only non wizard mode
   def edit
-    @new_uploader = params[:new_uploader] == "true"
+    @new_uploader = params[:new_uploader] == "true" || Rails.env.staging?
+
     @work = Work.find(params[:id])
     @work_decorator = WorkDecorator.new(@work, current_user)
     if validate_modification_permissions(work: @work,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.1/font/bootstrap-icons.css">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
     <link rel="stylesheet" href="https://code.jquery.com/ui/1.13.0/themes/ui-lightness/jquery-ui.css">
+    <link href="https://transloadit.edgly.net/releases/uppy/v0.25.2/dist/uppy.min.css" rel="stylesheet">
 
     <!-- Popper must be included before bootstrap JS
       See https://getbootstrap.com/docs/5.1/getting-started/download/ -->
@@ -31,6 +32,9 @@
       // Then the stand-alone JS files can reference this.
       let pdc = {};
     </script>
+
+    <!-- Bottom of the page -->
+    <script src="https://transloadit.edgly.net/releases/uppy/v0.25.2/dist/uppy.min.js"></script>
   </head>
 
   <body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,7 +33,7 @@
       let pdc = {};
     </script>
 
-    <!-- Bottom of the page -->
+    <!-- Uppy is used for file uploads -->
     <script src="https://transloadit.edgly.net/releases/uppy/v0.25.2/dist/uppy.min.js"></script>
   </head>
 

--- a/app/views/works/_form.html.erb
+++ b/app/views/works/_form.html.erb
@@ -27,13 +27,18 @@
             <%= render(partial: 'works/s3_resources', locals: { edit_mode: true, form: form }) %>
           </section>
           <div class="container-fluid deposit-uploads">
+
+            <% if @new_uploader == true %>
+              <div id="file-upload-area"></div>
+              <button id="add-files-button" class="btn btn-secondary" style="width: 200px;"><i class="bi bi-plus-circle"></i> Add More Files</button>
+            <% else %>
+              <%= form.label("Choose files to attach to this work", for: :pre_curation_uploads_added) %>
+              <%= form.file_field(:pre_curation_uploads_added, id: "pre_curation_uploads_added", multiple: true) %>
+              <!-- We populate this via JavaScript as the user selected files to upload -->
+              <div id="file-upload-list"></div>
+            <% end %>
             <div id="file-error" class="error_box"></div>
-            <%= form.label("Choose files to attach to this work", for: :pre_curation_uploads_added) %>
-            <%= form.file_field(:pre_curation_uploads_added, id: "pre_curation_uploads_added", multiple: true) %>
-            <!-- We populate this via JavaScript as the user selected files to upload -->
-            <div id="file-upload-list"></div>
           </div>
-          <div id="drag-drop-area"></div>
         <% end %>
       </div>
 
@@ -55,11 +60,36 @@
 <script>
   // https://davidwalsh.name/uppy-file-uploading
   // https://stackoverflow.com/a/75050497/446681
+  // https://uppy.io/docs/dashboard
+  // https://uppy.io/docs/xhr-upload/#bundle
   var uppy = Uppy.Core({ autoProceed: false })
-  uppy.use(Uppy.Dashboard, { target: '#drag-drop-area', inline: true })
+
+  uppy.use(Uppy.Dashboard, {
+    target: '#file-upload-area',
+    inline: false, // display of dashboard only when trigger is clicked
+    trigger: "#add-files-button"
+  })
+
   uppy.use(Uppy.XHRUpload, {
-    endpoint: '<%= work_upload_files_path(@work) %>' ,
+    endpoint: '<%= work_upload_files_path(@work) %>',
     headers: {
         'X-CSRF-Token': document.querySelector("meta[name='csrf-token']").content
-    }})
+    },
+    bundle: true,   // upload all selected files at once
+    formData: true, // required when bundle: true
+    getResponseData: function(responseText, response) {
+      const dashboard = uppy.getPlugin('Dashboard');
+      if (dashboard.isModalOpen()) {
+	      dashboard.closeModal();
+      }
+      // Reload the file list displayed
+      let fileTable = $('#files-table').dataTable();
+      fileTable.api().ajax.reload();
+    }
+  })
+
+  $("#add-files-button").on("click", function(_x) {
+    // Prevent the button's click from submitting the form
+    return false;
+  })
 </script>

--- a/app/views/works/_form.html.erb
+++ b/app/views/works/_form.html.erb
@@ -33,6 +33,7 @@
             <!-- We populate this via JavaScript as the user selected files to upload -->
             <div id="file-upload-list"></div>
           </div>
+          <div id="drag-drop-area"></div>
         <% end %>
       </div>
 
@@ -50,3 +51,15 @@
     <% end %>
   </div>
 </div>
+
+<script>
+  // https://davidwalsh.name/uppy-file-uploading
+  // https://stackoverflow.com/a/75050497/446681
+  var uppy = Uppy.Core({ autoProceed: false })
+  uppy.use(Uppy.Dashboard, { target: '#drag-drop-area', inline: true })
+  uppy.use(Uppy.XHRUpload, {
+    endpoint: '<%= work_upload_files_path(@work) %>' ,
+    headers: {
+        'X-CSRF-Token': document.querySelector("meta[name='csrf-token']").content
+    }})
+</script>

--- a/app/views/works/_form.html.erb
+++ b/app/views/works/_form.html.erb
@@ -59,17 +59,20 @@
 
 <script>
   // https://davidwalsh.name/uppy-file-uploading
-  // https://stackoverflow.com/a/75050497/446681
-  // https://uppy.io/docs/dashboard
-  // https://uppy.io/docs/xhr-upload/#bundle
-  var uppy = Uppy.Core({ autoProceed: false })
+  // https://uppy.io/blog/2018/08/0.27/#autoproceed-false-by-default
+  var uppy = Uppy.Core({ autoProceed: true })
 
+  // Configure the initial display
+  // https://uppy.io/docs/dashboard
   uppy.use(Uppy.Dashboard, {
     target: '#file-upload-area',
     inline: false, // display of dashboard only when trigger is clicked
     trigger: "#add-files-button"
   })
 
+  // We use the XHRUploader - this is the most basic
+  // https://uppy.io/docs/xhr-upload/
+  // X-CSRF-Toke: https://stackoverflow.com/a/75050497/446681
   uppy.use(Uppy.XHRUpload, {
     endpoint: '<%= work_upload_files_path(@work) %>',
     headers: {

--- a/app/views/works/_form.html.erb
+++ b/app/views/works/_form.html.erb
@@ -29,9 +29,11 @@
           <div class="container-fluid deposit-uploads">
 
             <% if @new_uploader == true %>
+              <!-- Uses Uppy for uploading -->
               <div id="file-upload-area"></div>
               <button id="add-files-button" class="btn btn-secondary" style="width: 200px;"><i class="bi bi-plus-circle"></i> Add More Files</button>
             <% else %>
+              <!-- Uses the browser's default file upload controls -->
               <%= form.label("Choose files to attach to this work", for: :pre_curation_uploads_added) %>
               <%= form.file_field(:pre_curation_uploads_added, id: "pre_curation_uploads_added", multiple: true) %>
               <!-- We populate this via JavaScript as the user selected files to upload -->
@@ -58,8 +60,10 @@
 </div>
 
 <script>
-  // https://davidwalsh.name/uppy-file-uploading
-  // https://uppy.io/blog/2018/08/0.27/#autoproceed-false-by-default
+  // Setup Uppy to handle file uploads
+  // References:
+  //    https://davidwalsh.name/uppy-file-uploading
+  //    https://uppy.io/blog/2018/08/0.27/#autoproceed-false-by-default
   var uppy = Uppy.Core({ autoProceed: true })
 
   // Configure the initial display
@@ -72,7 +76,7 @@
 
   // We use the XHRUploader - this is the most basic
   // https://uppy.io/docs/xhr-upload/
-  // X-CSRF-Toke: https://stackoverflow.com/a/75050497/446681
+  // X-CSRF-Token: https://stackoverflow.com/a/75050497/446681
   uppy.use(Uppy.XHRUpload, {
     endpoint: '<%= work_upload_files_path(@work) %>',
     headers: {
@@ -81,10 +85,6 @@
     bundle: true,   // upload all selected files at once
     formData: true, // required when bundle: true
     getResponseData: function(responseText, response) {
-      const dashboard = uppy.getPlugin('Dashboard');
-      if (dashboard.isModalOpen()) {
-	      dashboard.closeModal();
-      }
       // Reload the file list displayed
       let fileTable = $('#files-table').dataTable();
       fileTable.api().ajax.reload();

--- a/app/views/works/_form.html.erb
+++ b/app/views/works/_form.html.erb
@@ -59,6 +59,12 @@
   </div>
 </div>
 
+<!--
+  Only render the Uppy JavaScript if we are using it.
+  This also prevents the call to `work_upload_files_path(@work)` when the `work.id` is nil
+  which happens when migrating a dataset from DataSpace.
+-->
+<% if @new_uploader == true %>
 <script>
   // Setup Uppy to handle file uploads
   // References:
@@ -96,3 +102,4 @@
     return false;
   })
 </script>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ Rails.application.routes.draw do
   resources :works
   get "/doi/*doi", to: "works#resolve_doi", as: :resolve_doi, format: false
   get "/ark/*ark", to: "works#resolve_ark", as: :resolve_ark, format: false
+  post "works/:id/upload-files", to: "works#upload_files", as: :work_upload_files
 
   get "upload-snapshots/:work_id", to: "upload_snapshots#edit", as: :edit_upload_snapshot
   get "upload-snapshots/:id/download", to: "upload_snapshots#download", as: :download_upload_snapshot


### PR DESCRIPTION
Integrates Uppy to handle file uploads in the Work edit screen (i.e. not in the Wizard)

![Screenshot 2024-04-02 at 4 50 22 PM](https://github.com/pulibrary/pdc_describe/assets/568286/84716257-7f34-45ba-9966-45ead83fa29d)

Closes #1685 forward

Notice that Uppy is only used if we pass the `new_uploader=true` as a query string parameter. I am going to use this to demo the functionality to Matt.

There are a couple of additional tickets to implement this in the Wizard too: https://github.com/pulibrary/pdc_describe/issues/1731 and https://github.com/pulibrary/pdc_describe/issues/1732
