### PR TITLE
Fixes and logs bad Work URLs in production

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -12,7 +12,7 @@ class NotificationMailer < ApplicationMailer
     @url = work_url(@work_activity.work)
 
     # Troubleshooting https://github.com/pulibrary/pdc_describe/issues/1783
-    if @url.includes?("/describe/describe/")
+    if @url.include?("/describe/describe/")
       Rails.logger.error("URL #{@url} included /describe/describe/ and was fixed. See https://github.com/pulibrary/pdc_describe/issues/1783")
       @url = @url.gsub("/describe/describe/", "/describe/")
     end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -11,6 +11,12 @@ class NotificationMailer < ApplicationMailer
     @message_html = @work_activity.to_html
     @url = work_url(@work_activity.work)
 
+    # Troubleshooting https://github.com/pulibrary/pdc_describe/issues/1783
+    if @url.includes?("/describe/describe/")
+      Rails.logger.error("URL #{@url} included /describe/describe/ and was fixed. See https://github.com/pulibrary/pdc_describe/issues/1783")
+      @url = @url.gsub("/describe/describe/", "/describe/")
+    end
+
     mail(to: @user.email, subject: @subject)
   end
 end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -240,6 +240,13 @@ class Work < ApplicationRecord
     new_curator = User.find(curator_user_id)
 
     work_url = "[#{title}](#{Rails.application.routes.url_helpers.work_url(self)})"
+
+    # Troubleshooting https://github.com/pulibrary/pdc_describe/issues/1783
+    if work_url.includes?("/describe/describe/")
+      Rails.logger.error("URL #{work_url} included /describe/describe/ and was fixed. See https://github.com/pulibrary/pdc_describe/issues/1783")
+      work_url = work_url.gsub("/describe/describe/", "/describe/")
+    end
+
     message = if curator_user_id.to_i == current_user.id
                 "Self-assigned @#{current_user.uid} as curator for work #{work_url}"
               else

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -242,7 +242,7 @@ class Work < ApplicationRecord
     work_url = "[#{title}](#{Rails.application.routes.url_helpers.work_url(self)})"
 
     # Troubleshooting https://github.com/pulibrary/pdc_describe/issues/1783
-    if work_url.includes?("/describe/describe/")
+    if work_url.include?("/describe/describe/")
       Rails.logger.error("URL #{work_url} included /describe/describe/ and was fixed. See https://github.com/pulibrary/pdc_describe/issues/1783")
       work_url = work_url.gsub("/describe/describe/", "/describe/")
     end

--- a/app/models/work_state_transition_notification.rb
+++ b/app/models/work_state_transition_notification.rb
@@ -15,7 +15,7 @@ class WorkStateTransitionNotification
     @work_url = Rails.application.routes.url_helpers.work_url(work)
 
     # Troubleshooting https://github.com/pulibrary/pdc_describe/issues/1783
-    if @work_url.includes?("/describe/describe/")
+    if @work_url.include?("/describe/describe/")
       Rails.logger.error("URL #{@work_url} included /describe/describe/ and was fixed. See https://github.com/pulibrary/pdc_describe/issues/1783")
       @work_url = @work_url.gsub("/describe/describe/", "/describe/")
     end

--- a/app/models/work_state_transition_notification.rb
+++ b/app/models/work_state_transition_notification.rb
@@ -13,6 +13,13 @@ class WorkStateTransitionNotification
     @group = work.group
     @group_administrators = group.administrators.to_a
     @work_url = Rails.application.routes.url_helpers.work_url(work)
+
+    # Troubleshooting https://github.com/pulibrary/pdc_describe/issues/1783
+    if @work_url.includes?("/describe/describe/")
+      Rails.logger.error("URL #{@work_url} included /describe/describe/ and was fixed. See https://github.com/pulibrary/pdc_describe/issues/1783")
+      @work_url = @work_url.gsub("/describe/describe/", "/describe/")
+    end
+
     @work_title = work.title
     @notification = notification_for_transition
     @id = work.id


### PR DESCRIPTION
Temporary work-around to fix and troubleshoot bad Work URLs generated in some places.

In some instances Rails is adding an extra `/describe` to the Work URLs and we end up with links that go do `/describe/describe/`. See details in #1783

I believe this issue only happens when the call to `Rails.application.routes.url_helpers` to generate the `work_url` hapens outside of the Views or the Controllers (e.g. in the models, in our mailers).

And of course this only happens in production ¯\_(ツ)_/¯ 

I suspect this issue was introduced when we set `Rails.application.routes.default_url_options[:relative_url_root] = "/describe"` (see PR https://github.com/pulibrary/pdc_describe/pull/1733) but I suspect that *that PR* also fixed the weird redirect issue described in https://github.com/pulibrary/pdc_describe/issues/1748 which was a much harder issue to troubleshoot. Take these conjectures with a grain of salt.
