### PR TITLE
Fixes time out issue on records with very large number of provenance messages

### DIFF
--- a/app/decorators/work_decorator.rb
+++ b/app/decorators/work_decorator.rb
@@ -10,7 +10,7 @@ class WorkDecorator
   def initialize(work, current_user)
     @work = work
     @current_user = current_user
-    @changes =  WorkActivity.changes_for_work(work.id).order(created_at: :desc).take(100)
+    @changes =  WorkActivity.changes_for_work(work.id).order(created_at: :asc)
     @messages = WorkActivity.messages_for_work(work.id).order(created_at: :desc)
     @can_curate = current_user&.can_admin?(group)
   end

--- a/app/decorators/work_decorator.rb
+++ b/app/decorators/work_decorator.rb
@@ -10,7 +10,7 @@ class WorkDecorator
   def initialize(work, current_user)
     @work = work
     @current_user = current_user
-    @changes =  WorkActivity.changes_for_work(work.id)
+    @changes =  WorkActivity.changes_for_work(work.id).order(created_at: :desc).take(100)
     @messages = WorkActivity.messages_for_work(work.id).order(created_at: :desc)
     @can_curate = current_user&.can_admin?(group)
   end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -299,8 +299,12 @@ class Work < ApplicationRecord
     # Rails batching information:
     #   https://guides.rubyonrails.org/active_record_querying.html
     #   https://api.rubyonrails.org/classes/ActiveRecord/Batches.html
+
+    # Disable this validation since we want to force a SQL UPDATE.
+    # rubocop:disable Rails/SkipsModelValidations
     now_utc = Time.now.utc
     WorkActivityNotification.joins(:work_activity).where("user_id=? and work_id=?", user_id, id).in_batches(of: 1000).update_all(read_at: now_utc)
+    # rubocop:enable Rails/SkipsModelValidations
   end
 
   def current_transition

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -292,20 +292,15 @@ class Work < ApplicationRecord
   # In practice, the user_id is the id of the current user and therefore this method marks the current's user
   # notifications as read.
   def mark_new_notifications_as_read(user_id)
-    # https://guides.rubyonrails.org/active_record_querying.html
-    # TODO: Although we are batching the query (see batch_size parameter) we are still
-    # calling save on *each* notification and that might be too slow, is there a way to
-    # batch the save too?
-    WorkActivityNotification.joins(:work_activity).where("user_id=? and work_id=?", user_id, id).find_each(batch_size: 1000) do |unread_notification|
-      unread_notification.read_at = Time.now.utc
-      unread_notification.save
-    end
-
-    # TODO: Test if this work to save in batches
-    # ====
-    # now_utc = Time.now.utc
-    # WorkActivityNotification.joins(:work_activity).where("user_id=? and work_id=?", user_id, id).find_in_batches.update_all(read_at: now_utc)
-    # ====
+    # Notice that we fetch and update the information in batches
+    # so that we don't issue individual SQL SELECT + SQL UPDATE
+    # for each notification.
+    #
+    # Rails batching information:
+    #   https://guides.rubyonrails.org/active_record_querying.html
+    #   https://api.rubyonrails.org/classes/ActiveRecord/Batches.html
+    now_utc = Time.now.utc
+    WorkActivityNotification.joins(:work_activity).where("user_id=? and work_id=?", user_id, id).in_batches(of: 1000).update_all(read_at: now_utc)
   end
 
   def current_transition

--- a/app/models/work_activity.rb
+++ b/app/models/work_activity.rb
@@ -80,6 +80,8 @@ class WorkActivity < ApplicationRecord
   def created_by_user
     return nil unless created_by_user_id
 
+    # This is very slow when we have thousands of notifications
+    # (even when Rails is reading from cache, we are calling the find method way to many times)
     User.find(created_by_user_id)
   end
 

--- a/app/models/work_activity.rb
+++ b/app/models/work_activity.rb
@@ -79,9 +79,6 @@ class WorkActivity < ApplicationRecord
 
   def created_by_user
     return nil unless created_by_user_id
-
-    # This is very slow when we have thousands of notifications
-    # (even when Rails is reading from cache, we are calling the find method way to many times)
     User.find(created_by_user_id)
   end
 

--- a/app/views/works/_work_activity_provenance.html.erb
+++ b/app/views/works/_work_activity_provenance.html.erb
@@ -4,12 +4,15 @@
     No activity
   <% end %>
   <ul class="beads">
-    <% @work_decorator.changes.sort_by(&:created_at).each do |activity| %>
+    <% @work_decorator.changes.take(100).each_with_index do |activity| %>
       <li class="activity-history-item">
         <%= activity.to_html.html_safe %>
       </li>
     <% end %>
   </ul>
+  <% if @work_decorator.changes.size > 100 %>
+    <p><i>There are <b><%= @work_decorator.changes.size - 100 %></b> more notifications, contact RDSS if you need to view them.</i></p>
+  <% end %>
 
   <% if can_add_provenance_note %>
     <%= form_with url: add_provenance_note_path(@work) do |f| %>
@@ -34,7 +37,7 @@
         <summary  class="remove-see-more">
         Change Label
         <span class="summary-detail">
-        The change label applies a brief descriptor to the provenance log that labels the applied action. 
+        The change label applies a brief descriptor to the provenance log that labels the applied action.
         </span>
         <title>Change Label</title>
         </head>
@@ -55,11 +58,11 @@
       <div class="field">
         <details>
           <summary  class="remove-see-more">
-          Note 
+          Note
           <span class="summary-detail">
-          The note to add to the change history. Markdown can be used. 
+          The note to add to the change history. Markdown can be used.
           </span>
-          
+
           </summary>
         </details>
         <input id="new-provenance-note" name="new-provenance-note">

--- a/lib/tasks/works.rake
+++ b/lib/tasks/works.rake
@@ -109,6 +109,17 @@ namespace :works do
     puts work_preservation.preserve!
   end
 
+  # Artificially add a lot of notifications to a work
+  task :big_provenance, [:work_id] => :environment do |_, args|
+    work_id = args[:work_id].to_i
+    user = User.find_by(uid: "hc8719")
+    (0..10000).each do |i|
+      WorkActivity.add_work_activity(work_id, "random activity #{i} - #{rand(1000000)}", user.id, activity_type: WorkActivity::SYSTEM)
+    end
+    work = Work.find(work_id)
+    puts work.activities.count
+  end
+
   desc "Clean up the duplicate globus and data_space files in a work from migration"
   task :migration_cleanup, [:work_id, :force] => :environment do |_, args|
     work_id = args[:work_id].to_i

--- a/lib/tasks/works.rake
+++ b/lib/tasks/works.rake
@@ -115,11 +115,11 @@ namespace :works do
     work_id = args[:work_id].to_i
     user = User.find_by(uid: "hc8719")
     datestamp = DateTime.now.to_s
-    (0..2000).each do |i|
-      WorkActivity.add_work_activity(work_id, "SYSTEM #{datestamp} - #{rand(1000000)}", user.id, activity_type: WorkActivity::SYSTEM)
+    (0..2000).each do |_i|
+      WorkActivity.add_work_activity(work_id, "SYSTEM #{datestamp} - #{rand(1_000_000)}", user.id, activity_type: WorkActivity::SYSTEM)
     end
-    (0..40).each do |i|
-      WorkActivity.add_work_activity(work_id, "MESSAGE #{datestamp} - #{rand(1000000)} @hc8719", user.id, activity_type: WorkActivity::MESSAGE)
+    (0..40).each do |_i|
+      WorkActivity.add_work_activity(work_id, "MESSAGE #{datestamp} - #{rand(1_000_000)} @hc8719", user.id, activity_type: WorkActivity::MESSAGE)
     end
     work = Work.find(work_id)
     puts work.activities.count

--- a/lib/tasks/works.rake
+++ b/lib/tasks/works.rake
@@ -110,11 +110,16 @@ namespace :works do
   end
 
   # Artificially add a lot of notifications to a work
+  # (Will be used to test https://github.com/pulibrary/pdc_describe/issues/1978 in staging )
   task :big_provenance, [:work_id] => :environment do |_, args|
     work_id = args[:work_id].to_i
     user = User.find_by(uid: "hc8719")
-    (0..10000).each do |i|
-      WorkActivity.add_work_activity(work_id, "random activity #{i} - #{rand(1000000)}", user.id, activity_type: WorkActivity::SYSTEM)
+    datestamp = DateTime.now.to_s
+    (0..2000).each do |i|
+      WorkActivity.add_work_activity(work_id, "SYSTEM #{datestamp} - #{rand(1000000)}", user.id, activity_type: WorkActivity::SYSTEM)
+    end
+    (0..40).each do |i|
+      WorkActivity.add_work_activity(work_id, "MESSAGE #{datestamp} - #{rand(1000000)} @hc8719", user.id, activity_type: WorkActivity::MESSAGE)
     end
     work = Work.find(work_id)
     puts work.activities.count


### PR DESCRIPTION
Addresses the issue of loading a work with a large number of messages in the provenance log. 

The culprit was two fold:
1. The code to mark notifications as read iterates one by one on each notification which translates on individual SQL SELECT commands. This PR batches the SQL UPDATE which is much faster, particularly when there are thousand of notifications in the database.
2. There is also a problem with the way we determine the user name to display for each notification. The code issues a SQL SELECT for each notification to retrieve the user name to display (in addition to the user's netid). Even with Rails using its internal cache this is slow when there are thousands of SYSTEM generated notifications. This PR displays only the first 100 SYSTEM notifications and let's the user know if there are more to be aware of (see screenshot below).

![Screenshot 2024-10-30 at 5 39 24 PM](https://github.com/user-attachments/assets/58fdb457-e48e-4403-a2d3-545c20242744)

Closes #1978 
Closes #1977