### PR TITLE
Ensuring the SimpleCov utilizes the HTML formatter for local development environments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,6 @@ gem "retryable"
 gem "rolify"
 gem "rspec-rails", "~> 5.0.0"
 gem "sidekiq", "~> 7.2"
-gem "simplecov", require: false
 gem "vite_rails", "3.0.12"
 gem "whenever"
 
@@ -72,6 +71,7 @@ group :development, :test do
   gem "equivalent-xml", "~> 0.6.0"
   gem "pry-byebug"
   gem "pry-rails"
+  gem "simplecov", "~> 0.22"
   gem "yard"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.0)
+    bigdecimal (3.1.8)
     bindex (0.8.1)
     bixby (4.0.0)
       rubocop (>= 1, < 2)
@@ -155,11 +156,11 @@ GEM
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.3.1)
     connection_pool (2.4.1)
-    coveralls_reborn (0.24.0)
-      simplecov (>= 0.18.1, < 0.22.0)
-      term-ansicolor (~> 1.6)
-      thor (>= 0.20.3, < 2.0)
-      tins (~> 1.16)
+    coveralls_reborn (0.28.0)
+      simplecov (~> 0.22.0)
+      term-ansicolor (~> 1.7)
+      thor (~> 1.2)
+      tins (~> 1.32)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -454,7 +455,7 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.19.0)
-    simplecov (0.21.2)
+    simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
@@ -499,7 +500,8 @@ GEM
     time (0.2.2)
       date
     timeout (0.1.1)
-    tins (1.31.0)
+    tins (1.33.0)
+      bigdecimal
       sync
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
@@ -612,7 +614,7 @@ DEPENDENCIES
   sass-rails (>= 6)
   selenium-webdriver
   sidekiq (~> 7.2)
-  simplecov
+  simplecov (~> 0.22)
   sinatra
   turbolinks (~> 5)
   tzinfo-data

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,17 @@
 # frozen_string_literal: true
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 
+require "simplecov"
+require "simplecov_json_formatter"
+SimpleCov.start "rails" do
+  multi = SimpleCov::Formatter::MultiFormatter.new([
+                                                     SimpleCov::Formatter::SimpleFormatter,
+                                                     SimpleCov::Formatter::HTMLFormatter,
+                                                     SimpleCov::Formatter::JSONFormatter
+                                                   ])
+  formatter(multi)
+end
+
 require "spec_helper"
 ENV["RAILS_ENV"] ||= "test"
 require File.expand_path("../config/environment", __dir__)


### PR DESCRIPTION
I am also experiencing a strange `Coveralls` error where including `Coveralls.wear!` triggers an error. I am attempting to test this commit first and confirm that Coveralls is still receiving reports.