### PR TITLE
Ensures that empty files and nil user IDs for WorkActivity objects raise ArgumentErrors

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -265,7 +265,6 @@ class Work < ApplicationRecord
 
   def add_provenance_note(date, note, current_user_id, change_label = "")
     WorkActivity.add_work_activity(id, { note:, change_label: }.to_json, current_user_id, activity_type: WorkActivity::PROVENANCE_NOTES, created_at: date)
-    # WorkActivity.add_work_activity(id, note, current_user_id, activity_type: WorkActivity::PROVENANCE_NOTES, created_at: date)
   end
 
   def log_changes(resource_compare, current_user_id)

--- a/app/models/work_activity.rb
+++ b/app/models/work_activity.rb
@@ -267,6 +267,7 @@ class WorkActivity < ApplicationRecord
             "<a class='message-user-link' title='#{user_info}' href='#{@work_activity.users_path}/#{uid}'>#{at_uid}</a>"
           end
         else
+          Rails.logger.warn("Failed to extract the user ID from #{uid}")
           UNKNOWN_USER
         end
       end

--- a/app/models/work_state_transition_notification.rb
+++ b/app/models/work_state_transition_notification.rb
@@ -23,6 +23,8 @@ class WorkStateTransitionNotification
     @work_title = work.title
     @notification = notification_for_transition
     @id = work.id
+
+    raise(NotImplementedError, "Invalid user ID provided.") if current_user_id.nil?
     @current_user_id = current_user_id
   end
 

--- a/spec/models/background_upload_snapshot_spec.rb
+++ b/spec/models/background_upload_snapshot_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe BackgroundUploadSnapshot, type: :model do
   let(:work) { FactoryBot.create(:approved_work) }
   let(:uploaded_file1) { fixture_file_upload("us_covid_2019.csv", "text/csv") }
   let(:uploaded_file2) { fixture_file_upload("us_covid_2020.csv", "text/csv") }
+  let(:current_user) { work.created_by_user }
 
   describe "#count" do
     it "only counts the bacground uploads" do
@@ -16,10 +17,12 @@ RSpec.describe BackgroundUploadSnapshot, type: :model do
   end
 
   describe "#store_files" do
+    let(:current_user) { work.created_by_user }
+
     it "lists filenames associated with the snapshot" do
-      background_upload_snapshot.store_files([uploaded_file1, uploaded_file2])
-      expect(background_upload_snapshot.files).to eq([{ "filename" => "#{work.prefix}us_covid_2019.csv", "upload_status" => "started", "user_id" => nil, "snapshot_id" => 123 },
-                                                      { "filename" => "#{work.prefix}us_covid_2020.csv", "upload_status" => "started", "user_id" => nil, "snapshot_id" => 123 }])
+      background_upload_snapshot.store_files([uploaded_file1, uploaded_file2], current_user:)
+      expect(background_upload_snapshot.files).to eq([{ "filename" => "#{work.prefix}us_covid_2019.csv", "upload_status" => "started", "snapshot_id" => 123, "user_id" => current_user.id },
+                                                      { "filename" => "#{work.prefix}us_covid_2020.csv", "upload_status" => "started", "user_id" => current_user.id, "snapshot_id" => 123 }])
       expect(background_upload_snapshot.existing_files).to eq([])
       expect(background_upload_snapshot.upload_complete?).to be_falsey
     end
@@ -39,26 +42,50 @@ RSpec.describe BackgroundUploadSnapshot, type: :model do
   describe "#mark_complete" do
     it "changes the status" do
       allow(Honeybadger).to receive(:notify)
-      background_upload_snapshot.store_files([uploaded_file1, uploaded_file2])
+      background_upload_snapshot.store_files([uploaded_file1, uploaded_file2], current_user:)
       expect(work.work_activity.count).to eq(0)
       background_upload_snapshot.mark_complete(uploaded_file2.original_filename, "checksumabc123")
       expect(work.work_activity.count).to eq(0)
-      expect(background_upload_snapshot.files).to eq([{ "filename" => "#{work.prefix}us_covid_2019.csv", "upload_status" => "started", "user_id" => nil, "snapshot_id" => 123 },
-                                                      { "filename" => "#{work.prefix}us_covid_2020.csv", "upload_status" => "complete", "user_id" => nil, "checksum" => "checksumabc123",
+      expect(background_upload_snapshot.files).to eq([{ "filename" => "#{work.prefix}us_covid_2019.csv", "upload_status" => "started", "user_id" => current_user.id, "snapshot_id" => 123 },
+                                                      { "filename" => "#{work.prefix}us_covid_2020.csv", "upload_status" => "complete", "user_id" => current_user.id, "checksum" => "checksumabc123",
                                                         "snapshot_id" => 123 }])
       expect(background_upload_snapshot.upload_complete?).to be_falsey
-      expect(background_upload_snapshot.existing_files).to eq([{ "filename" => "#{work.prefix}us_covid_2020.csv", "upload_status" => "complete", "user_id" => nil, "checksum" => "checksumabc123",
+      # rubocop:disable Layout/LineLength
+      expect(background_upload_snapshot.existing_files).to eq([{ "filename" => "#{work.prefix}us_covid_2020.csv", "upload_status" => "complete", "user_id" => current_user.id, "checksum" => "checksumabc123",
                                                                  "snapshot_id" => 123 }])
       background_upload_snapshot.mark_complete(uploaded_file1.original_filename, "checksumdef456")
       expect(background_upload_snapshot.upload_complete?).to be_truthy
       expect(background_upload_snapshot.existing_files).to eq([{ "filename" => "#{work.prefix}us_covid_2019.csv", "upload_status" => "complete",
-                                                                 "user_id" => nil, "checksum" => "checksumdef456", "snapshot_id" => 123 },
-                                                               { "filename" => "#{work.prefix}us_covid_2020.csv", "upload_status" => "complete", "user_id" => nil, "checksum" => "checksumabc123",
+                                                                 "user_id" => current_user.id, "checksum" => "checksumdef456", "snapshot_id" => 123 },
+                                                               { "filename" => "#{work.prefix}us_covid_2020.csv", "upload_status" => "complete", "user_id" => current_user.id, "checksum" => "checksumabc123",
                                                                  "snapshot_id" => 123 }])
+      # rubocop:enable Layout/LineLength
       expect(work.work_activity.count).to eq(1)
       expect(work.work_activity.first.message).to eq("[{\"action\":\"added\",\"filename\":\"#{work.prefix}us_covid_2019.csv\"}"\
       ",{\"action\":\"added\",\"filename\":\"#{work.prefix}us_covid_2020.csv\"}]")
-      expect(work.work_activity.first.created_by_user_id).to eq(nil)
+      expect(work.work_activity.first.created_by_user_id).to eq(current_user.id)
+    end
+  end
+
+  describe "#finalize_upload" do
+    context "when no files are associated with the work" do
+      it "raises an exception" do
+        expect { background_upload_snapshot.finalize_upload }.to raise_error(ArgumentError, "Upload failed with empty files.")
+      end
+    end
+
+    context "when the file is not associated with a user" do
+      let(:uploaded_file1) { fixture_file_upload("us_covid_2019.csv", "text/csv") }
+      let(:files) do
+        [
+          uploaded_file1
+        ]
+      end
+
+      it "raises an error" do
+        pattern = Regexp.escape("Failed to resolve the user ID from ")
+        expect { background_upload_snapshot.store_files(files) }.to raise_error(ArgumentError, /#{pattern}/)
+      end
     end
   end
 end


### PR DESCRIPTION
Advances #1919 by ensuring that errors (and a warning) are logged in order to capture what led to the errors in the production environment