### PR TITLE
Fixes the bad provenance logged when deleting files

### DIFF
--- a/app/models/background_upload_snapshot.rb
+++ b/app/models/background_upload_snapshot.rb
@@ -45,7 +45,7 @@ class BackgroundUploadSnapshot < UploadSnapshot
     if filename.include?(work.prefix)
       filename
     else
-      Pathname.new(work.prefix).join(filename).to_s
+      "#{work.prefix}#{filename}"
     end
   end
 end

--- a/app/models/background_upload_snapshot.rb
+++ b/app/models/background_upload_snapshot.rb
@@ -45,7 +45,7 @@ class BackgroundUploadSnapshot < UploadSnapshot
     if filename.include?(work.prefix)
       filename
     else
-      "#{work.prefix}#{filename}"
+      Pathname.new(work.prefix).join(filename).to_s
     end
   end
 end


### PR DESCRIPTION
Logs the correct provenance (who deleted the file) when deleting a file via the Edit screen:

![Screenshot 2024-06-24 at 4 23 31 PM](https://github.com/pulibrary/pdc_describe/assets/568286/b933d677-5453-408f-af6c-2721fcb38331)

Closes #1834
