### PR TITLE
Allow urls to wrap and setup widths on description list to be responsive

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -271,6 +271,8 @@ dl {
 
   dd {
     grid-column-start: 2;
+    width: calc(100% - 10rem);
+    word-wrap: break-word;
   }
 }
 
@@ -373,4 +375,8 @@ div.form-subcommunities .form-check{
 
 .hidden-element {
   display: none;
+}
+
+table.dataTable {
+  overflow-wrap: anywhere
 }


### PR DESCRIPTION
fixes #1868

Note:  Datatable will resize properly with a reload, but not with a change of the window.

## Before the change to the DL:
![Screenshot 2024-08-12 at 8 21 30 AM](https://github.com/user-attachments/assets/f24d71e9-4217-481d-b394-0b05350d6964)

## After the change to the DL:
![Screenshot 2024-08-12 at 8 22 05 AM](https://github.com/user-attachments/assets/665a1bf1-53da-46c9-8803-ac5f8e0dfdb2)

## Before the change to the Datatable:
![Screenshot 2024-08-12 at 8 21 39 AM](https://github.com/user-attachments/assets/a6c475ab-8b72-40ce-95e0-c0af144c2cb0)

## After the change to the Datatable:
![Screenshot 2024-08-12 at 8 21 54 AM](https://github.com/user-attachments/assets/a28975e7-ea9b-41a7-8c38-e8ba90d6842e)
