### PR TITLE
Make the Redis health check random number seed larger so we do not collide

### DIFF
--- a/app/services/pul_redis.rb
+++ b/app/services/pul_redis.rb
@@ -9,7 +9,7 @@ class PULRedis < HealthMonitor::Providers::Redis
 
     # Add a random number to the key so we do not collide with another machine
     def key
-      random = rand(99)
+      random = rand(999)
       @key ||= ["health", request.try(:remote_ip), random].join(":")
     end
 end


### PR DESCRIPTION

We are seeing so many less now.  How about a slightly larger random key https://app.honeybadger.io/projects/99214/faults/115631944 