### PR TITLE
Allow redis to be remote based on the redis url

### DIFF
--- a/config/initializers/health_monitor.rb
+++ b/config/initializers/health_monitor.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
+require_relative "redis_config"
 
 HealthMonitor.configure do |config|
   config.cache
-  config.redis
+  config.redis.configure do |provider_config|
+    provider_config.url = RedisConfig.url
+  end
 
   # Make this health check available at /health
   config.path = :health

--- a/config/initializers/redis_config.rb
+++ b/config/initializers/redis_config.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module RedisConfig
+  def config
+    @config ||= config_yaml.with_indifferent_access
+  end
+
+  def url
+    @url ||= "redis://#{config[:host]}:#{config[:port]}/#{config[:db]}"
+  end
+
+    private
+
+      def config_yaml
+        YAML.safe_load(ERB.new(IO.read(Rails.root.join("config", "redis.yml"))).result, aliases: true)[Rails.env]
+      end
+
+      module_function :config, :url, :config_yaml
+end

--- a/config/initializers/sidekiq_config.rb
+++ b/config/initializers/sidekiq_config.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+Sidekiq.configure_server do |config|
+  config.redis = { url: RedisConfig.url }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: RedisConfig.url }
+end

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -4,3 +4,7 @@ production: &production
   db: <%= ENV['PDC_REDIS_DB'] || 0 %>
 staging:
   <<: *production
+development:
+  <<: *production
+test:
+  <<: *production


### PR DESCRIPTION
We were not configuring sidekiq correctly to allow a remote redis 