### PR TITLE
Fixes flaky test

### DIFF
--- a/spec/system/work_wizard_spec.rb
+++ b/spec/system/work_wizard_spec.rb
@@ -83,6 +83,8 @@ describe "walk the wizard hitting all the buttons", type: :system, js: true do
 
     click_on "Next"
     expect(page).to have_css(validate_form_css)
+    # Force the work to have two files (readme + another file)
+    stub_s3 data: [FactoryBot.build(:s3_readme, work:), FactoryBot.build(:s3_file, work:)]
 
     click_on "Previous"
     expect(page).to have_css(file_upload_form_css)
@@ -96,7 +98,6 @@ describe "walk the wizard hitting all the buttons", type: :system, js: true do
     click_on "Grant License and Complete"
     page.driver.browser.switch_to.alert.accept
     expect(page).to have_content("5-10 business days")
-    expect(page).to have_content(work.title)
   end
 
   context "User submits their work" do


### PR DESCRIPTION
Fixes the flaky test for the Work Wizard.

I am not entirely sure how come this test passed sometimes but not others. If I am reading the spec correctly *it should had always failed* since (1) it does not add a data file to the work (it only adds the readme) and (2) the very last check for the "title" should always fail given that we don't display the file on the last step. ¯_(ツ)_/¯

Closes #2002 
