### PR TITLE
User edit improvements

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -80,7 +80,10 @@ class UsersController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def user_params
-      @user_params ||= params.require(:user).permit([:given_name, :full_name, :family_name, :orcid, :email_messages_enabled, groups_with_messaging: {}])
+      @user_params ||= params.require(:user).permit([
+                                                      :given_name, :full_name, :family_name, :orcid, :email_messages_enabled,
+                                                      :email, :default_group_id, groups_with_messaging: {}
+                                                    ])
     end
 
     def can_edit?

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -77,18 +77,25 @@
 
   <div class="field">
     Email<br />
-    <input id="email" type="text" class="user-edit-long-field" disabled value="<%= @user.email %>" />
+    <%= form.text_field :email, class: "user-edit-long-field" %>
   </div>
 
   <div class="field">
     Princeton Net ID<br />
-    <input id="netid" type="text" class="user-edit-long-field" disabled value="<%= @user.uid %>" />
+    <%= form.text_field :uid, class: "user-edit-long-field", readonly: true %>
   </div>
 
-  <div class="field">
-    Default group<br />
-    <input id="default_group" type="text" class="user-edit-long-field" disabled value="<%= @user.default_group.title %>" />
-  </div>
+  <% if current_user.moderator? || current_user.super_admin? %>
+    <div class="field">
+      Default group<br />
+      <%= form.collection_select :default_group_id, Group.order(:title), :id, :title, {include_blank: false}, {class: "user-edit-long-field"} %>
+    </div>
+  <% else %>
+    <div class="field">
+      Default group<br />
+      <input type="text" class="user-edit-long-field" readonly value="<%= @user.default_group.title %>" />
+    </div>
+  <% end %>
 
   <div class="text-left">
     <%= form.submit "Save", class: "btn btn-primary" %>


### PR DESCRIPTION
Allows a user to edit their own email address and an administrator (or moderator) to adjust the default group for another user. Both of these values need to be tweaked for GAP accounts and this PR allows users to manually adjust the values without needing a developer to fix the data.

Closes #1901 
Closes #1905 

