### PR TITLE
Updating the readme to allow for existing files for provenance

### DIFF
--- a/spec/models/readme_spec.rb
+++ b/spec/models/readme_spec.rb
@@ -32,13 +32,15 @@ RSpec.describe Readme, type: :model do
                                                tempfile: File.new(Rails.root.join("spec", "fixtures", "files", "orcid.csv"))
                                              })
     end
+    let(:new_readme) { FactoryBot.build :s3_file, filename: "bucket/key/README.csv" }
 
     it "attaches the file and renames to to README" do
+      allow(fake_s3_service).to receive(:client_s3_files).and_return([new_readme])
       allow(fake_s3_service).to receive(:upload_file).with(io: uploaded_file.to_io, filename: "README.csv", size: 287).and_return("bucket/key/README.csv")
       expect { expect(readme.attach(uploaded_file)).to be_nil }.to change { UploadSnapshot.count }.by 1
       expect(fake_s3_service).to have_received(:upload_file).with(io: uploaded_file.to_io, filename: "README.csv", size: 287)
       expect(readme.file_name).to eq("orcid.csv")
-      expect(work.activities.first.message).to eq("[{\"action\":\"added\",\"filename\":\"bucket/key/README.csv\"}]")
+      expect(work.activities.first.message).to eq("[{\"action\":\"added\",\"filename\":\"bucket/key/README.csv\",\"checksum\":\"abc123\"}]")
     end
 
     context "when no uploaded file is sent" do
@@ -72,14 +74,18 @@ RSpec.describe Readme, type: :model do
 
     context "there is an existing readme that should be replaced" do
       let(:s3_files) { [FactoryBot.build(:s3_file, work:), FactoryBot.build(:s3_readme, work:)] }
+      let(:new_readme) { FactoryBot.build :s3_file, filename: "bucket/key/README.csv" }
 
       it "returns no error message" do
+        allow(fake_s3_service).to receive(:client_s3_files).and_return(s3_files, s3_files, s3_files, [s3_files.first, new_readme])
         allow(fake_s3_service).to receive(:upload_file).with(io: uploaded_file.to_io, filename: "README.csv", size: 287).and_return("bucket/key/README.csv")
+        work.reload_snapshots
         expect { expect(readme.attach(uploaded_file)).to be_nil }.to change { UploadSnapshot.count }.by 1
         expect(fake_s3_service).to have_received(:upload_file).with(io: uploaded_file.to_io, filename: "README.csv", size: 287)
         expect(fake_s3_service).to have_received(:delete_s3_object).with(s3_files.last.key)
         expect(readme.file_name).to eq("orcid.csv")
-        expect(work.activities.first.message).to eq("[{\"action\":\"removed\",\"filename\":\"README.txt\"},{\"action\":\"added\",\"filename\":\"bucket/key/README.csv\"}]")
+        expect(work.activities.last.message).to eq("[{\"action\":\"removed\",\"filename\":\"README.txt\",\"checksum\":\"abc123\"}," \
+                                                   "{\"action\":\"added\",\"filename\":\"bucket/key/README.csv\",\"checksum\":\"abc123\"}]")
       end
     end
   end


### PR DESCRIPTION
Allows for back and forth movement in the wizard and the correct update of the provenance log

fixes #1766
