### PR TITLE
uri encoding the source key in dataspace file copy

### DIFF
--- a/app/services/s3_query_service.rb
+++ b/app/services/s3_query_service.rb
@@ -236,7 +236,7 @@ class S3QueryService
     if size > part_size
       copy_multi_part(source_key:, target_bucket:, target_key:, size:)
     else
-      client.copy_object(copy_source: source_key, bucket: target_bucket, key: target_key, checksum_algorithm: "SHA256")
+      client.copy_object(copy_source: source_key.gsub("+", "%2B"), bucket: target_bucket, key: target_key, checksum_algorithm: "SHA256")
     end
   rescue Aws::Errors::ServiceError => aws_service_error
     message = "An error was encountered when requesting to copy AWS S3 Object from #{source_key} to #{target_key} in the bucket #{target_bucket}: #{aws_service_error}"


### PR DESCRIPTION
Turns out you need to url encode the key if you put it with the bucket name. 
'bucket/key+with+space' needs to be 'bucket/key%2Bwith%2Bspace' for copy_object 
even though aws will tell you the key is 'key+with+space'

![Screenshot 2024-08-05 at 8 50 37 AM](https://github.com/user-attachments/assets/635e076b-2bea-4cd4-be1b-9cb93c2a6781)

fixes #1874 