### PR TITLE
Restoring the commented blocks and removing code comments

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -278,28 +278,24 @@ class WorksController < ApplicationController
       params[:work] || {}
     end
 
-    # not a route, not called elsewhere
     def patch_params
       return {} unless params.key?(:patch)
 
       params[:patch]
     end
 
-    # not a route, not called elsewhere
     def pre_curation_uploads_param
       return if patch_params.nil?
 
       patch_params[:pre_curation_uploads]
     end
 
-    # not a route, not called elsewhere
     def readme_file_param
       return if patch_params.nil?
 
       patch_params[:readme_file]
     end
 
-    # not called
     def rescue_aasm_error
       super
     rescue StandardError => generic_error
@@ -310,7 +306,6 @@ class WorksController < ApplicationController
       end
     end
 
-    # not called
     def handle_error_for_create(generic_error)
       if @work.persisted?
         Honeybadger.notify("Failed to create the new Dataset #{@work.id}: #{generic_error.message}")
@@ -326,7 +321,6 @@ class WorksController < ApplicationController
       end
     end
 
-    # not called
     def redirect_aasm_error(transition_error_message)
       if @work.persisted?
         redirect_to edit_work_url(id: @work.id), notice: transition_error_message, params:
@@ -339,7 +333,6 @@ class WorksController < ApplicationController
       end
     end
 
-    # not called
     def error_action
       @form_resource_decorator = FormResourceDecorator.new(@work, current_user)
       if action_name == "create"

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -12,10 +12,10 @@ class NotificationMailer < ApplicationMailer
     @url = work_url(@work_activity.work)
 
     # Troubleshooting https://github.com/pulibrary/pdc_describe/issues/1783
-    # if @url.include?("/describe/describe/")
-    #  Rails.logger.error("URL #{@url} included /describe/describe/ and was fixed. See https://github.com/pulibrary/pdc_describe/issues/1783")
-    #  @url = @url.gsub("/describe/describe/", "/describe/")
-    # end
+    if @url.include?("/describe/describe/")
+      Rails.logger.error("URL #{@url} included /describe/describe/ and was fixed. See https://github.com/pulibrary/pdc_describe/issues/1783")
+      @url = @url.gsub("/describe/describe/", "/describe/")
+    end
 
     mail(to: @user.email, subject: @subject)
   end

--- a/app/models/work_state_transition_notification.rb
+++ b/app/models/work_state_transition_notification.rb
@@ -15,10 +15,10 @@ class WorkStateTransitionNotification
     @work_url = Rails.application.routes.url_helpers.work_url(work)
 
     # Troubleshooting https://github.com/pulibrary/pdc_describe/issues/1783
-    # if @work_url.include?("/describe/describe/")
-    #  Rails.logger.error("URL #{@work_url} included /describe/describe/ and was fixed. See https://github.com/pulibrary/pdc_describe/issues/1783")
-    #  @work_url = @work_url.gsub("/describe/describe/", "/describe/")
-    # end
+    if @work_url.include?("/describe/describe/")
+      Rails.logger.error("URL #{@work_url} included /describe/describe/ and was fixed. See https://github.com/pulibrary/pdc_describe/issues/1783")
+      @work_url = @work_url.gsub("/describe/describe/", "/describe/")
+    end
 
     @work_title = work.title
     @notification = notification_for_transition

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -20,6 +20,13 @@ RSpec.describe UsersController do
     expect(response).to render_template("show")
   end
 
+  it "renders the show page for external users" do
+    # Notice that for external users like "pppltest@gmail.com" Rails splits the ".com" in the URL
+    sign_in user_external
+    get :show, params: { id: user_external.friendly_id }
+    expect(response).to render_template("show")
+  end
+
   describe "#edit" do
     context "when authenticated and the current user is authorized" do
       before do


### PR DESCRIPTION
While you are correct in removing https://github.com/pulibrary/pdc_describe/pull/1858/files#diff-8c3fb4a34f9f014040e82fda94adff3d6344eacfbcea5bfd039afab491c205a3L15 and https://github.com/pulibrary/pdc_describe/pull/1858/files#diff-88f3a762d2fd74e42ef154e979619b890a12d146214366033da05a0af4357c26L18, my concern is that this must be explicitly confirmed before this is introduced into `main` (if it has not yet been removed, this might break any attempts to deploy `main`, or any branches rebased upon `main`).