### PR TITLE
Fixes file count discrepancy

### DIFF
--- a/app/models/s3_file.rb
+++ b/app/models/s3_file.rb
@@ -3,7 +3,7 @@ class S3File
   include Rails.application.routes.url_helpers
   include ActionView::Helpers::NumberHelper
 
-  attr_accessor :safe_id, :filename, :last_modified, :size, :checksum, :url, :filename_display, :last_modified_display, :display_size
+  attr_accessor :safe_id, :filename, :last_modified, :size, :checksum, :url, :filename_display, :last_modified_display, :display_size, :is_folder
   alias key filename
   alias id filename
 
@@ -29,6 +29,7 @@ class S3File
     @checksum = checksum.delete('"')
     @url = url || work_download_path(work, filename:)
     @work = work
+    @is_folder = filename.ends_with?("/")
   end
 
   def created_at

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -322,7 +322,8 @@ class Work < ApplicationRecord
         "last_modified_display": s3_file.last_modified_display,
         "size": s3_file.size,
         "display_size": s3_file.display_size,
-        "url": s3_file.url
+        "url": s3_file.url,
+        "is_folder": s3_file.is_folder
       }
     end
     files_info

--- a/app/services/pul_dspace_aws_connector.rb
+++ b/app/services/pul_dspace_aws_connector.rb
@@ -27,7 +27,7 @@ class PULDspaceAwsConnector
 
   def aws_files
     return [] if ark.nil? || dspace_doi.nil?
-    @aws_files ||= work.s3_query_service.client_s3_files(reload: true, bucket_name: dspace_bucket_name, prefix: dspace_doi.tr(".", "-"), ignore_directories: false)
+    @aws_files ||= work.s3_query_service.client_s3_files(reload: true, bucket_name: dspace_bucket_name, prefix: dspace_doi.tr(".", "-"))
   end
 
   private

--- a/app/services/s3_query_service.rb
+++ b/app/services/s3_query_service.rb
@@ -160,12 +160,12 @@ class S3QueryService
 
   # Retrieve the S3 resources uploaded to the S3 Bucket
   # @return [Array<S3File>]
-  def client_s3_files(reload: false, bucket_name: self.bucket_name, prefix: self.prefix, ignore_directories: true)
+  def client_s3_files(reload: false, bucket_name: self.bucket_name, prefix: self.prefix)
     if reload # force a reload
       @client_s3_files = nil
       clear_s3_responses(bucket_name:, prefix:)
     end
-    @client_s3_files ||= get_s3_objects(bucket_name:, prefix:, ignore_directories:)
+    @client_s3_files ||= get_s3_objects(bucket_name:, prefix:)
   end
 
   def client_s3_empty_files(reload: false, bucket_name: self.bucket_name, prefix: self.prefix)
@@ -174,7 +174,7 @@ class S3QueryService
       clear_s3_responses(bucket_name:, prefix:)
     end
     @client_s3_empty_files ||= begin
-      files_and_directories = get_s3_objects(bucket_name:, prefix:, ignore_directories: false)
+      files_and_directories = get_s3_objects(bucket_name:, prefix:)
       files_and_directories.select { |object| !object.filename.ends_with?("/") && object.empty? }
     end
   end
@@ -211,7 +211,6 @@ class S3QueryService
     source_bucket = S3QueryService.pre_curation_config[:bucket]
     target_bucket = S3QueryService.post_curation_config[:bucket]
     empty_files = client_s3_empty_files(reload: true, bucket_name: source_bucket)
-    # See TODO below
     # Do not move the empty files, however, ensure that it is noted that the
     #   presence of empty files is specified in the provenance log.
     unless empty_files.empty?
@@ -351,12 +350,12 @@ class S3QueryService
       responses
     end
 
-    def get_s3_objects(bucket_name:, prefix:, ignore_directories:)
+    def get_s3_objects(bucket_name:, prefix:)
       start = Time.zone.now
       responses = s3_responses(bucket_name:, prefix:)
       objects = responses.reduce([]) do |all_objects, resp|
         resp_hash = resp.to_h
-        resp_objects = parse_objects(resp_hash, ignore_directories:)
+        resp_objects = parse_objects(resp_hash)
         all_objects + resp_objects
       end
       elapsed = Time.zone.now - start
@@ -364,13 +363,11 @@ class S3QueryService
       objects
     end
 
-    def parse_objects(resp, ignore_directories: true)
+    def parse_objects(resp)
       objects = []
       resp_hash = resp.to_h
       response_objects = resp_hash[:contents]
       response_objects&.each do |object|
-        # TODO: Revisit this, we might need this logic
-        # next if object[:size] == 0 && ignore_directories
         s3_file = S3File.new(work: model, filename: object[:key], last_modified: object[:last_modified], size: object[:size], checksum: object[:etag])
         objects << s3_file
       end

--- a/app/services/s3_query_service.rb
+++ b/app/services/s3_query_service.rb
@@ -211,6 +211,7 @@ class S3QueryService
     source_bucket = S3QueryService.pre_curation_config[:bucket]
     target_bucket = S3QueryService.post_curation_config[:bucket]
     empty_files = client_s3_empty_files(reload: true, bucket_name: source_bucket)
+    # See TODO below
     # Do not move the empty files, however, ensure that it is noted that the
     #   presence of empty files is specified in the provenance log.
     unless empty_files.empty?
@@ -368,7 +369,8 @@ class S3QueryService
       resp_hash = resp.to_h
       response_objects = resp_hash[:contents]
       response_objects&.each do |object|
-        next if object[:size] == 0 && ignore_directories
+        # TODO: Revisit this, we might need this logic
+        # next if object[:size] == 0 && ignore_directories
         s3_file = S3File.new(work: model, filename: object[:key], last_modified: object[:last_modified], size: object[:size], checksum: object[:etag])
         objects << s3_file
       end

--- a/app/services/s3_query_service.rb
+++ b/app/services/s3_query_service.rb
@@ -175,7 +175,7 @@ class S3QueryService
     end
     @client_s3_empty_files ||= begin
       files_and_directories = get_s3_objects(bucket_name:, prefix:)
-      files_and_directories.select { |object| !object.filename.ends_with?("/") && object.empty? }
+      files_and_directories.select { |object| object.empty? }
     end
   end
 

--- a/app/services/s3_query_service.rb
+++ b/app/services/s3_query_service.rb
@@ -175,7 +175,7 @@ class S3QueryService
     end
     @client_s3_empty_files ||= begin
       files_and_directories = get_s3_objects(bucket_name:, prefix:)
-      files_and_directories.select { |object| object.empty? }
+      files_and_directories.select(&:empty?)
     end
   end
 

--- a/app/views/works/_s3_resources.html.erb
+++ b/app/views/works/_s3_resources.html.erb
@@ -94,20 +94,28 @@
                 // On edit mode, file is marked to be deleted display strikethrough
                 html = `<span><s>${row.filename_display.substring(1)}</s></span>`;
               } else {
-                // Display as a hyperlink with the download icon
-                // (Note: Interpolation in the client is interpreted after the server-side Ruby builds the download path)
-                let downloadUrl;
-                if (work) {
-                  downloadUrl = `<%= @work_decorator.download_path %>?filename=${data}`;
+                if (row.size == 0) {
+                  // Display the filename as text (i.e. not a hyperlink)
+                  html = `<span>
+                    <i class="bi bi-dash-square"></i>
+                    ${row.filename_display}
+                  </span>`;
                 } else {
-                  downloadUrl = '<%= root_path %>';
-                }
-                var encodedUrl = window.encodeURI(downloadUrl);
+                  // Display as a hyperlink with the download icon
+                  // (Note: Interpolation in the client is interpreted after the server-side Ruby builds the download path)
+                  let downloadUrl;
+                  if (work) {
+                    downloadUrl = `<%= @work_decorator.download_path %>?filename=${data}`;
+                  } else {
+                    downloadUrl = '<%= root_path %>';
+                  }
+                  var encodedUrl = window.encodeURI(downloadUrl);
 
-                html = `<span>
-                  <i class="bi bi-file-arrow-down"></i>
-                  <a href="${encodedUrl}" target="_blank">${row.filename_display}</a>
-                </span>`;
+                  html = `<span>
+                    <i class="bi bi-file-arrow-down"></i>
+                    <a href="${encodedUrl}" target="_blank">${row.filename_display}</a>
+                  </span>`;
+                }
               }
               return html;
             }
@@ -137,8 +145,13 @@
           render: function (data, type, row) {
             // size
             if (type == "display") {
-              // human readable (e.g. 34 KB)
-              return row.display_size;
+              if (row.is_folder === true) {
+                // display no size for folders
+                return "";
+              } else {
+                // human readable (e.g. 34 KB)
+                return row.display_size;
+              }
             }
             // raw bytes
             return row.size;

--- a/spec/services/pul_dspace_aws_connector_spec.rb
+++ b/spec/services/pul_dspace_aws_connector_spec.rb
@@ -45,8 +45,7 @@ RSpec.describe PULDspaceAwsConnector, type: :model do
       end
       it "finds files" do
         expect(dspace_data.aws_files).to eq([s3_file])
-        expect(fake_s3_service).to have_received(:client_s3_files).with({ bucket_name: "example-bucket-dspace", prefix: "10-123456/acb-123",
-                                                                          ignore_directories: false, reload: true })
+        expect(fake_s3_service).to have_received(:client_s3_files).with({ bucket_name: "example-bucket-dspace", prefix: "10-123456/acb-123", reload: true })
       end
     end
 

--- a/spec/services/s3_query_service_spec.rb
+++ b/spec/services/s3_query_service_spec.rb
@@ -739,7 +739,7 @@ XML
     end
 
     it "retrieves the directories if requested" do
-      files = s3_query_service.client_s3_files(reload: true, bucket_name: "other-bucket", prefix: "new-prefix", ignore_directories: false)
+      files = s3_query_service.client_s3_files(reload: true, bucket_name: "other-bucket", prefix: "new-prefix")
       expect(files.count).to eq 6
       expect(files[0].filename).to match(/README/)
       expect(files[1].filename).to match(/SCoData_combined_v1_2020-07_datapackage.json/)

--- a/spec/services/s3_query_service_spec.rb
+++ b/spec/services/s3_query_service_spec.rb
@@ -268,8 +268,8 @@ XML
                                                 "snapshot_id" => snapshot.id, "upload_status" => "complete", "user_id" => user.id },
                                               { "checksum" => "abc123etagetag", "filename" => "10.34770/pe9w-x904/#{work.id}/SCoData_combined_v1_2020-07_datapackage.json",
                                                 "snapshot_id" => snapshot.id, "upload_status" => "complete", "user_id" => user.id },
-                                              {"checksum" => "abc123etagetag", "filename" => "10.34770/pe9w-x904/#{work.id}/a_directory/",
-                                                "snapshot_id" => snapshot.id, "upload_status"=>"complete", "user_id" => user.id }
+                                              { "checksum" => "abc123etagetag", "filename" => "10.34770/pe9w-x904/#{work.id}/a_directory/",
+                                                "snapshot_id" => snapshot.id, "upload_status" => "complete", "user_id" => user.id }
                                             ])
       end
       context "the copy fails for some reason" do
@@ -775,7 +775,7 @@ XML
 
   describe "#client_s3_empty_files" do
     let(:fake_aws_client) { double(Aws::S3::Client) }
-    let(:s3_size2) { 0 }   # forces file SCoData_combined_v1_2020-07_datapackage.json to be zero length
+    let(:s3_size2) { 0 } # forces file SCoData_combined_v1_2020-07_datapackage.json to be zero length
 
     before do
       s3_query_service.stub(:client).and_return(fake_aws_client)

--- a/spec/services/s3_query_service_spec.rb
+++ b/spec/services/s3_query_service_spec.rb
@@ -9,10 +9,13 @@ RSpec.describe S3QueryService do
   let(:s3_bucket_key) { "10.34770/pe9w-x904/#{work.id}/" }
   let(:s3_key1) { "#{s3_bucket_key}SCoData_combined_v1_2020-07_README.txt" }
   let(:s3_key2) { "#{s3_bucket_key}SCoData_combined_v1_2020-07_datapackage.json" }
+  let(:s3_key3) { "#{s3_bucket_key}a_directory/" }
   let(:s3_last_modified1) { Time.parse("2022-04-21T18:29:40.000Z") }
   let(:s3_last_modified2) { Time.parse("2022-04-21T18:30:07.000Z") }
+  let(:s3_last_modified3) { Time.parse("2022-05-21T18:31:07.000Z") }
   let(:s3_size1) { 5_368_709_122 }
   let(:s3_size2) { 5_368_709_128 }
+  let(:s3_size3) { 0 }
   let(:s3_etag1) { "008eec11c39e7038409739c0160a793a" }
   let(:s3_hash) do
     {
@@ -34,9 +37,9 @@ RSpec.describe S3QueryService do
         },
         {
           etag: "\"7bd3d4339c034ebc663b99065771111\"",
-          key: "a_directory/",
-          last_modified: s3_last_modified2,
-          size: 0,
+          key: s3_key3,
+          last_modified: s3_last_modified3,
+          size: s3_size3,
           storage_class: "STANDARD"
         }
       ],
@@ -119,7 +122,7 @@ XML
     data_profile = s3_query_service.data_profile
     expect(data_profile[:objects]).to be_instance_of(Array)
     expect(data_profile[:ok]).to eq true
-    expect(data_profile[:objects].count).to eq 2
+    expect(data_profile[:objects].count).to eq 3
     expect(data_profile[:objects].first).to be_instance_of(S3File)
     expect(data_profile[:objects].first.filename).to match(/README/)
     expect(data_profile[:objects].first.last_modified).to eq Time.parse("2022-04-21T18:29:40.000Z")
@@ -137,11 +140,13 @@ XML
     data_profile = s3_query_service.data_profile
     expect(data_profile[:objects]).to be_instance_of(Array)
     expect(data_profile[:ok]).to eq true
-    expect(data_profile[:objects].count).to eq 4
-    expect(data_profile[:objects].first.filename).to match(/README/)
+    expect(data_profile[:objects].count).to eq 6
+    expect(data_profile[:objects][0].filename).to match(/README/)
     expect(data_profile[:objects][1].filename).to match(/SCoData_combined_v1_2020-07_datapackage.json/)
-    expect(data_profile[:objects][2].filename).to match(/README/)
-    expect(data_profile[:objects][3].filename).to match(/SCoData_combined_v1_2020-07_datapackage.json/)
+    expect(data_profile[:objects][2].filename).to match(/a_directory/)
+    expect(data_profile[:objects][3].filename).to match(/README/)
+    expect(data_profile[:objects][4].filename).to match(/SCoData_combined_v1_2020-07_datapackage.json/)
+    expect(data_profile[:objects][5].filename).to match(/a_directory/)
   end
 
   it "handles connecting to a bad bucket" do
@@ -214,7 +219,9 @@ XML
                                        { "filename" => "10.34770/pe9w-x904/#{work.id}/SCoData_combined_v1_2020-07_README.txt", "snapshot_id" => snapshot.id, "upload_status" => "started",
                                          "user_id" => user.id, "checksum" => "008eec11c39e7038409739c0160a793a" },
                                        { "filename" => "10.34770/pe9w-x904/#{work.id}/SCoData_combined_v1_2020-07_datapackage.json", "snapshot_id" => snapshot.id, "upload_status" => "started",
-                                         "user_id" => user.id, "checksum" => "7bd3d4339c034ebc663b990657714688" }
+                                         "user_id" => user.id, "checksum" => "7bd3d4339c034ebc663b990657714688" },
+                                       { "filename" => "10.34770/pe9w-x904/#{work.id}/a_directory/", "snapshot_id" => snapshot.id, "upload_status" => "started",
+                                       "user_id" => user.id, "checksum" => "7bd3d4339c034ebc663b99065771111" }
                                      ])
         perform_enqueued_jobs
         expect(s3_query_service.client).to have_received(:create_multipart_upload)
@@ -326,29 +333,33 @@ XML
         expect(data_profile).to include(:objects)
         children = data_profile[:objects]
 
-        expect(children.count).to eq 2
+        expect(children.count).to eq 3
+
         expect(children.first).to be_instance_of(S3File)
         expect(children.first.filename).to eq(s3_key1)
-
-        last_modified = children.first.last_modified
-        expect(last_modified.to_s).to eq(s3_last_modified1.to_s)
-
+        expect(children.first.last_modified.to_s).to eq(s3_last_modified1.to_s)
         expect(children.first.size).to eq(s3_size1)
 
+        expect(children.second).to be_instance_of(S3File)
+        expect(children.second.filename).to eq(s3_key2)
+        expect(children.second.last_modified.to_s).to eq(s3_last_modified2.to_s)
+        expect(children.second.size).to eq(s3_size2)
+
         expect(children.last).to be_instance_of(S3File)
-        expect(children.last.filename).to eq(s3_key2)
-
-        last_modified = children.last.last_modified
-        expect(last_modified.to_s).to eq(s3_last_modified2.to_s)
-
-        expect(children.last.size).to eq(s3_size2)
+        expect(children.last.filename).to eq(s3_key3)
+        expect(children.last.last_modified.to_s).to eq(s3_last_modified3.to_s)
+        expect(children.last.size).to eq(s3_size3)
       end
     end
 
     describe "#file_count" do
-      it "returns only the files" do
-        expect(s3_query_service.file_count).to eq(2)
+      it "returns files and directories" do
+        expect(s3_query_service.file_count).to eq(3)
       end
+
+      # =
+      # TODO: Add a test that checks for files only
+      # =
 
       context "when an error is encountered" do
         subject(:s3_query_service) { described_class.new(work) }
@@ -422,7 +433,7 @@ XML
       data_profile = s3_query_service.data_profile
       expect(data_profile[:objects]).to be_instance_of(Array)
       expect(data_profile[:ok]).to eq true
-      expect(data_profile[:objects].count).to eq 2
+      expect(data_profile[:objects].count).to eq 3
       expect(data_profile[:objects].first).to be_instance_of(S3File)
       expect(data_profile[:objects].first.filename).to match(/README/)
       expect(data_profile[:objects].first.last_modified).to eq Time.parse("2022-04-21T18:29:40.000Z")
@@ -705,11 +716,13 @@ XML
 
     it "it retrieves the files for the work" do
       files = s3_query_service.client_s3_files
-      expect(files.count).to eq 4
-      expect(files.first.filename).to match(/README/)
+      expect(files.count).to eq 6
+      expect(files[0].filename).to match(/README/)
       expect(files[1].filename).to match(/SCoData_combined_v1_2020-07_datapackage.json/)
-      expect(files[2].filename).to match(/README/)
-      expect(files[3].filename).to match(/SCoData_combined_v1_2020-07_datapackage.json/)
+      expect(files[2].filename).to match(/a_directory/)
+      expect(files[3].filename).to match(/README/)
+      expect(files[4].filename).to match(/SCoData_combined_v1_2020-07_datapackage.json/)
+      expect(files[5].filename).to match(/a_directory/)
       expect(fake_aws_client).to have_received(:list_objects_v2).with(bucket: "example-bucket", max_keys: 1000, prefix: "10.34770/pe9w-x904/#{work.id}/")
       expect(fake_aws_client).to have_received(:list_objects_v2).with(bucket: "example-bucket", continuation_token: "abc123", max_keys: 1000, prefix: "10.34770/pe9w-x904/#{work.id}/")
     end
@@ -717,11 +730,13 @@ XML
     it "it retrieves the files for a bucket and prefix once" do
       s3_query_service.client_s3_files(bucket_name: "other-bucket", prefix: "new-prefix")
       files = s3_query_service.client_s3_files(bucket_name: "other-bucket", prefix: "new-prefix")
-      expect(files.count).to eq 4
-      expect(files.first.filename).to match(/README/)
+      expect(files.count).to eq 6
+      expect(files[0].filename).to match(/README/)
       expect(files[1].filename).to match(/SCoData_combined_v1_2020-07_datapackage.json/)
-      expect(files[2].filename).to match(/README/)
-      expect(files[3].filename).to match(/SCoData_combined_v1_2020-07_datapackage.json/)
+      expect(files[2].filename).to match(/a_directory/)
+      expect(files[3].filename).to match(/README/)
+      expect(files[4].filename).to match(/SCoData_combined_v1_2020-07_datapackage.json/)
+      expect(files[5].filename).to match(/a_directory/)
       expect(fake_aws_client).to have_received(:list_objects_v2).with(bucket: "other-bucket", max_keys: 1000, prefix: "new-prefix").once
       expect(fake_aws_client).to have_received(:list_objects_v2).with(bucket: "other-bucket", continuation_token: "abc123", max_keys: 1000, prefix: "new-prefix").once
     end
@@ -729,11 +744,13 @@ XML
     it "it retrieves the files for a bucket and prefix any time reload is true" do
       s3_query_service.client_s3_files(reload: true, bucket_name: "other-bucket", prefix: "new-prefix")
       files = s3_query_service.client_s3_files(reload: true, bucket_name: "other-bucket", prefix: "new-prefix")
-      expect(files.count).to eq 4
-      expect(files.first.filename).to match(/README/)
+      expect(files.count).to eq 6
+      expect(files[0].filename).to match(/README/)
       expect(files[1].filename).to match(/SCoData_combined_v1_2020-07_datapackage.json/)
-      expect(files[2].filename).to match(/README/)
-      expect(files[3].filename).to match(/SCoData_combined_v1_2020-07_datapackage.json/)
+      expect(files[2].filename).to match(/a_directory/)
+      expect(files[3].filename).to match(/README/)
+      expect(files[4].filename).to match(/SCoData_combined_v1_2020-07_datapackage.json/)
+      expect(files[5].filename).to match(/a_directory/)
       expect(fake_aws_client).to have_received(:list_objects_v2).with(bucket: "other-bucket", max_keys: 1000, prefix: "new-prefix").twice
       expect(fake_aws_client).to have_received(:list_objects_v2).with(bucket: "other-bucket", continuation_token: "abc123", max_keys: 1000, prefix: "new-prefix").twice
     end
@@ -743,10 +760,10 @@ XML
       expect(files.count).to eq 6
       expect(files[0].filename).to match(/README/)
       expect(files[1].filename).to match(/SCoData_combined_v1_2020-07_datapackage.json/)
-      expect(files[2].filename).to match(/directory/)
+      expect(files[2].filename).to match(/a_directory/)
       expect(files[3].filename).to match(/README/)
       expect(files[4].filename).to match(/SCoData_combined_v1_2020-07_datapackage.json/)
-      expect(files[5].filename).to match(/directory/)
+      expect(files[5].filename).to match(/a_directory/)
       expect(fake_aws_client).to have_received(:list_objects_v2).with(bucket: "other-bucket", max_keys: 1000, prefix: "new-prefix")
       expect(fake_aws_client).to have_received(:list_objects_v2).with(bucket: "other-bucket", continuation_token: "abc123", max_keys: 1000, prefix: "new-prefix")
     end
@@ -852,6 +869,7 @@ XML
       s3_query_service.publish_files(user)
     end
 
+    # TODO: Make sure this still works since it depends on the empty files
     describe "#publish_files" do
       it "creates a work activity identifying the empty files" do
         work.reload

--- a/spec/services/s3_query_service_spec.rb
+++ b/spec/services/s3_query_service_spec.rb
@@ -203,6 +203,7 @@ XML
       allow(s3_query_service.client).to receive(:head_object).and_return(true)
       allow(s3_query_service.client).to receive(:complete_multipart_upload).and_return(fake_completion)
       allow(s3_query_service.client).to receive(:put_object).and_return(nil)
+      allow(s3_query_service.client).to receive(:copy_object).and_return(fake_completion)
 
       allow(WorkPreservationService).to receive(:new).and_return(preservation_service)
       allow(preservation_service).to receive(:preserve!)
@@ -213,7 +214,7 @@ XML
         expect do
           expect(s3_query_service.publish_files(user)).to be_truthy
         end.to change { work.upload_snapshots.count }.by 1
-        fake_s3_resp.stub(:to_h).and_return(s3_hash, empty_s3_hash)
+        fake_s3_resp.stub(:to_h).and_return(s3_hash, s3_hash, empty_s3_hash)
         snapshot = work.upload_snapshots.first
         expect(snapshot.files).to eq([
                                        { "filename" => "10.34770/pe9w-x904/#{work.id}/SCoData_combined_v1_2020-07_README.txt", "snapshot_id" => snapshot.id, "upload_status" => "started",
@@ -221,7 +222,7 @@ XML
                                        { "filename" => "10.34770/pe9w-x904/#{work.id}/SCoData_combined_v1_2020-07_datapackage.json", "snapshot_id" => snapshot.id, "upload_status" => "started",
                                          "user_id" => user.id, "checksum" => "7bd3d4339c034ebc663b990657714688" },
                                        { "filename" => "10.34770/pe9w-x904/#{work.id}/a_directory/", "snapshot_id" => snapshot.id, "upload_status" => "started",
-                                       "user_id" => user.id, "checksum" => "7bd3d4339c034ebc663b99065771111" }
+                                         "user_id" => user.id, "checksum" => "7bd3d4339c034ebc663b99065771111" }
                                      ])
         perform_enqueued_jobs
         expect(s3_query_service.client).to have_received(:create_multipart_upload)
@@ -240,6 +241,9 @@ XML
         expect(s3_query_service.client).to have_received(:upload_part_copy)
           .with({ bucket: "example-bucket-post", copy_source: "/example-bucket/#{s3_key2}",
                   copy_source_range: "bytes=5368709120-5368709127", key: "abc", part_number: 2, upload_id: "upload id" })
+        expect(s3_query_service.client).to have_received(:copy_object)
+          .with({ bucket: "example-bucket-post", copy_source: "/example-bucket/#{s3_key3}",
+                  key: s3_key3, checksum_algorithm: "SHA256" })
         expect(s3_query_service.client).to have_received(:complete_multipart_upload)
           .with({ bucket: "example-bucket-post", key: s3_key1, multipart_upload: { parts: [{ etag: "etag123abc", part_number: 1, checksum_sha256: "sha256abc123" },
                                                                                            { etag: "etag123abc", part_number: 2, checksum_sha256: "sha256abc123" }] }, upload_id: "upload id" })
@@ -250,18 +254,22 @@ XML
           .with({ bucket: "example-bucket-post", key: s3_key1 })
         expect(s3_query_service.client).to have_received(:head_object)
           .with({ bucket: "example-bucket-post", key: s3_key2 })
+        expect(s3_query_service.client).to have_received(:head_object)
+          .with({ bucket: "example-bucket-post", key: s3_key3 })
         expect(s3_query_service.client).to have_received(:delete_object)
           .with({ bucket: "example-bucket", key: s3_key1 })
         expect(s3_query_service.client).to have_received(:delete_object)
           .with({ bucket: "example-bucket", key: s3_key2 })
         expect(s3_query_service.client).to have_received(:delete_object)
-          .with({ bucket: "example-bucket", key: work.s3_object_key })
+          .with({ bucket: "example-bucket", key: s3_key3 })
         expect(preservation_service).to have_received(:preserve!)
         expect(snapshot.reload.files).to eq([
-                                              { "checksum" => "abc123etagetag", "filename" => "10.34770/pe9w-x904/#{work.id}/SCoData_combined_v1_2020-07_README.txt", "snapshot_id" => snapshot.id,
-                                                "upload_status" => "complete", "user_id" => user.id },
+                                              { "checksum" => "abc123etagetag", "filename" => "10.34770/pe9w-x904/#{work.id}/SCoData_combined_v1_2020-07_README.txt",
+                                                "snapshot_id" => snapshot.id, "upload_status" => "complete", "user_id" => user.id },
                                               { "checksum" => "abc123etagetag", "filename" => "10.34770/pe9w-x904/#{work.id}/SCoData_combined_v1_2020-07_datapackage.json",
-                                                "snapshot_id" => snapshot.id, "upload_status" => "complete", "user_id" => user.id }
+                                                "snapshot_id" => snapshot.id, "upload_status" => "complete", "user_id" => user.id },
+                                              {"checksum" => "abc123etagetag", "filename" => "10.34770/pe9w-x904/#{work.id}/a_directory/",
+                                                "snapshot_id" => snapshot.id, "upload_status"=>"complete", "user_id" => user.id }
                                             ])
       end
       context "the copy fails for some reason" do


### PR DESCRIPTION
Updated the code to display empty file names and empty folders on the file list.

This prevents the issue where the file count displayed to the user does not match the number of files on the list.

We made empty files and empty folders not downloadables on the file list.

Below is an example of how these empty files/folders are displayed:

![Screenshot 2024-06-03 at 12 25 21 PM](https://github.com/pulibrary/pdc_describe/assets/568286/f4a1b65a-bbf6-46c5-aa85-0d45e77a327c)


Co-authored-by: Robert-Anthony Lee-Faison <leefaisonr@users.noreply.github.com>

Closes #1826 
Closes #1784
See also https://github.com/pulibrary/pdc_describe/issues/1836