### PR TITLE
Display confirm dialog before approving a work

### DIFF
--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -286,7 +286,7 @@
         <dt>Location notes</dt>
         <dd><%= @work.location_notes %></dd>
       <% end %>
-      <dt>Total Size</dt> 
+      <dt>Total Size</dt>
       <dd>
         <%= number_to_human_size(@work.total_file_size)%>
       </dd>
@@ -330,14 +330,10 @@
     });
 
     $("#approve-button").on("click", (event) => {
-      <% if @work.embargoed? %>
-        var embargo = true;
-      <% else %>
-        var embargo = false;
-      <% end %>
+      var embargo = <%= @work.embargoed? %>;
       var message = "";
       if(embargo == true){
-        message = "Embargo";
+        message = "You're about to publish this dataset, files will be embargoed until <%= @work.embargo_date %>. There's no going back. Are you sure?";
       }
       else{
         message = "You're about to publish this dataset. There's no going back. Are you sure?";

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -78,7 +78,7 @@
       <%= link_to("Edit", edit_work_path(@work, wizard: @work_decorator.wizard_mode?), class: "btn btn-primary") %>
     <% end %>
     <% if @work_decorator.show_approve_button? %>
-      <%= button_to("Approve Dataset", approve_work_path(@work), class: "btn btn-secondary", method: :post) %>
+      <%= button_to("Approve Dataset", approve_work_path(@work), class: "btn btn-secondary", method: :post, id: "approve-button") %>
     <% end %>
     <% if @work_decorator.show_complete_button? %>
       <%= button_to("Complete", work_validate_path(@work), class: "btn btn-secondary", method: :post) %>
@@ -327,6 +327,25 @@
       const oldClass = $leftOfMessages.attr("class");
       $leftOfMessages.attr("class", $leftOfMessages.data("class"));
       $leftOfMessages.data("class", oldClass);
+    });
+
+    $("#approve-button").on("click", (event) => {
+      <% if @work.embargoed? %>
+        var embargo = true;
+      <% else %>
+        var embargo = false;
+      <% end %>
+      var message = "";
+      if(embargo == true){
+        message = "Embargo";
+      }
+      else{
+        message = "You're about to publish this dataset. There's no going back. Are you sure?";
+      }
+      var input = confirm(message);
+      if(input == false){
+        event.preventDefault();
+      }
     });
 
     // Issues HTTP POST to update the curator assigned to the work.

--- a/spec/system/authz_super_admin_spec.rb
+++ b/spec/system/authz_super_admin_spec.rb
@@ -82,6 +82,7 @@ RSpec.describe "Authz for super admins", type: :system, js: true do
       sign_in super_admin
       visit work_path(work)
       click_on "Approve Dataset"
+      page.driver.browser.switch_to.alert.accept
       expect(page).to have_content "marked as Approved"
     end
   end

--- a/spec/system/migrate_submission_spec.rb
+++ b/spec/system/migrate_submission_spec.rb
@@ -186,6 +186,7 @@ RSpec.describe "Form submission for a legacy dataset", type: :system, mock_ezid_
 
       visit work_path(work)
       click_on "Approve"
+      page.driver.browser.switch_to.alert.accept
     end
 
     context "Approving a work with a DOI we own" do

--- a/spec/system/work_approve_spec.rb
+++ b/spec/system/work_approve_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe "Work Approval", type: :system do
       click_link work.title
       expect(page).to have_content(work.doi)
       click_on "Approve Dataset"
+      page.driver.browser.switch_to.alert.accept
       expect(page).to have_content("Uploads must be present for a work to be approved")
     end
   end

--- a/spec/system/work_approve_spec.rb
+++ b/spec/system/work_approve_spec.rb
@@ -21,5 +21,16 @@ RSpec.describe "Work Approval", type: :system do
       page.driver.browser.switch_to.alert.accept
       expect(page).to have_content("Uploads must be present for a work to be approved")
     end
+
+    it "does not display warning if user cancels approval", js: true do
+      sign_in curator
+      visit(user_path(curator))
+      expect(page).to have_content curator.given_name
+      click_link work.title
+      expect(page).to have_content(work.doi)
+      click_on "Approve Dataset"
+      page.driver.browser.switch_to.alert.dismiss
+      expect(page).to_not have_content("Uploads must be present for a work to be approved")
+    end
   end
 end


### PR DESCRIPTION
Display warning dialog before approving a work. Takes into account works with embargoes.

Closes #1650 