### PR TITLE
Fixes bug in validation

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -389,6 +389,7 @@ class WorksController < ApplicationController
         # This is needed for rendering HTML views with validation errors
         @uploads = @work.uploads
         @form_resource_decorator = FormResourceDecorator.new(@work, current_user)
+        @work_decorator = WorkDecorator.new(@work, current_user)
 
         # return 200 so the loadbalancer doesn't capture the error
         render :edit

--- a/spec/system/work_edit_spec.rb
+++ b/spec/system/work_edit_spec.rb
@@ -183,6 +183,20 @@ RSpec.describe "Creating and updating works", type: :system, js: true do
     end
   end
 
+  context "when introducing errors while editting " do
+    let(:work) { FactoryBot.create(:awaiting_approval_work) }
+    let(:curator) { FactoryBot.create(:user, groups_to_admin: [work.group]) }
+
+    it "reports the errors to the user" do
+      sign_in curator
+      visit edit_work_path(work)
+      click_on "Curator Controlled"
+      fill_in "resource_type", with: "invalid value"
+      click_on "Save Work"
+      expect(page).to have_content("error prohibited")
+    end
+  end
+
   context "for PRDS works" do
     let(:work) { FactoryBot.create(:distinct_cytoskeletal_proteins_work) }
     let(:user) { work.created_by_user }


### PR DESCRIPTION
Fixes the bug in the validation process that was causing the system to run into a `nil` value in the `@work_decorator`

We were not setting `@work_decorator` after detecting the errors and this was resulting on the view crashing rather than displaying the error to the user.

Closes #1869 
