### PR TITLE
Adds the additional step to the wizard that takes you to the Additional Metadata portion of the form

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,25 +15,6 @@ class ApplicationController < ActionController::Base
 
   private
 
-  def rescue_aasm_error
-    yield
-  rescue AASM::InvalidTransition => error
-    message = message_from_assm_error(aasm_error: error, work: @work)
-    Honeybadger.notify("Invalid #{@work.current_transition}: #{error.message} errors: #{message}")
-    transition_error_message = "We apologize, the following errors were encountered: #{message}. Please contact the PDC Describe administrators for any assistance."
-    @errors = [transition_error_message]
-
-    if @work.persisted?
-      redirect_to edit_work_url(id: @work.id), notice: transition_error_message, params:
-    else
-      new_params = {}
-      new_params[:wizard] = wizard_mode? if wizard_mode?
-      new_params[:migrate] = migrating? if migrating?
-      @form_resource_decorator = FormResourceDecorator.new(@work, current_user)
-      redirect_to new_work_url(params: new_params), notice: transition_error_message, params: new_params
-    end
-  end
-
     # Take all the errors from the exception and the work and combine them into a single error message that can be shown to the user
     #
     # @param [AASM::InvalidTransition] aasm_error Error thrown by trying to transition states

--- a/app/controllers/works_update_additional_controller.rb
+++ b/app/controllers/works_update_additional_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "nokogiri"
+require "open-uri"
+
+# Controller to handle the update Additional Metadata step in wizard Mode when editing an work
+#
+# The wizard flow is as follows:
+# new_submission -> new_submission_save -> edit_wizard -> update_wizard -> update_additional -> update_additional_save ->readme_select -> readme_uploaded -> attachment_select ->
+#     attachment_selected -> file_other ->                  review -> validate -> [ work controller ] show & file_list
+#                         \> file_upload -> file_uploaded -^
+
+class WorksUpdateAdditionalController < WorksWizardController
+  before_action :load_work, only: [:update_additional_save, :update_additional]
+
+  # get /works/1/update-additional
+  def update_additional
+    prepare_decorators_for_work_form(@work)
+  end
+
+  # PATCH /works/1/update-additional
+  def update_additional_save
+    edit_helper(:update_additional, work_readme_select_path(@work))
+  end
+end

--- a/app/controllers/works_wizard_controller.rb
+++ b/app/controllers/works_wizard_controller.rb
@@ -16,7 +16,7 @@ class WorksWizardController < ApplicationController
 
   before_action :load_work, only: [:edit_wizard, :update_wizard, :attachment_select, :attachment_selected,
                                    :file_upload, :file_uploaded, :file_other, :review, :validate,
-                                   :readme_select, :readme_uploaded]
+                                   :readme_select, :readme_uploaded, :update_additional_save]
 
   # get Renders the "step 0" information page before creating a new dataset
   # GET /works/new_submission
@@ -51,20 +51,7 @@ class WorksWizardController < ApplicationController
 
   # PATCH /works/1/update-wizard
   def update_wizard
-    if validate_modification_permissions(work: @work,
-                                         uneditable_message: "Can not update work: #{@work.id} is not editable by #{current_user.uid}",
-                                         current_state_message: "Can not update work: #{@work.id} is not editable in current state by #{current_user.uid}")
-      prepare_decorators_for_work_form(@work)
-      if WorkCompareService.update_work(work: @work, update_params:, current_user:)
-        if params[:save_only] == "true"
-          render :edit_wizard
-        else
-          redirect_to work_update_additional_path(@work)
-        end
-      else
-        render :edit_wizard, status: :unprocessable_entity
-      end
-    end
+    edit_helper(:edit_wizard, work_update_additional_path(@work))
   end
 
   # get /works/1/update-additional
@@ -72,21 +59,9 @@ class WorksWizardController < ApplicationController
 
   # PATCH /works/1/update-additional
   def update_additional_save
-    if validate_modification_permissions(work: @work,
-                                         uneditable_message: "Can not update work: #{@work.id} is not editable by #{current_user.uid}",
-                                         current_state_message: "Can not update work: #{@work.id} is not editable in current state by #{current_user.uid}")
-      prepare_decorators_for_work_form(@work)
-      if WorkCompareService.update_work(work: @work, update_params:, current_user:)
-        if params[:save_only] == "true"
-          render :update_additional
-        else
-          redirect_to work_readme_select_url(@work)
-        end
-      else
-        render :update_additional, status: :unprocessable_entity
-      end
-    end
+    edit_helper(:update_additional, work_readme_select_path(@work))
   end
+
   # Prompt to select how to submit their files
   # GET /works/1/attachment_select
   def attachment_select; end
@@ -191,6 +166,23 @@ class WorksWizardController < ApplicationController
   helper_method :file_location_url
 
   private
+
+    def edit_helper(view_name, redirect_url)
+      if validate_modification_permissions(work: @work,
+                                           uneditable_message: "Can not update work: #{@work.id} is not editable by #{current_user.uid}",
+                                           current_state_message: "Can not update work: #{@work.id} is not editable in current state by #{current_user.uid}")
+        prepare_decorators_for_work_form(@work)
+        if WorkCompareService.update_work(work: @work, update_params:, current_user:)
+          if params[:save_only] == "true"
+            render view_name
+          else
+            redirect_to redirect_url
+          end
+        else
+          render view_name, status: :unprocessable_entity
+        end
+      end
+    end
 
     def load_work
       @work = Work.find(params[:id])

--- a/app/controllers/works_wizard_controller.rb
+++ b/app/controllers/works_wizard_controller.rb
@@ -59,7 +59,7 @@ class WorksWizardController < ApplicationController
         if params[:save_only] == "true"
           render :edit_wizard
         else
-          redirect_to work_readme_select_url(@work)
+          redirect_to work_update_additional_path(@work)
         end
       else
         render :edit_wizard, status: :unprocessable_entity
@@ -67,6 +67,26 @@ class WorksWizardController < ApplicationController
     end
   end
 
+  # get /works/1/update-additional
+  def update_additional; end
+
+  # PATCH /works/1/update-additional
+  def update_additional_save
+    if validate_modification_permissions(work: @work,
+                                         uneditable_message: "Can not update work: #{@work.id} is not editable by #{current_user.uid}",
+                                         current_state_message: "Can not update work: #{@work.id} is not editable in current state by #{current_user.uid}")
+      prepare_decorators_for_work_form(@work)
+      if WorkCompareService.update_work(work: @work, update_params:, current_user:)
+        if params[:save_only] == "true"
+          render :update_additional
+        else
+          redirect_to work_readme_select_url(@work)
+        end
+      else
+        render :update_additional, status: :unprocessable_entity
+      end
+    end
+  end
   # Prompt to select how to submit their files
   # GET /works/1/attachment_select
   def attachment_select; end

--- a/app/controllers/works_wizard_controller.rb
+++ b/app/controllers/works_wizard_controller.rb
@@ -16,7 +16,7 @@ class WorksWizardController < ApplicationController
 
   before_action :load_work, only: [:edit_wizard, :update_wizard, :attachment_select, :attachment_selected,
                                    :file_upload, :file_uploaded, :file_other, :review, :validate,
-                                   :readme_select, :readme_uploaded, :update_additional_save]
+                                   :readme_select, :readme_uploaded, :update_additional_save, :update_additional]
 
   # get Renders the "step 0" information page before creating a new dataset
   # GET /works/new_submission
@@ -55,7 +55,9 @@ class WorksWizardController < ApplicationController
   end
 
   # get /works/1/update-additional
-  def update_additional; end
+  def update_additional
+    prepare_decorators_for_work_form(@work)
+  end
 
   # PATCH /works/1/update-additional
   def update_additional_save

--- a/app/controllers/works_wizard_controller.rb
+++ b/app/controllers/works_wizard_controller.rb
@@ -6,7 +6,7 @@ require "open-uri"
 # Controller to handle wizard Mode when editing an work
 #
 # The wizard flow is as follows:
-# new_submission -> new_submission_save -> edit_wizard -> update_wizard -> readme_select -> readme_uploaded -> attachment_select ->
+# new_submission -> new_submission_save -> edit_wizard -> update_wizard -> update_additional -> update_additional_save ->readme_select -> readme_uploaded -> attachment_select ->
 #     attachment_selected -> file_other ->                  review -> validate -> [ work controller ] show & file_list
 #                         \> file_upload -> file_uploaded -^
 
@@ -16,7 +16,7 @@ class WorksWizardController < ApplicationController
 
   before_action :load_work, only: [:edit_wizard, :update_wizard, :attachment_select, :attachment_selected,
                                    :file_upload, :file_uploaded, :file_other, :review, :validate,
-                                   :readme_select, :readme_uploaded, :update_additional_save, :update_additional]
+                                   :readme_select, :readme_uploaded]
 
   # get Renders the "step 0" information page before creating a new dataset
   # GET /works/new_submission
@@ -52,16 +52,6 @@ class WorksWizardController < ApplicationController
   # PATCH /works/1/update-wizard
   def update_wizard
     edit_helper(:edit_wizard, work_update_additional_path(@work))
-  end
-
-  # get /works/1/update-additional
-  def update_additional
-    prepare_decorators_for_work_form(@work)
-  end
-
-  # PATCH /works/1/update-additional
-  def update_additional_save
-    edit_helper(:update_additional, work_readme_select_path(@work))
   end
 
   # Prompt to select how to submit their files

--- a/app/views/works/_form.html.erb
+++ b/app/views/works/_form.html.erb
@@ -7,11 +7,12 @@
 -->
 <div class="d-flex align-items-start">
 
-<%= render 'form_nav' %>
+<%= render  partial: 'form_nav', locals:  { additional_selected: false, required_selected: true,
+                                            additional_button_class: "show active", required_button_class: "" }  %>
 
   <div>
     <%= form_with(model: @work, class: ["work-form"], data: { work: @work.form_attributes }) do |form| %>
-      <%= render partial: 'form_metadata', locals:  { form: form } %>
+      <%= render partial: 'form_metadata', locals:  { form: form, required_class: "show active", additional_class: "" } %>
 
 
       <hr />

--- a/app/views/works/_form.html.erb
+++ b/app/views/works/_form.html.erb
@@ -8,7 +8,7 @@
 <div class="d-flex align-items-start">
 
 <%= render  partial: 'form_nav', locals:  { additional_selected: false, required_selected: true,
-                                            additional_button_class: "show active", required_button_class: "" }  %>
+                                            additional_button_class: "", required_button_class: "show active" }  %>
 
   <div>
     <%= form_with(model: @work, class: ["work-form"], data: { work: @work.form_attributes }) do |form| %>

--- a/app/views/works/_form_metadata.html.erb
+++ b/app/views/works/_form_metadata.html.erb
@@ -2,13 +2,13 @@
 <div class="tab-content" id="v-pills-tabContent">
 
     <!-- tab: required fields -->
-    <div class="tab-pane fade" id="v-pills-required" role="tabpanel" aria-labelledby="v-pills-required-tab">
+    <div class="tab-pane fade <%= required_class %>" id="v-pills-required" role="tabpanel" aria-labelledby="v-pills-required-tab">
     <%= form.hidden_field :work_id %>
     <%= render '/works/required_form' %>
     </div>
 
     <!-- tab: additional fields -->
-    <div class="tab-pane show fade active" id="v-pills-additional" role="tabpanel" aria-labelledby="v-pills-additional-tab">
+    <div class="tab-pane fade <%= additional_class %>" id="v-pills-additional" role="tabpanel" aria-labelledby="v-pills-additional-tab">
     <%= render '/works/additional_form' %>
     </div>
 

--- a/app/views/works/_form_metadata.html.erb
+++ b/app/views/works/_form_metadata.html.erb
@@ -2,13 +2,13 @@
 <div class="tab-content" id="v-pills-tabContent">
 
     <!-- tab: required fields -->
-    <div class="tab-pane fade show active" id="v-pills-required" role="tabpanel" aria-labelledby="v-pills-required-tab">
+    <div class="tab-pane fade" id="v-pills-required" role="tabpanel" aria-labelledby="v-pills-required-tab">
     <%= form.hidden_field :work_id %>
     <%= render '/works/required_form' %>
     </div>
 
     <!-- tab: additional fields -->
-    <div class="tab-pane fade" id="v-pills-additional" role="tabpanel" aria-labelledby="v-pills-additional-tab">
+    <div class="tab-pane show fade active" id="v-pills-additional" role="tabpanel" aria-labelledby="v-pills-additional-tab">
     <%= render '/works/additional_form' %>
     </div>
 

--- a/app/views/works/_form_nav.html.erb
+++ b/app/views/works/_form_nav.html.erb
@@ -1,6 +1,6 @@
 <!-- This div holds the "tabs menu" section that we display on the left -->
 <div class="nav flex-column nav-pills me-3" id="v-pills-tab" role="tablist" aria-orientation="vertical">
-  <button class="nav-link active" id="v-pills-required-tab" data-bs-toggle="pill" data-bs-target="#v-pills-required" type="button" role="tab" aria-controls="v-pills-required" aria-selected="true">Required Metadata</button>
-  <button class="nav-link btn btn-light" id="v-pills-additional-tab" data-bs-toggle="pill" data-bs-target="#v-pills-additional" type="button" role="tab" aria-controls="v-pills-additional" aria-selected="false">Additional Metadata</button>
+  <button class="nav-link <%= required_button_class %>" id="v-pills-required-tab" data-bs-toggle="pill" data-bs-target="#v-pills-required" type="button" role="tab" aria-controls="v-pills-required" aria-selected="<%= required_selected %>">Required Metadata</button>
+  <button class="nav-link btn btn-light <%= additional_button_class %>" id="v-pills-additional-tab" data-bs-toggle="pill" data-bs-target="#v-pills-additional" type="button" role="tab" aria-controls="v-pills-additional" aria-selected="<%= additional_selected %>">Additional Metadata</button>
   <button class="nav-link" id="v-pills-curator-controlled-tab" data-bs-toggle="pill" data-bs-target="#v-pills-curator-controlled" type="button" role="tab" aria-controls="v-pills-curator-controlled" aria-selected="false"><%= t('works.form.curator_controlled') %></button>
 </div>

--- a/app/views/works_update_additional/_form_wizard.html.erb
+++ b/app/views/works_update_additional/_form_wizard.html.erb
@@ -7,12 +7,12 @@
 -->
 <div class="d-flex align-items-start">
 
-<%= render  partial: '/works/form_nav', locals:  { additional_selected: false, required_selected: true,
-                                                   additional_button_class: "", required_button_class: "show active" } %>
+<%= render  partial: '/works/form_nav', locals:  { additional_selected: true, required_selected: false,
+                                                   additional_button_class: "show active", required_button_class: "" } %>
 
   <div>
-    <%= form_with(model: @work, url: update_work_wizard_path(@work), class: ["work-form"], data: { work: @work.form_attributes }) do |form| %>
-      <%= render partial: '/works/form_metadata', locals:  { form: form, required_class: "show active", additional_class: "" } %>
+    <%= form_with(model: @work, url: work_update_additional_path(@work), class: ["work-form"], data: { work: @work.form_attributes }) do |form| %>
+      <%= render partial: '/works/form_metadata', locals:  { form: form, required_class: "", additional_class: "show active" } %>
 
       <hr />
       <div class="actions">
@@ -20,6 +20,7 @@
 
         <%= form.submit "Next", class: "btn btn-primary wizard-next-button", id: "btn-submit" %>
         <%= form.button 'Save', type: 'submit', name: 'save_only', value: 'true', class: "btn btn-save wizard-next-button" %>
+        <%= link_to 'Previous', edit_work_wizard_path(@work), class: "btn btn-previous wizard-next-button" %>
       </div>
 
       <%= render '/works/form_hidden_fields' %>

--- a/app/views/works_update_additional/update_additional.html.erb
+++ b/app/views/works_update_additional/update_additional.html.erb
@@ -1,7 +1,7 @@
 <div class="wizard-area">
   <h1>New Submission</h1>
-  <%= render "wizard_progress", wizard_step: 1 %>
-  <%= render partial: 'form_wizard', locals: { form_submit_url: work_update_additional_path(@work),
+  <%= render "/works_wizard/wizard_progress", wizard_step: 1 %>
+  <%= render partial: '/works_wizard/form_wizard', locals: { form_submit_url: work_update_additional_path(@work),
                                                additional_selected: true, required_selected: false,
                                                required_class: "", additional_class: "show active"} %>
 </div>

--- a/app/views/works_update_additional/update_additional.html.erb
+++ b/app/views/works_update_additional/update_additional.html.erb
@@ -1,9 +1,7 @@
 <div class="wizard-area">
   <h1>New Submission</h1>
   <%= render "/works_wizard/wizard_progress", wizard_step: 1 %>
-  <%= render partial: '/works_wizard/form_wizard', locals: { form_submit_url: work_update_additional_path(@work),
-                                               additional_selected: true, required_selected: false,
-                                               required_class: "", additional_class: "show active"} %>
+  <%= render partial: 'form_wizard' %>
 </div>
 
 <%= javascript_include_tag 'edit_work_utils' %>

--- a/app/views/works_wizard/_form_wizard.html.erb
+++ b/app/views/works_wizard/_form_wizard.html.erb
@@ -10,7 +10,7 @@
 <%= render '/works/form_nav' %>
 
   <div>
-    <%= form_with(model: @work, url: update_work_wizard_path(@work), class: ["work-form"], data: { work: @work.form_attributes }) do |form| %>
+    <%= form_with(model: @work, url: form_submit_url, class: ["work-form"], data: { work: @work.form_attributes }) do |form| %>
       <%= render partial: '/works/form_metadata', locals:  { form: form } %>
 
       <hr />

--- a/app/views/works_wizard/_form_wizard.html.erb
+++ b/app/views/works_wizard/_form_wizard.html.erb
@@ -7,11 +7,12 @@
 -->
 <div class="d-flex align-items-start">
 
-<%= render '/works/form_nav' %>
+<%= render  partial: '/works/form_nav', locals:  { additional_selected: additional_selected, required_selected: required_selected,
+                                                   additional_button_class: additional_class, required_button_class: required_class}  %>
 
   <div>
     <%= form_with(model: @work, url: form_submit_url, class: ["work-form"], data: { work: @work.form_attributes }) do |form| %>
-      <%= render partial: '/works/form_metadata', locals:  { form: form } %>
+      <%= render partial: '/works/form_metadata', locals:  { form: form, required_class:, additional_class: } %>
 
       <hr />
       <div class="actions">

--- a/app/views/works_wizard/edit_wizard.html.erb
+++ b/app/views/works_wizard/edit_wizard.html.erb
@@ -1,7 +1,9 @@
 <div class="wizard-area">
   <h1>New Submission</h1>
   <%= render "wizard_progress", wizard_step: 1 %>
-  <%= render partial: 'form_wizard', locals: { form_submit_url: update_work_wizard_path(@work)} %>
+  <%= render partial: 'form_wizard', locals: { form_submit_url: update_work_wizard_path(@work),
+                                               additional_selected: false, required_selected: true,
+                                               required_class: "show active", additional_class: ""} %>
 </div>
 
 <%= javascript_include_tag 'edit_work_utils' %>

--- a/app/views/works_wizard/edit_wizard.html.erb
+++ b/app/views/works_wizard/edit_wizard.html.erb
@@ -1,7 +1,7 @@
 <div class="wizard-area">
   <h1>New Submission</h1>
   <%= render "wizard_progress", wizard_step: 1 %>
-  <%= render 'form_wizard' %>
+  <%= render partial: 'form_wizard', locals: { form_submit_url: update_work_wizard_path(@work)} %>
 </div>
 
 <%= javascript_include_tag 'edit_work_utils' %>

--- a/app/views/works_wizard/readme_select.html.erb
+++ b/app/views/works_wizard/readme_select.html.erb
@@ -27,7 +27,7 @@
     <div class="actions">
       <%= f.submit(t('works.form.readme_upload.continue'), class: "btn btn-primary wizard-next-button", id: 'readme-upload', disabled: @readme.blank?) %>
       <%= f.button 'Save', type: 'submit', name: 'save_only', value: 'true', class: "btn btn-save wizard-next-button" %>
-      <%= link_to 'Previous', edit_work_wizard_path(@work), class: "btn btn-previous wizard-next-button" %>
+      <%= link_to 'Previous', work_update_additional_path(@work), class: "btn btn-previous wizard-next-button" %>
     </div>
   <% end %>
 </div>

--- a/app/views/works_wizard/update_additional.html.erb
+++ b/app/views/works_wizard/update_additional.html.erb
@@ -1,7 +1,7 @@
 <div class="wizard-area">
   <h1>New Submission</h1>
   <%= render "wizard_progress", wizard_step: 1 %>
-  <%= render 'form_wizard' %>
+  <%= render partial: 'form_wizard', locals: { form_submit_url: work_update_additional_path(@work)} %>
 </div>
 
 <%= javascript_include_tag 'edit_work_utils' %>

--- a/app/views/works_wizard/update_additional.html.erb
+++ b/app/views/works_wizard/update_additional.html.erb
@@ -1,7 +1,9 @@
 <div class="wizard-area">
   <h1>New Submission</h1>
   <%= render "wizard_progress", wizard_step: 1 %>
-  <%= render partial: 'form_wizard', locals: { form_submit_url: work_update_additional_path(@work)} %>
+  <%= render partial: 'form_wizard', locals: { form_submit_url: work_update_additional_path(@work),
+                                               additional_selected: true, required_selected: false,
+                                               required_class: "", additional_class: "show active"} %>
 </div>
 
 <%= javascript_include_tag 'edit_work_utils' %>

--- a/app/views/works_wizard/update_additional.html.erb
+++ b/app/views/works_wizard/update_additional.html.erb
@@ -1,0 +1,7 @@
+<div class="wizard-area">
+  <h1>New Submission</h1>
+  <%= render "wizard_progress", wizard_step: 1 %>
+  <%= render 'form_wizard' %>
+</div>
+
+<%= javascript_include_tag 'edit_work_utils' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,8 +37,6 @@ Rails.application.routes.draw do
   get "works/:id/file-upload", to: "works_wizard#file_upload", as: :work_file_upload
   patch "works/:id/update-wizard", to: "works_wizard#update_wizard", as: :update_work_wizard
   get "works/:id/edit-wizard", to: "works_wizard#edit_wizard", as: :edit_work_wizard
-  get "works/:id/update-additional", to: "works_wizard#update_additional", as: :work_update_additional
-  patch "works/:id/update-additional", to: "works_wizard#update_additional_save"
   get "works/:id/file-other", to: "works_wizard#file_other", as: :work_file_other
   get "works/:id/review", to: "works_wizard#review", as: :work_review
   post "works/:id/review", to: "works_wizard#review"
@@ -48,6 +46,9 @@ Rails.application.routes.draw do
   get "works/:id/attachment-select", to: "works_wizard#attachment_select", as: :work_attachment_select
   post "works/:id/attachment-select", to: "works_wizard#attachment_selected", as: :work_attachment_selected
   patch "works/:id/attachment-select", to: "works_wizard#attachment_selected"
+
+  get "works/:id/update-additional", to: "works_update_additional#update_additional", as: :work_update_additional
+  patch "works/:id/update-additional", to: "works_update_additional#update_additional_save"
 
   get "works/:id/file-list", to: "works#file_list", as: :work_file_list
   post "work/:id/approve", to: "works#approve", as: :approve_work

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,8 @@ Rails.application.routes.draw do
   get "works/:id/file-upload", to: "works_wizard#file_upload", as: :work_file_upload
   patch "works/:id/update-wizard", to: "works_wizard#update_wizard", as: :update_work_wizard
   get "works/:id/edit-wizard", to: "works_wizard#edit_wizard", as: :edit_work_wizard
+  get "works/:id/update-additional", to: "works_wizard#update_additional", as: :work_update_additional
+  patch "works/:id/update-additional", to: "works_wizard#update_additional_save"
   get "works/:id/file-other", to: "works_wizard#file_other", as: :work_file_other
   get "works/:id/review", to: "works_wizard#review", as: :work_review
   post "works/:id/review", to: "works_wizard#review"

--- a/spec/controllers/works_update_additonal_controller_spec.rb
+++ b/spec/controllers/works_update_additonal_controller_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WorksUpdateAdditionalController do
+  include ActiveJob::TestHelper
+  before do
+    stub_ark
+    Group.create_defaults
+    user
+    stub_datacite(host: "api.datacite.org", body: datacite_register_body(prefix: "10.34770"))
+    allow(ActiveStorage::PurgeJob).to receive(:new).and_call_original
+
+    stub_request(:get, /#{Regexp.escape('https://example-bucket.s3.amazonaws.com/us_covid_20')}.*\.csv/).to_return(status: 200, body: "", headers: {})
+  end
+
+  let(:group) { Group.first }
+  let(:curator) { FactoryBot.create(:user, groups_to_admin: [group]) }
+  let(:resource) { FactoryBot.build :resource }
+  let(:work) { FactoryBot.create(:draft_work, doi: "10.34770/123-abc") }
+  let(:user) { work.created_by_user }
+  let(:pppl_user) { FactoryBot.create(:pppl_submitter) }
+
+  let(:uploaded_file) { fixture_file_upload("us_covid_2019.csv", "text/csv") }
+
+  context "valid user login" do
+    describe "#update_additional_save" do
+      let(:params) do
+        {
+          "title_main" => "test dataset updated",
+          "description" => "a new description",
+          "group_id" => work.group.id,
+          "commit" => "Update Dataset",
+          "controller" => "works",
+          "action" => "update",
+          "id" => work.id.to_s,
+          "publisher" => "Princeton University",
+          "publication_year" => "2022",
+          creators: [{ "orcid" => "", "given_name" => "Jane", "family_name" => "Smith" }]
+        }
+      end
+
+      it "updates the Work and redirects the readme to select" do
+        sign_in user
+        patch(:update_additional_save, params:)
+        expect(response.status).to be 302
+        expect(response.location).to eq "http://test.host/works/#{work.id}/readme-select"
+        expect(ActiveStorage::PurgeJob).not_to have_received(:new)
+      end
+
+      context "save and stay on page" do
+        let(:stay_params) { params.merge(save_only: true) }
+
+        it "updates the Work and redirects the client to select attachments" do
+          sign_in user
+          patch(:update_additional_save, params: stay_params)
+          expect(response.status).to be 200
+          expect(response).to render_template(:update_additional)
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/works_wizard_controller_spec.rb
+++ b/spec/controllers/works_wizard_controller_spec.rb
@@ -102,42 +102,6 @@ RSpec.describe WorksWizardController do
       end
     end
 
-    describe "#update_additional" do
-      let(:params) do
-        {
-          "title_main" => "test dataset updated",
-          "description" => "a new description",
-          "group_id" => work.group.id,
-          "commit" => "Update Dataset",
-          "controller" => "works",
-          "action" => "update",
-          "id" => work.id.to_s,
-          "publisher" => "Princeton University",
-          "publication_year" => "2022",
-          creators: [{ "orcid" => "", "given_name" => "Jane", "family_name" => "Smith" }]
-        }
-      end
-
-      it "updates the Work and redirects the readme to select" do
-        sign_in user
-        patch(:update_additional_save, params:)
-        expect(response.status).to be 302
-        expect(response.location).to eq "http://test.host/works/#{work.id}/readme-select"
-        expect(ActiveStorage::PurgeJob).not_to have_received(:new)
-      end
-
-      context "save and stay on page" do
-        let(:stay_params) { params.merge(save_only: true) }
-
-        it "updates the Work and redirects the client to select attachments" do
-          sign_in user
-          patch(:update_additional_save, params: stay_params)
-          expect(response.status).to be 200
-          expect(response).to render_template(:update_additional)
-        end
-      end
-    end
-
     describe "#readme_select" do
       let(:fake_readme) { instance_double Readme, file_name: "README.txt" }
 

--- a/spec/controllers/works_wizard_controller_spec.rb
+++ b/spec/controllers/works_wizard_controller_spec.rb
@@ -103,41 +103,40 @@ RSpec.describe WorksWizardController do
     end
 
     describe "#update_additional" do
-    let(:params) do
-      {
-        "title_main" => "test dataset updated",
-        "description" => "a new description",
-        "group_id" => work.group.id,
-        "commit" => "Update Dataset",
-        "controller" => "works",
-        "action" => "update",
-        "id" => work.id.to_s,
-        "publisher" => "Princeton University",
-        "publication_year" => "2022",
-        "keywords" => "one,two,three",
-        creators: [{ "orcid" => "", "given_name" => "Jane", "family_name" => "Smith" }]
-      }
-    end
+      let(:params) do
+        {
+          "title_main" => "test dataset updated",
+          "description" => "a new description",
+          "group_id" => work.group.id,
+          "commit" => "Update Dataset",
+          "controller" => "works",
+          "action" => "update",
+          "id" => work.id.to_s,
+          "publisher" => "Princeton University",
+          "publication_year" => "2022",
+          creators: [{ "orcid" => "", "given_name" => "Jane", "family_name" => "Smith" }]
+        }
+      end
 
-    it "updates the Work and redirects the readme to select" do
-      sign_in user
-      post(:update_additional, params:)
-      expect(response.status).to be 302
-      expect(response.location).to eq "http://test.host/works/#{work.id}/readme-select"
-      expect(ActiveStorage::PurgeJob).not_to have_received(:new)
-    end
-
-    context "save and stay on page" do
-      let(:stay_params) { params.merge(save_only: true) }
-
-      it "updates the Work and redirects the client to select attachments" do
+      it "updates the Work and redirects the readme to select" do
         sign_in user
-        post(:update_additional, params: stay_params)
-        expect(response.status).to be 200
-        expect(response).to render_template(:update_additional)
+        patch(:update_additional_save, params:)
+        expect(response.status).to be 302
+        expect(response.location).to eq "http://test.host/works/#{work.id}/readme-select"
+        expect(ActiveStorage::PurgeJob).not_to have_received(:new)
+      end
+
+      context "save and stay on page" do
+        let(:stay_params) { params.merge(save_only: true) }
+
+        it "updates the Work and redirects the client to select attachments" do
+          sign_in user
+          patch(:update_additional_save, params: stay_params)
+          expect(response.status).to be 200
+          expect(response).to render_template(:update_additional)
+        end
       end
     end
-  end
 
     describe "#readme_select" do
       let(:fake_readme) { instance_double Readme, file_name: "README.txt" }

--- a/spec/controllers/works_wizard_controller_spec.rb
+++ b/spec/controllers/works_wizard_controller_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe WorksWizardController do
         sign_in user
         post(:update_wizard, params:)
         expect(response.status).to be 302
-        expect(response.location).to eq "http://test.host/works/#{work.id}/readme-select"
+        expect(response.location).to eq "http://test.host/works/#{work.id}/update-additional"
         expect(ActiveStorage::PurgeJob).not_to have_received(:new)
       end
 
@@ -101,6 +101,43 @@ RSpec.describe WorksWizardController do
         end
       end
     end
+
+    describe "#update_additional" do
+    let(:params) do
+      {
+        "title_main" => "test dataset updated",
+        "description" => "a new description",
+        "group_id" => work.group.id,
+        "commit" => "Update Dataset",
+        "controller" => "works",
+        "action" => "update",
+        "id" => work.id.to_s,
+        "publisher" => "Princeton University",
+        "publication_year" => "2022",
+        "keywords" => "one,two,three",
+        creators: [{ "orcid" => "", "given_name" => "Jane", "family_name" => "Smith" }]
+      }
+    end
+
+    it "updates the Work and redirects the readme to select" do
+      sign_in user
+      post(:update_additional, params:)
+      expect(response.status).to be 302
+      expect(response.location).to eq "http://test.host/works/#{work.id}/readme-select"
+      expect(ActiveStorage::PurgeJob).not_to have_received(:new)
+    end
+
+    context "save and stay on page" do
+      let(:stay_params) { params.merge(save_only: true) }
+
+      it "updates the Work and redirects the client to select attachments" do
+        sign_in user
+        post(:update_additional, params: stay_params)
+        expect(response.status).to be 200
+        expect(response).to render_template(:update_additional)
+      end
+    end
+  end
 
     describe "#readme_select" do
       let(:fake_readme) { instance_double Readme, file_name: "README.txt" }

--- a/spec/system/authz_submitter_spec.rb
+++ b/spec/system/authz_submitter_spec.rb
@@ -33,6 +33,8 @@ RSpec.describe "Authz for submitters", type: :system, js: true do
       click_on "Curator Controlled"
       expect(page).to have_content "Research Data"
       click_on "Next"
+      expect(page).to have_content("These metadata properties are not required")  #testing additional metadata page
+      click_on "Next"
       path = Rails.root.join("spec", "fixtures", "files", "readme.txt")
       attach_file(path) do
         page.find("#patch_readme_file").click

--- a/spec/system/authz_submitter_spec.rb
+++ b/spec/system/authz_submitter_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Authz for submitters", type: :system, js: true do
       click_on "Curator Controlled"
       expect(page).to have_content "Research Data"
       click_on "Next"
-      expect(page).to have_content("These metadata properties are not required")  #testing additional metadata page
+      expect(page).to have_content("These metadata properties are not required") # testing additional metadata page
       click_on "Next"
       path = Rails.root.join("spec", "fixtures", "files", "readme.txt")
       attach_file(path) do

--- a/spec/system/authz_super_admin_spec.rb
+++ b/spec/system/authz_super_admin_spec.rb
@@ -31,6 +31,8 @@ RSpec.describe "Authz for super admins", type: :system, js: true do
       click_on "Curator Controlled"
       expect(page).to have_content "Research Data"
       click_on "Next"
+      expect(page).to have_content("These metadata properties are not required")  #testing additional metadata page
+      click_on "Next"
       path = Rails.root.join("spec", "fixtures", "files", "readme.txt")
       attach_file(path) do
         page.find("#patch_readme_file").click

--- a/spec/system/authz_super_admin_spec.rb
+++ b/spec/system/authz_super_admin_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Authz for super admins", type: :system, js: true do
       click_on "Curator Controlled"
       expect(page).to have_content "Research Data"
       click_on "Next"
-      expect(page).to have_content("These metadata properties are not required")  #testing additional metadata page
+      expect(page).to have_content("These metadata properties are not required") # testing additional metadata page
       click_on "Next"
       path = Rails.root.join("spec", "fixtures", "files", "readme.txt")
       attach_file(path) do

--- a/spec/system/external_ids_spec.rb
+++ b/spec/system/external_ids_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "External Identifiers", type: :system, mock_ezid_api: true, js: t
     fill_in "description", with: "test description"
     select "GNU General Public License", from: "rights_identifiers"
     click_on "Next"
-    expect(page).to have_content("These metadata properties are not required")  #testing additional metadata page
+    expect(page).to have_content("These metadata properties are not required")  # testing additional metadata page
     click_on "Next"
     path = Rails.root.join("spec", "fixtures", "files", "readme.txt")
     attach_file(path) do

--- a/spec/system/external_ids_spec.rb
+++ b/spec/system/external_ids_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe "External Identifiers", type: :system, mock_ezid_api: true, js: t
     fill_in "description", with: "test description"
     select "GNU General Public License", from: "rights_identifiers"
     click_on "Next"
+    expect(page).to have_content("These metadata properties are not required")  #testing additional metadata page
+    click_on "Next"
     path = Rails.root.join("spec", "fixtures", "files", "readme.txt")
     attach_file(path) do
       page.find("#patch_readme_file").click

--- a/spec/system/pppl_work_create_spec.rb
+++ b/spec/system/pppl_work_create_spec.rb
@@ -42,6 +42,8 @@ RSpec.describe "Form submission for a PPPL dataset", type: :system do
       click_on "Curator Controlled"
       expect(page).to have_field("publisher", with: "Princeton Plasma Physics Laboratory, Princeton University")
       click_on "Next"
+      expect(page).to have_content("These metadata properties are not required")  #testing additional metadata page
+      click_on "Next"
       expect(page).to have_content("Please upload the README")
       expect(page).to have_button("Next", disabled: true)
       path = Rails.root.join("spec", "fixtures", "files", "readme.txt")

--- a/spec/system/pppl_work_create_spec.rb
+++ b/spec/system/pppl_work_create_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Form submission for a PPPL dataset", type: :system do
       click_on "Curator Controlled"
       expect(page).to have_field("publisher", with: "Princeton Plasma Physics Laboratory, Princeton University")
       click_on "Next"
-      expect(page).to have_content("These metadata properties are not required")  #testing additional metadata page
+      expect(page).to have_content("These metadata properties are not required") # testing additional metadata page
       click_on "Next"
       expect(page).to have_content("Please upload the README")
       expect(page).to have_button("Next", disabled: true)

--- a/spec/system/work_create_spec.rb
+++ b/spec/system/work_create_spec.rb
@@ -399,7 +399,7 @@ RSpec.describe "Form submission for a legacy dataset", type: :system do
       fill_in "description", with: description
       click_on "Next"
 
-      expect(page).to have_content("These metadata properties are not required")  #testing additional metadata page
+      expect(page).to have_content("These metadata properties are not required") # testing additional metadata page
       click_on "Next"
 
       expect(page).to have_content("Please upload the README")

--- a/spec/system/work_create_spec.rb
+++ b/spec/system/work_create_spec.rb
@@ -399,6 +399,9 @@ RSpec.describe "Form submission for a legacy dataset", type: :system do
       fill_in "description", with: description
       click_on "Next"
 
+      expect(page).to have_content("These metadata properties are not required")  #testing additional metadata page
+      click_on "Next"
+
       expect(page).to have_content("Please upload the README")
       expect(page).to have_button("Next", disabled: true)
 

--- a/spec/system/work_wizard_reverse_spec.rb
+++ b/spec/system/work_wizard_reverse_spec.rb
@@ -23,7 +23,7 @@ describe "walk the wizard in reverse", type: :system, js: true do
     expect(page).to have_content "By initiating this new submission"
     click_on "Next"
 
-    expect(page).to have_content("These metadata properties are not required")  #testing additional metadata page
+    expect(page).to have_content("These metadata properties are not required")  # testing additional metadata page
     click_on "Next"
 
     expect(page).to have_content "Please upload the README"

--- a/spec/system/work_wizard_reverse_spec.rb
+++ b/spec/system/work_wizard_reverse_spec.rb
@@ -23,6 +23,9 @@ describe "walk the wizard in reverse", type: :system, js: true do
     expect(page).to have_content "By initiating this new submission"
     click_on "Next"
 
+    expect(page).to have_content("These metadata properties are not required")  #testing additional metadata page
+    click_on "Next"
+
     expect(page).to have_content "Please upload the README"
     click_on "Next"
 

--- a/spec/system/work_wizard_reverse_spec.rb
+++ b/spec/system/work_wizard_reverse_spec.rb
@@ -20,6 +20,9 @@ describe "walk the wizard in reverse", type: :system, js: true do
     expect(page).to have_content "Please upload the README"
     click_on "Previous"
 
+    expect(page).to have_content "These metadata properties are not required"
+    click_on "Previous"
+
     expect(page).to have_content "By initiating this new submission"
     click_on "Next"
 

--- a/spec/system/work_wizard_spec.rb
+++ b/spec/system/work_wizard_spec.rb
@@ -17,6 +17,7 @@ describe "walk the wizard hitting all the buttons", type: :system, js: true do
 
     work = Work.last
     edit_form_css = "form[action='/works/#{work.id}/update-wizard']"
+    additional_form_css = "form[action='/works/#{work.id}/update-additional']"
     readme_form_css = "form[action='/works/#{work.id}/readme-uploaded']"
     upload_form_css = "form[action='/works/#{work.id}/attachment-select']"
     file_upload_form_css = "form[action='/works/#{work.id}/file-upload']"
@@ -29,6 +30,15 @@ describe "walk the wizard hitting all the buttons", type: :system, js: true do
     expect { click_on "Save" }.to change { work.work_activity.count }.by(1)
     expect(page).to have_css(edit_form_css)
     click_on "Next"
+
+    expect(page).to have_css(additional_form_css)
+
+    click_on "Previous"
+    expect(page).to have_css(edit_form_css)
+
+    click_on "Next"
+    expect(page).to have_css(additional_form_css)
+
     expect(page).to have_css(readme_form_css)
     expect(page).not_to have_content("previously uploaded")
 

--- a/spec/system/work_wizard_spec.rb
+++ b/spec/system/work_wizard_spec.rb
@@ -31,7 +31,7 @@ describe "walk the wizard hitting all the buttons", type: :system, js: true do
     expect(page).to have_css(edit_form_css)
     click_on "Next"
 
-    expect(page).to have_css(additional_form_css) #additional metadata has no previous button, so no need to test that it goes back
+    expect(page).to have_css(additional_form_css) # additional metadata has no previous button, so no need to test that it goes back
     click_on "Next"
 
     expect(page).to have_css(readme_form_css)
@@ -40,7 +40,7 @@ describe "walk the wizard hitting all the buttons", type: :system, js: true do
     click_on "Previous"
     expect(page).to have_css(edit_form_css)
     click_on "Next"
-    click_on "Next" #clicking next twice to get back to the readme
+    click_on "Next" # clicking next twice to get back to the readme
     expect(page).to have_css(readme_form_css)
     stub_s3 data: [FactoryBot.build(:s3_readme, work:)]
     click_on "Save"

--- a/spec/system/work_wizard_spec.rb
+++ b/spec/system/work_wizard_spec.rb
@@ -23,7 +23,7 @@ describe "walk the wizard hitting all the buttons", type: :system, js: true do
     file_upload_form_css = "form[action='/works/#{work.id}/file-upload']"
     validate_form_css = "form[action='/works/#{work.id}/validate']"
 
-    # edit form has no previous button so no need to test that is goes back
+    # edit form has no previous button so no need to test that it goes back
     expect(page).not_to have_content("Previous")
     expect(page).to have_css(edit_form_css)
     fill_in "description", with: "description"
@@ -31,13 +31,8 @@ describe "walk the wizard hitting all the buttons", type: :system, js: true do
     expect(page).to have_css(edit_form_css)
     click_on "Next"
 
-    expect(page).to have_css(additional_form_css)
-
-    click_on "Previous"
-    expect(page).to have_css(edit_form_css)
-
+    expect(page).to have_css(additional_form_css) #additional metadata has no previous button, so no need to test that it goes back
     click_on "Next"
-    expect(page).to have_css(additional_form_css)
 
     expect(page).to have_css(readme_form_css)
     expect(page).not_to have_content("previously uploaded")
@@ -45,6 +40,7 @@ describe "walk the wizard hitting all the buttons", type: :system, js: true do
     click_on "Previous"
     expect(page).to have_css(edit_form_css)
     click_on "Next"
+    click_on "Next" #clicking next twice to get back to the readme
     expect(page).to have_css(readme_form_css)
     stub_s3 data: [FactoryBot.build(:s3_readme, work:)]
     click_on "Save"

--- a/spec/system/work_wizard_spec.rb
+++ b/spec/system/work_wizard_spec.rb
@@ -31,16 +31,19 @@ describe "walk the wizard hitting all the buttons", type: :system, js: true do
     expect(page).to have_css(edit_form_css)
     click_on "Next"
 
-    expect(page).to have_css(additional_form_css) # additional metadata has no previous button, so no need to test that it goes back
+    expect(page).to have_css(additional_form_css)
+    click_on "Previous"
+    expect(page).to have_css(edit_form_css)
+    click_on "Next"
+    expect(page).to have_css(additional_form_css)
     click_on "Next"
 
     expect(page).to have_css(readme_form_css)
     expect(page).not_to have_content("previously uploaded")
 
     click_on "Previous"
-    expect(page).to have_css(edit_form_css)
+    expect(page).to have_css(additional_form_css)
     click_on "Next"
-    click_on "Next" # clicking next twice to get back to the readme
     expect(page).to have_css(readme_form_css)
     stub_s3 data: [FactoryBot.build(:s3_readme, work:)]
     click_on "Save"


### PR DESCRIPTION
fixes #1684 

Adds variables to the form partials to either show the required metadata tab first or the additional metadata tab first.
Updates the tests that walk through the system to hit next on the Additional metadata screen