### PR TITLE
Allowing the new submission form to save and stay on page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -288,6 +288,7 @@ th {
 
 .actions .btn-primary {
   background-color: #467dd1ff;
+  margin-right: 0.5em;
 }
 
 .submit-ordered-list {

--- a/app/controllers/works_wizard_controller.rb
+++ b/app/controllers/works_wizard_controller.rb
@@ -27,15 +27,12 @@ class WorksWizardController < ApplicationController
     prepare_decorators_for_work_form(@work)
   end
 
-  # Creates the new dataset
-  # POST /works/1/new_submission
+  # Creates the new dataset or update the dataset is save only was done previously
+  # POST /works/new_submission or POST /works/1/new_submission
   def new_submission_save
-    group = Group.find_by(code: params[:group_code]) || current_user.default_group
-    group_id = group.id
-    @work = Work.new(created_by_user_id: current_user.id, group_id:)
-    @work.resource = FormToResourceService.convert(params, @work)
-    @work.draft!(current_user)
-    if params[:save_only] == "true"
+    @work = WorkMetadataService.new(params:, current_user:).new_submission
+    @errors = @work.errors.to_a
+    if params[:save_only] == "true" || @errors.count.positive?
       prepare_decorators_for_work_form(@work)
       render :new_submission
     else

--- a/app/services/work_metadata_service.rb
+++ b/app/services/work_metadata_service.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# A place to move the logic to from the work controllers
+#   Process the parameters and permissions to update a work
+class WorkMetadataService
+  attr_reader :params, :current_user
+
+  # @params [User] current_user the user who is currently logged in
+  # @param [HashWithIndifferentAccess] update_params values to update the work with
+  def initialize(params:, current_user:)
+    @params = params
+    @current_user = current_user
+  end
+
+  # generates or load the work for a new submission based on the parameters
+  #
+  #
+  # @returns the new or updated work
+  #
+  def new_submission
+    if params[:id].present?
+      update_work
+    else
+      draft_work
+    end
+  end
+
+private
+
+  def update_work
+    work = Work.find(params[:id])
+    update_params = { group: group_code, resource: FormToResourceService.convert(params, work) }
+    WorkCompareService.update_work(work:, update_params:, current_user:)
+    work
+  end
+
+  def draft_work
+    group_id = group_code.id
+    work = Work.new(created_by_user_id: current_user.id, group_id:)
+    work.resource = FormToResourceService.convert(params, work)
+    if work.valid_to_draft
+      work.draft!(current_user)
+    end
+    work
+  end
+
+  def group_code
+    @group_code ||= Group.find_by(code: params[:group_code]) || current_user.default_group
+  end
+end

--- a/app/views/works_wizard/new_submission.html.erb
+++ b/app/views/works_wizard/new_submission.html.erb
@@ -59,7 +59,7 @@
     your submission, we may be reached at <a href="mailto:prds@princeton.edu">prds@princeton.edu</a>.
   </p>
 
-  <%= form_tag(action: "new_submission_save") do %>
+  <%= form_with(model: @work, url: work_new_submission_path(@work)) do |form| %>
     <%= render(partial: 'works/required_title', locals: {allow_many: false}) %>
     <%= render(partial: 'works/required_creators_table') %>
     <%= render '/works/form_hidden_fields' %>
@@ -67,6 +67,7 @@
     <div class="actions">
       <%= link_to "Cancel", root_path, class: "btn btn-secondary" %>
       <%= submit_tag "Next", class: "btn btn-primary wizard-next-button", id: "btn-create-new" %>
+      <%= form.button 'Save', type: 'submit', name: 'save_only', value: 'true', class: "btn btn-primary wizard-next-button" %>
     </div>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,8 @@ Rails.application.routes.draw do
 
   # The work wizard
   get "works/new-submission", to: "works_wizard#new_submission", as: :work_create_new_submission
-  post "works/new-submission", to: "works_wizard#new_submission_save", as: :work_new_submission
+  post "works/new-submission/(:id)", to: "works_wizard#new_submission_save", as: :work_new_submission
+  patch "works/new-submission/:id", to: "works_wizard#new_submission_save"
   get "works/:id/readme-select", to: "works_wizard#readme_select", as: :work_readme_select
   patch "works/:id/readme-uploaded", to: "works_wizard#readme_uploaded", as: :work_readme_uploaded
   patch "works/:id/file-upload", to: "works_wizard#file_uploaded", as: :work_file_uploaded


### PR DESCRIPTION
This was more complex than expected, because some times the work is persisted and sometimes not now that we can stay on the page.

For this reason I extracted some code into the WorkMetadataService.

The new button:
![Screenshot 2024-04-01 at 11 23 51 AM](https://github.com/pulibrary/pdc_describe/assets/1599081/103922c4-7afa-4bee-9c37-976e148cab1f)

#1684 
