### PR TITLE
Fixes Wizard delay in displaying uploaded files

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -216,8 +216,12 @@ class WorksController < ApplicationController
 
   def upload_files
     @work = Work.find(params[:id])
-    upload_service = WorkUploadsEditService.new(@work, current_user)
-    upload_service.update_precurated_file_list(params["files"], [])
+    readme = Readme.new(@work, current_user)
+    params["files"].each do |file|
+      puts readme.attach_other(file)
+    end
+    # upload_service = WorkUploadsEditService.new(@work, current_user)
+    # upload_service.update_precurated_file_list(params["files"], [])
   end
 
   private

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -354,7 +354,7 @@ class WorksController < ApplicationController
 
         return head(:forbidden) unless deleted_uploads.empty?
       else
-        @work = upload_service.update_precurated_file_list(added_files_param, deleted_files_param, true)
+        @work = upload_service.update_precurated_file_list(added_files_param, deleted_files_param)
       end
 
       process_updates

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -350,7 +350,7 @@ class WorksController < ApplicationController
 
         return head(:forbidden) unless deleted_uploads.empty?
       else
-        @work = upload_service.update_precurated_file_list(added_files_param, deleted_files_param)
+        @work = upload_service.update_precurated_file_list(added_files_param, deleted_files_param, true)
       end
 
       process_updates

--- a/app/controllers/works_wizard_controller.rb
+++ b/app/controllers/works_wizard_controller.rb
@@ -73,6 +73,7 @@ class WorksWizardController < ApplicationController
     # to /works/1/upload-files-wizard therefore we only need to handle deleted files here.
     @work = upload_service.update_precurated_file_list([], deleted_files_param)
     @work.reload_snapshots
+    #todo modify the snapshot here for unknow user
     prepare_decorators_for_work_form(@work)
     if params[:save_only] == "true"
       render :file_upload
@@ -208,9 +209,9 @@ class WorksWizardController < ApplicationController
     def upload_file(file)
       key = @work.s3_query_service.upload_file(io: file.to_io, filename: file.original_filename, size: file.size)
       if key
-        UploadSnapshot.create(work: @work, files: [{ "filename" => key, "checksum" => @work.s3_query_service.last_response.etag.delete('"') }])
-        @work.track_change(:added, key)
-        @work.log_file_changes(current_user.id)
+        # UploadSnapshot.create(work: @work, files: [{ "filename" => key, "checksum" => @work.s3_query_service.last_response.etag.delete('"') }])
+        # @work.track_change(:added, key)
+        # @work.log_file_changes(current_user.id)
       else
         Rails.logger.error("Error uploading #{file.original_filename} to work #{@work.id}")
       end

--- a/app/controllers/works_wizard_controller.rb
+++ b/app/controllers/works_wizard_controller.rb
@@ -71,9 +71,8 @@ class WorksWizardController < ApplicationController
     upload_service = WorkUploadsEditService.new(@work, current_user)
     # By the time we hit this endpoint files have been uploaded by Uppy submmitting POST requests
     # to /works/1/upload-files-wizard therefore we only need to handle deleted files here.
-    @work = upload_service.update_precurated_file_list([], deleted_files_param)
-    @work.reload_snapshots(user_id: current_user.id)
-    #todo modify the snapshot here for unknow user
+    @work = upload_service.process_background_uploads_and_foreground_deletes(deleted_files_param)
+
     prepare_decorators_for_work_form(@work)
     if params[:save_only] == "true"
       render :file_upload

--- a/app/controllers/works_wizard_controller.rb
+++ b/app/controllers/works_wizard_controller.rb
@@ -65,7 +65,7 @@ class WorksWizardController < ApplicationController
     upload_service = WorkUploadsEditService.new(@work, current_user)
     # By the time we hit this endpoint files have been uploaded by Uppy submmitting POST requests
     # to /works/1/upload-files therefore we only need to handle deleted files here.
-    @work = upload_service.update_precurated_file_list([], deleted_files_param, true)
+    @work = upload_service.update_precurated_file_list([], deleted_files_param)
     @work.reload_snapshots
     prepare_decorators_for_work_form(@work)
     if params[:save_only] == "true"

--- a/app/controllers/works_wizard_controller.rb
+++ b/app/controllers/works_wizard_controller.rb
@@ -72,7 +72,7 @@ class WorksWizardController < ApplicationController
     # By the time we hit this endpoint files have been uploaded by Uppy submmitting POST requests
     # to /works/1/upload-files-wizard therefore we only need to handle deleted files here.
     @work = upload_service.update_precurated_file_list([], deleted_files_param)
-    @work.reload_snapshots
+    @work.reload_snapshots(user_id: current_user.id)
     #todo modify the snapshot here for unknow user
     prepare_decorators_for_work_form(@work)
     if params[:save_only] == "true"

--- a/app/controllers/works_wizard_controller.rb
+++ b/app/controllers/works_wizard_controller.rb
@@ -65,7 +65,7 @@ class WorksWizardController < ApplicationController
     upload_service = WorkUploadsEditService.new(@work, current_user)
     # By the time we hit this endpoint files have been uploaded by Uppy submmitting POST requests
     # to /works/1/upload-files therefore we only need to handle deleted files here.
-    @work = upload_service.update_precurated_file_list([], deleted_files_param)
+    @work = upload_service.update_precurated_file_list([], deleted_files_param, true)
     @work.reload_snapshots
     prepare_decorators_for_work_form(@work)
     if params[:save_only] == "true"

--- a/app/models/readme.rb
+++ b/app/models/readme.rb
@@ -24,21 +24,6 @@ class Readme
     end
   end
 
-  def attach_other(file)
-    extension = File.extname(file.original_filename)
-    filename = file.original_filename # TODO sanitize
-    puts "==> attach_other #{filename} started"
-    size = file.size
-    key = work.s3_query_service.upload_file(io: file.to_io, filename:, size:)
-    puts "==> attach_other #{filename} ended"
-    if key
-      log_change(key)
-      nil
-    else
-      "An error uploading your #{filename}.  Please try again."
-    end
-  end
-
   def blank?
     s3_readme_idx.nil?
   end

--- a/app/models/readme.rb
+++ b/app/models/readme.rb
@@ -24,6 +24,21 @@ class Readme
     end
   end
 
+  def attach_other(file)
+    extension = File.extname(file.original_filename)
+    filename = file.original_filename # TODO sanitize
+    puts "==> attach_other #{filename} started"
+    size = file.size
+    key = work.s3_query_service.upload_file(io: file.to_io, filename:, size:)
+    puts "==> attach_other #{filename} ended"
+    if key
+      log_change(key)
+      nil
+    else
+      "An error uploading your #{filename}.  Please try again."
+    end
+  end
+
   def blank?
     s3_readme_idx.nil?
   end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -436,8 +436,9 @@ class Work < ApplicationRecord
   end
 
   # Build or find persisted UploadSnapshot models for this Work
+  # @param [integer] user_id optional user to assign the snapshot to
   # @return [UploadSnapshot]
-  def reload_snapshots
+  def reload_snapshots(user_id: nil)
     work_changes = []
     s3_files = pre_curation_uploads_fast
     s3_filenames = s3_files.map(&:filename)
@@ -453,7 +454,7 @@ class Work < ApplicationRecord
       new_snapshot = UploadSnapshot.new(work: self, url: s3_query_service.prefix)
       new_snapshot.store_files(s3_files)
       new_snapshot.save!
-      WorkActivity.add_work_activity(id, work_changes.to_json, nil, activity_type: WorkActivity::FILE_CHANGES)
+      WorkActivity.add_work_activity(id, work_changes.to_json, user_id, activity_type: WorkActivity::FILE_CHANGES)
     end
   end
 

--- a/app/services/work_uploads_edit_service.rb
+++ b/app/services/work_uploads_edit_service.rb
@@ -19,7 +19,11 @@ class WorkUploadsEditService
     work
   end
 
-  def process_background_uploads_and_foreground_deletes(deleted_files)
+  # Delete any files the user has decided not to keep and
+  #  add all files that were uploaded in the backgroud via uppy and any files deleted to an upload snapshot
+  #
+  # @param [Array] deleted_files files that exist in AWS that should be removed
+  def snapshot_uppy_and_delete_files(deleted_files)
     deleted_files.each do |filename|
       s3_service.delete_s3_object(filename)
     end

--- a/app/services/work_uploads_edit_service.rb
+++ b/app/services/work_uploads_edit_service.rb
@@ -26,6 +26,7 @@ class WorkUploadsEditService
     
     # assigns all backgroun changes and deletes to the current user
     work.reload_snapshots(user_id: current_user.id)
+    work
   end
 
   def find_post_curation_uploads(upload_keys: [])

--- a/app/services/work_uploads_edit_service.rb
+++ b/app/services/work_uploads_edit_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class WorkUploadsEditService
-  attr_reader :work, :s3_service
+  attr_reader :work, :s3_service, :current_user
 
   def initialize(work, current_user)
     @work = work
@@ -19,6 +19,15 @@ class WorkUploadsEditService
     work
   end
 
+  def process_background_uploads_and_foreground_deletes(deleted_files)
+    deleted_files.each do |filename|
+      s3_service.delete_s3_object(filename)
+    end
+    
+    # assigns all backgroun changes and deletes to the current user
+    work.reload_snapshots(user_id: current_user.id)
+  end
+
   def find_post_curation_uploads(upload_keys: [])
     return [] unless work.approved? && !upload_keys.empty?
     work.post_curation_uploads.select { |upload| upload_keys.include?(upload.key) }
@@ -31,7 +40,7 @@ class WorkUploadsEditService
 
       deleted_files.each do |filename|
         s3_service.delete_s3_object(filename)
-        work.track_change(:deleted, filename)
+        work.track_change(:removed, filename)
       end
       work.log_file_changes(@current_user.id)
     end

--- a/app/services/work_uploads_edit_service.rb
+++ b/app/services/work_uploads_edit_service.rb
@@ -8,9 +8,9 @@ class WorkUploadsEditService
     @current_user = current_user
   end
 
-  def update_precurated_file_list(added_files, deleted_files)
+  def update_precurated_file_list(added_files, deleted_files, fast = false)
     delete_uploads(deleted_files)
-    add_uploads(added_files)
+    add_uploads(added_files, fast)
     if work.changes.count > 0
       s3_service.client_s3_files(reload: true)
       work.reload # reload the work to pick up the changes in the attachments
@@ -36,7 +36,7 @@ class WorkUploadsEditService
       work.log_file_changes(@current_user.id)
     end
 
-    def add_uploads(added_files)
+    def add_uploads(added_files, fast = false)
       return if added_files.empty?
 
       last_snapshot = work.upload_snapshots.first
@@ -46,7 +46,11 @@ class WorkUploadsEditService
       added_files.map do |file|
         new_path = "/tmp/#{file.original_filename}"
         FileUtils.mv(file.path, new_path)
-        AttachFileToWorkJob.perform_later(file_path: new_path, file_name: file.original_filename, size: file.size, background_upload_snapshot_id: snapshot.id)
+        if fast
+          AttachFileToWorkJob.perform_now(file_path: new_path, file_name: file.original_filename, size: file.size, background_upload_snapshot_id: snapshot.id)
+        else
+          AttachFileToWorkJob.perform_later(file_path: new_path, file_name: file.original_filename, size: file.size, background_upload_snapshot_id: snapshot.id)
+        end
       end
     end
 end

--- a/app/services/work_uploads_edit_service.rb
+++ b/app/services/work_uploads_edit_service.rb
@@ -23,7 +23,7 @@ class WorkUploadsEditService
     deleted_files.each do |filename|
       s3_service.delete_s3_object(filename)
     end
-    
+
     # assigns all backgroun changes and deletes to the current user
     work.reload_snapshots(user_id: current_user.id)
     work

--- a/app/views/works_wizard/file_upload.html.erb
+++ b/app/views/works_wizard/file_upload.html.erb
@@ -10,7 +10,7 @@
         <%= render(partial: 'works/s3_resources', locals: { edit_mode: true, form: f }) %>
       </section>
       <div class="container-fluid deposit-uploads">
-        <span id="uppy_upload_url" class="hidden"><%= work_upload_files_path(@work) %></span>
+        <span id="uppy_upload_url" class="hidden"><%= work_wizard_upload_files_path(@work) %></span>
         <div id="file-upload-area"></div>
         <button id="add-files-button" class="btn btn-secondary" style="width: 200px;"><i class="bi bi-plus-circle"></i> Add Files</button>
         <div id="file-error" class="error_box"></div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,7 @@ Rails.application.routes.draw do
   get "works/:id/attachment-select", to: "works_wizard#attachment_select", as: :work_attachment_select
   post "works/:id/attachment-select", to: "works_wizard#attachment_selected", as: :work_attachment_selected
   patch "works/:id/attachment-select", to: "works_wizard#attachment_selected"
+  post "works/:id/upload-files-wizard", to: "works_wizard#upload_files", as: :work_wizard_upload_files
 
   get "works/:id/update-additional", to: "works_update_additional#update_additional", as: :work_update_additional
   patch "works/:id/update-additional", to: "works_update_additional#update_additional_save"

--- a/spec/services/work_upload_edit_service_spec.rb
+++ b/spec/services/work_upload_edit_service_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe WorkUploadsEditService do
       # it logs the addition (and no delete)
       activity_log = JSON.parse(updated_work.work_activity.first.message)
       expect(activity_log.find { |log| log["action"] == "added" && log["filename"].include?(s3_file3.filename_display) }).not_to be nil
-      expect(activity_log.find { |log| log["action"] == "deleted" }).to be nil
+      expect(activity_log.find { |log| log["action"] == "removed" }).to be nil
     end
   end
 
@@ -108,7 +108,7 @@ RSpec.describe WorkUploadsEditService do
 
       # it logs the delete (and no additions)
       activity_log = JSON.parse(work.work_activity.first.message)
-      expect(activity_log.find { |log| log["action"] == "deleted" && log["filename"] == s3_data[0].filename }).not_to be nil
+      expect(activity_log.find { |log| log["action"] == "removed" && log["filename"] == s3_data[0].filename }).not_to be nil
       expect(activity_log.find { |log| log["action"] == "added" }).to be nil
     end
   end
@@ -132,7 +132,7 @@ RSpec.describe WorkUploadsEditService do
       work_activities = work.work_activity
       expect(work_activities.count).to eq(2) # one for the deletes and one for the adds
       activity_log = work_activities.map { |work_activity| JSON.parse(work_activity.message) }.flatten
-      expect(activity_log.find { |log| log["action"] == "deleted" && log["filename"].include?(s3_file1.key) }).not_to be nil
+      expect(activity_log.find { |log| log["action"] == "removed" && log["filename"].include?(s3_file1.key) }).not_to be nil
       expect(activity_log.find { |log| log["action"] == "added" && log["filename"].include?("us_covid_2020.csv") }).not_to be nil
       expect(activity_log.find { |log| log["action"] == "added" && log["filename"].include?("orcid.csv") }).not_to be nil
     end
@@ -159,8 +159,8 @@ RSpec.describe WorkUploadsEditService do
       work_activities = updated_work.work_activity
       expect(work_activities.count).to eq(2) # one for the deletes and one for the adds
       activity_log = work_activities.map { |work_activity| JSON.parse(work_activity.message) }.flatten
-      expect(activity_log.find { |log| log["action"] == "deleted" && log["filename"].include?("us_covid_2019.csv") }).not_to be nil
-      expect(activity_log.find { |log| log["action"] == "deleted" && log["filename"].include?("us_covid_2020.csv") }).not_to be nil
+      expect(activity_log.find { |log| log["action"] == "removed" && log["filename"].include?("us_covid_2019.csv") }).not_to be nil
+      expect(activity_log.find { |log| log["action"] == "removed" && log["filename"].include?("us_covid_2020.csv") }).not_to be nil
       expect(activity_log.find { |log| log["action"] == "added" && log["filename"].include?("us_covid_2020.csv") }).not_to be nil
       expect(activity_log.find { |log| log["action"] == "added" && log["filename"].include?("orcid.csv") }).not_to be nil
     end


### PR DESCRIPTION
Uploading files added via the Wizard right away (instead of as a background job). This fixes the display issue reported in #1760. 

I also added Rails route to handle the Upload of files on the Wizard (instead of using the Upload process from the Work controller) as described in https://github.com/pulibrary/pdc_describe/issues/1757

The new code introduces a bug in the way we generate the UploadSnapshots, though. See below:

![Screenshot 2024-04-15 at 11 46 09 AM](https://github.com/pulibrary/pdc_describe/assets/568286/e80bfbb3-41ae-472c-ba6a-5ea0ceb62c3e)

