### PR TITLE
Handle File Upload errors when the Load Balancer blocks the request

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -227,8 +227,10 @@ class WorksController < ApplicationController
   # POST /works/1/upload-files (called via Uppy)
   def upload_files
     @work = Work.find(params[:id])
-    upload_service = WorkUploadsEditService.new(@work, current_user)
-    upload_service.update_precurated_file_list(params["files"], [])
+    # upload_service = WorkUploadsEditService.new(@work, current_user)
+    # upload_service.update_precurated_file_list(params["files"], [])
+    byebug
+    render plain: "An error from the load balancer: Your Support ID is 123"
   end
 
   # Validates that the work is ready to be approved

--- a/app/controllers/works_wizard_controller.rb
+++ b/app/controllers/works_wizard_controller.rb
@@ -60,8 +60,11 @@ class WorksWizardController < ApplicationController
   # POST /works/1/upload-files-wizard (called via Uppy)
   def upload_files
     @work = Work.find(params[:id])
-    upload_service = WorkUploadsEditService.new(@work, current_user)
-    upload_service.update_precurated_file_list(params["files"], [])
+    # upload_service = WorkUploadsEditService.new(@work, current_user)
+    # upload_service.update_precurated_file_list(params["files"], [])
+    # byebug
+    render plain: "An error from the load balancer: Your Support ID is 456"
+    # render plain: "something went wrong"
   end
 
   # POST /works/1/file_upload
@@ -150,16 +153,19 @@ class WorksWizardController < ApplicationController
     raise StandardError("Only one README file can be uploaded.") if files_param.empty?
     raise StandardError("Only one README file can be uploaded.") if files_param.length > 1
 
-    readme_file = files_param.first
-    readme = Readme.new(@work, current_user)
+    # readme_file = files_param.first
+    # readme = Readme.new(@work, current_user)
 
-    readme_error = readme.attach(readme_file)
-    if readme_error.nil?
-      render plain: readme.file_name
-    else
-      # Tell Uppy there was an error uploading the README
-      render plain: readme.file_name, status: :internal_server_error
-    end
+    # readme_error = readme.attach(readme_file)
+    # if readme_error.nil?
+    #   render plain: readme.file_name
+    # else
+    #   # Tell Uppy there was an error uploading the README
+    #   render plain: readme.file_name, status: :internal_server_error
+    # end
+
+    byebug
+    render plain: "An error from the load balancer: Your Support ID is 789"
   end
 
   def file_location_url

--- a/app/javascript/entrypoints/pdc/work_readme_file_upload.es6
+++ b/app/javascript/entrypoints/pdc/work_readme_file_upload.es6
@@ -61,6 +61,7 @@ export default class WorkReadmeFileUpload {
       bundle: true, // upload all selected files at once
       formData: true, // required when bundle: true
       getResponseData(filename) {
+        debugger;
         $('#new-readme').html(
           `File <b>${filename}</b> has been uploaded and set as the README for this dataset.`,
         );


### PR DESCRIPTION
Detects when we get an error from the Load Balancer uploading a file. 

Closes #2012 