### PR TITLE
Updating configuration to work in local dev environments

### DIFF
--- a/app/services/s3_query_service.rb
+++ b/app/services/s3_query_service.rb
@@ -94,18 +94,12 @@ class S3QueryService
     signer.presigned_url(:get_object, bucket: bucket_name, key:)
   end
 
-  # There is probably a better way to fetch the current ActiveStorage configuration but we have
-  # not found it.
-  def active_storage_configuration
-    Rails.configuration.active_storage.service_configurations[Rails.configuration.active_storage.service.to_s]
-  end
-
   def access_key_id
-    active_storage_configuration["access_key_id"]
+    S3QueryService.configuration["access_key_id"]
   end
 
   def secret_access_key
-    active_storage_configuration["secret_access_key"]
+    S3QueryService.configuration["secret_access_key"]
   end
 
   def credentials

--- a/config/s3.yml
+++ b/config/s3.yml
@@ -1,5 +1,7 @@
 ---
 production:
+  access_key_id: <%= ENV['AWS_S3_KEY_ID'] || 'not-used-access_key_id' %>
+  secret_access_key: <%= ENV['AWS_S3_SECRET_KEY'] || 'not-used-secret_access_key' %>
   pre_curation:
     bucket: <%= ENV['AWS_S3_PRE_CURATE_BUCKET'] || 'example-bucket' %>
     region: <%= ENV['AWS_S3_PRE_CURATE_REGION'] || 'us-east-1' %>
@@ -13,6 +15,8 @@ production:
     bucket: <%= ENV['AWS_S3_DSPACE_BUCKET'] || 'example-bucket' %>
     region: <%= ENV['AWS_S3_DSPACE_REGION'] || 'us-east-1' %>
 staging:
+  access_key_id: <%= ENV['AWS_S3_KEY_ID'] || 'not-used-access_key_id' %>
+  secret_access_key: <%= ENV['AWS_S3_SECRET_KEY'] || 'not-used-secret_access_key' %>
   pre_curation:
     bucket: <%= ENV['AWS_S3_PRE_CURATE_BUCKET'] || 'example-bucket' %>
     region: <%= ENV['AWS_S3_PRE_CURATE_REGION'] || 'us-east-1' %>
@@ -26,6 +30,8 @@ staging:
     bucket: <%= ENV['AWS_S3_DSPACE_BUCKET'] || 'example-bucket' %>
     region: <%= ENV['AWS_S3_DSPACE_REGION'] || 'us-east-1' %>
 development:
+  access_key_id: <%= ENV['AWS_S3_KEY_ID'] || 'not-used-access_key_id' %>
+  secret_access_key: <%= ENV['AWS_S3_SECRET_KEY'] || 'not-used-secret_access_key' %>
   pre_curation:
     bucket: <%= ENV['AWS_S3_PRE_CURATE_BUCKET'] || 'example-bucket' %>
     region: <%= ENV['AWS_S3_PRE_CURATE_REGION'] || 'us-east-1' %>
@@ -39,6 +45,8 @@ development:
     bucket: <%= ENV['AWS_S3_DSPACE_BUCKET'] || 'example-bucket' %>
     region: <%= ENV['AWS_S3_DSPACE_REGION'] || 'us-east-1' %>
 test:
+  access_key_id: 'not-used-access_key_id'
+  secret_access_key: 'not-used-secret_access_key'
   pre_curation:
     bucket: 'example-bucket'
     region: 'us-east-1'


### PR DESCRIPTION
Since we are moving away from ActiveStorage::Blob we moved our configuration values out of the Rails `storage.yml` file into our own `s3.yml` file. Technically we copied the values from one config to the other, we have not deleted `storage.yml`

The reason for this is that Rails was failing to automagically load values from `storage.yml` now that we are not loading the ActiveStorage:Blob classes (see https://github.com/pulibrary/pdc_describe/pull/1775 for more information on that) and it made sense to stop putting the values in a Rails file that Rails is not using.