### PR TITLE
Handles abandoned works in the wizard

### DIFF
--- a/app/views/users/_dataset_table.html.erb
+++ b/app/views/users/_dataset_table.html.erb
@@ -13,7 +13,11 @@
       <% datasets.each do |ds| %>
         <tr>
           <td>
-            <a href="<%= work_path(ds) %>"><%= ds.title %></a>
+            <% if ds.title.blank? %>
+              <a href="<%= edit_work_wizard_path(ds) %>">(untitled)</a>
+            <% else %>
+              <a href="<%= work_path(ds) %>"><%= ds.title %></a>
+            <% end %>
             <% if ds.new_notification_count_for_user(@user.id) > 0 %>
               <a href="<%= work_path(ds) %>">
                 <span class="badge rounded-pill bg-primary" title="<%= ds.new_notification_count_for_user(@user.id) %> new notifications"><%= ds.new_notification_count_for_user(@user.id) %></span>

--- a/app/views/users/_dataset_table.html.erb
+++ b/app/views/users/_dataset_table.html.erb
@@ -14,7 +14,7 @@
         <tr>
           <td>
             <% if ds.title.blank? %>
-              <a href="<%= edit_work_wizard_path(ds) %>">(untitled)</a>
+              <a href="<%= work_create_new_submission_path(ds) %>">(untitled)</a>
             <% else %>
               <a href="<%= work_path(ds) %>"><%= ds.title %></a>
             <% end %>

--- a/spec/system/work_wizard_spec.rb
+++ b/spec/system/work_wizard_spec.rb
@@ -136,12 +136,12 @@ describe "walk the wizard hitting all the buttons", type: :system, js: true do
       click_on "Confirm"
       work = Work.last
 
-      # Emulates the user completelly abandoning the wizard
+      # Emulate the user completelly abandoning the wizard
       visit user_path(user)
 
-      # Force the user back to the wizard
+      # Force the user back to the wizard (rather than to the Show page)
       expect(page.html.include?("(untitled)")).to be true
-      expect(page.html.include?("/works/#{work.id}/edit-wizard")).to be true
+      expect(page.html.include?("/works/#{work.id}/new-submission")).to be true
     end
   end
 end

--- a/spec/system/work_wizard_spec.rb
+++ b/spec/system/work_wizard_spec.rb
@@ -126,4 +126,22 @@ describe "walk the wizard hitting all the buttons", type: :system, js: true do
       expect(page).to have_css(validate_form_css)
     end
   end
+
+  context "user bails out of the wizard after record has been created on the database" do
+    it "handles an abandoned work properly" do
+      sign_in user
+      stub_datacite
+      visit work_policy_path
+      check "agreement"
+      click_on "Confirm"
+      work = Work.last
+
+      # Emulates the user completelly abandoning the wizard
+      visit user_path(user)
+
+      # Force the user back to the wizard
+      expect(page.html.include?("(untitled)")).to be true
+      expect(page.html.include?("/works/#{work.id}/edit-wizard")).to be true
+    end
+  end
 end


### PR DESCRIPTION
Displays the record as "untitled" and forces the user back to the wizard.

Closes #1802 