### PR TITLE
Preserves user's README file name

### DIFF
--- a/app/models/readme.rb
+++ b/app/models/readme.rb
@@ -48,8 +48,7 @@ class Readme
       end
 
       def upload_readme(readme_file_param)
-        extension = File.extname(readme_file_param.original_filename)
-        readme_name = "README#{extension}"
+        readme_name = readme_file_param.original_filename
         size = readme_file_param.size
         work.s3_query_service.upload_file(io: readme_file_param.to_io, filename: readme_name, size:)
       end


### PR DESCRIPTION
Closes #1782 

Updates the code to not rename the README file anymore.
