### PR TITLE
Making the UID not include unsafe characters for routing

### DIFF
--- a/db/migrate/20240705120614_safe_uid.rb
+++ b/db/migrate/20240705120614_safe_uid.rb
@@ -1,0 +1,10 @@
+class SafeUid < ActiveRecord::Migration[6.1]
+  def change
+    # update any exisitng user to have a safe uid so that correct user will be found when the user logs in
+    User.where(" uid like '%@%'").each do |user|
+      safe_uid = User.safe_uid(user.uid)
+      user.uid = safe_uid
+      user.save
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_10_25_155725) do
+ActiveRecord::Schema.define(version: 2024_07_05_120614) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -14,6 +14,17 @@ RSpec.describe Users::OmniauthCallbacksController do
     end
   end
 
+  context "a guest cas user" do
+    it "redirects to home page with success notice" do
+      allow(User).to receive(:from_cas) { FactoryBot.create(:user, uid: "test.user@example.com", email: "test.user@example.com@princeton.edu") }
+      get :cas
+      expect(response).to redirect_to(root_path)
+      expect(flash[:notice]).to eq("Successfully authenticated from Princeton Central Authentication Service account.")
+      expect(User.first.email).to eq("test.user@example.com@princeton.edu")
+      expect(User.first.uid).to eq("test_user_example_com")
+    end
+  end
+
   context "invalid user" do
     it "redirects to home page with warning notice" do
       allow(User).to receive(:from_cas) { nil }

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -19,6 +19,13 @@ RSpec.describe UsersController do
     expect(response).to render_template("show")
   end
 
+  it "renders the show page for external users" do
+    # Notice that for external users like "pppltest@gmail.com" Rails splits the ".com" in the URL
+    sign_in user_external
+    get :show, params: { id: user_external.friendly_id }
+    expect(response).to render_template("show")
+  end
+
   describe "#edit" do
     context "when authenticated and the current user is authorized" do
       before do

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -58,7 +58,7 @@ FactoryBot.define do
   end
 
   factory :external_user, class: "User" do
-    uid { FFaker::InternetSE.user_name + "@gmail.com" }
+    uid { User.safe_uid(FFaker::InternetSE.user_name + ".abc@gmail.com") }
     email { "#{uid}@princeton.edu" }
     provider { :cas }
   end


### PR DESCRIPTION
external uids are the entire email, so we need to make them safe

Also makes all existing uids in the database safe via migration

![Screenshot 2024-07-05 at 8 11 13 AM](https://github.com/pulibrary/pdc_describe/assets/1599081/650c9340-624d-40a6-b8a0-62d5506e7546)

fixes https://github.com/pulibrary/pdc_describe/issues/1823