### PR TITLE
Upping the number of items that can be in the sidekiq queue

### DIFF
--- a/config/initializers/health_monitor.rb
+++ b/config/initializers/health_monitor.rb
@@ -8,7 +8,7 @@ HealthMonitor.configure do |config|
 
   config.sidekiq.configure do |sidekiq_config|
     sidekiq_config.latency = 6.hours
-    sidekiq_config.queue_size = 10_000
+    sidekiq_config.queue_size = 20_000
     sidekiq_config.maximum_amount_of_retries = 100
     sidekiq_config.critical = false
   end


### PR DESCRIPTION
We had more than 20k and that was normal for a large work