### PR TITLE
Switch to use gigabytes instead of gigibytes

### DIFF
--- a/config/initializers/number_to_human_size_converter.rb
+++ b/config/initializers/number_to_human_size_converter.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+# Source: https://github.com/rails/rails/issues/40054#issuecomment-674449143
+# Additional information: https://massive.io/file-transfer/gb-vs-gib-whats-the-difference/
+module ActiveSupport
+  module NumberHelper
+    class NumberToHumanSizeConverter < NumberConverter
+      private
+
+        # Allows a base to be specified for the conversion
+        # 1024 was the default and that produces gigibytes
+        # 1000 produces gigabytes
+        def base
+          options[:base] || 1000
+        end
+    end
+  end
+end

--- a/spec/models/s3_file_spec.rb
+++ b/spec/models/s3_file_spec.rb
@@ -33,6 +33,14 @@ RSpec.describe S3File, type: :model do
     end
   end
 
+  context "display file size" do
+    it "uses 1000 base" do
+      expect(s3_file.display_size).to eq "10.8 KB"
+      # expect(number_to_human_size(size)).to eq "10.8 KB"
+    end
+   
+  end
+
   context "safe_id" do
     it "calculates correct safe_id for files with spaces and non-alpha numeric characters" do
       expect(s3_file.safe_id).to eq "10-99999-123-abc-#{work.id}-filename--with-spaces--w-----chars-txt"

--- a/spec/models/s3_file_spec.rb
+++ b/spec/models/s3_file_spec.rb
@@ -34,11 +34,17 @@ RSpec.describe S3File, type: :model do
   end
 
   context "display file size" do
-    it "uses 1000 base" do
+    it "uses 1000 base by default when calculating display value" do
       expect(s3_file.display_size).to eq "10.8 KB"
-      # expect(number_to_human_size(size)).to eq "10.8 KB"
     end
-   
+  end
+
+  describe "#number_to_human_size" do
+    it "honors the base if we pass it one" do
+      expect(s3_file.number_to_human_size(size)).to eq "10.8 KB"
+      expect(s3_file.number_to_human_size(size, base: 1000)).to eq "10.8 KB"
+      expect(s3_file.number_to_human_size(size, base: 1024)).to eq "10.5 KB"
+    end
   end
 
   context "safe_id" do

--- a/spec/system/work_upload_s3_objects_spec.rb
+++ b/spec/system/work_upload_s3_objects_spec.rb
@@ -52,7 +52,7 @@ describe "Uploading S3 Bucket Objects for new Work", mock_ezid_api: true do
         expect(page).to have_content upload_file_name
         expect(page).to have_content filename1
         expect(page).to have_content filename2
-        expect(page).to have_content "Total Size\n31.5 KB"
+        expect(page).to have_content "Total Size\n32.3 KB"
         expect(work.reload.pre_curation_uploads.length).to eq(3)
       end
 


### PR DESCRIPTION
Closes #1793 

Rails does not specify a parameter to allow us to specify a specific base. So, we override the function to allow us to specify a base which by default is now 1000 instead of 1024.