### PR TITLE
Logs if a dataset updates will overwrite previous updates

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -110,4 +110,25 @@ class ApplicationController < ActionController::Base
 
       redirect_to root_path
     end
+
+    # Logs if the work is being updated with stale data.
+    #
+    # This can happen if user A opens two browser windows, edits the data on both of them,
+    # and saves from both of them. This could also happen if a user A edits the data,
+    # another user (say user B) also edits the data and saves it before user A saves their
+    # own changes.
+    def check_for_stale_update(work, params)
+      stale = false
+      last_updated_at = params["last_updated_at"] || "" # when was this record last saved (when the edit form was loaded)
+      loaded_at = params["loaded_at"] || "" # when was the edit form loaded
+      edit_time = (Time.now.in_time_zone - loaded_at.to_time).to_i
+      if work.updated_at.to_s != last_updated_at
+        log_message = "Update to work #{work.id} by #{current_user.uid} via will overwrite changes"
+        log_message << " (current: #{work.updated_at}, with: #{last_updated_at}, edit time: #{edit_time} seconds)"
+        Rails.logger.warn log_message
+        Honeybadger.notify log_message
+        stale = true
+      end
+      stale
+    end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -120,7 +120,7 @@ class ApplicationController < ActionController::Base
     def check_for_stale_update(work, params)
       stale = false
       last_updated_at = params["last_updated_at"] || "" # when was this record last saved (when the edit form was loaded)
-      loaded_at = params["loaded_at"] || "" # when was the edit form loaded
+      loaded_at = params["loaded_at"] || "00:00" # when was the edit form loaded
       edit_time = (Time.now.in_time_zone - loaded_at.to_time).to_i
       if work.updated_at.to_s != last_updated_at
         log_message = "Update to work #{work.id} by #{current_user.uid} via will overwrite changes"

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -381,6 +381,8 @@ class WorksController < ApplicationController
     end
 
     def update_work
+      byebug
+      validate_work_update(@work, params["last_updated_at"])
       upload_service = WorkUploadsEditService.new(@work, current_user)
       if @work.approved?
         upload_keys = deleted_files_param || []
@@ -392,6 +394,12 @@ class WorksController < ApplicationController
       end
 
       process_updates
+    end
+
+    def validate_work_update(work, last_updated_at)
+      if work.updated_at.to_s != last_updated_at
+        Rails.logger.warn "Update to work #{@work.id} by #{current_user.uid} will overwrite changes (last update: #{@work.updated_at.to_s}, with update: #{last_updated_at})"
+      end
     end
 
     def added_files_param

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -381,7 +381,7 @@ class WorksController < ApplicationController
     end
 
     def update_work
-      validate_work_update(@work, params)
+      check_for_stale_update(@work, params)
       upload_service = WorkUploadsEditService.new(@work, current_user)
       if @work.approved?
         upload_keys = deleted_files_param || []
@@ -393,20 +393,6 @@ class WorksController < ApplicationController
       end
 
       process_updates
-    end
-
-    # Logs if the work is being updated with stale data.
-    #
-    # This can happen if a user A opens two browser windows, edits the data on both of them,
-    # and saves from both of them. This could also happen if a user A edits the data,
-    # another user B also edits the data and saves it before user A saves their own changes.
-    def validate_work_update(work, params)
-      last_updated_at = params["last_updated_at"] || "" # when was this record last saved (when the edit form was loaded)
-      loaded_at = params["loaded_at"] || "" # when was the edit form loaded
-      edit_time = (Time.now.in_time_zone - loaded_at.to_time).to_i
-      if work.updated_at.to_s != last_updated_at
-        Rails.logger.warn "Update to work #{@work.id} by #{current_user.uid} will overwrite changes (current: #{@work.updated_at}, with: #{last_updated_at}, edit time: #{edit_time} seconds)"
-      end
     end
 
     def added_files_param

--- a/app/controllers/works_wizard_controller.rb
+++ b/app/controllers/works_wizard_controller.rb
@@ -175,6 +175,7 @@ class WorksWizardController < ApplicationController
                                            uneditable_message: "Can not update work: #{@work.id} is not editable by #{current_user.uid}",
                                            current_state_message: "Can not update work: #{@work.id} is not editable in current state by #{current_user.uid}")
         prepare_decorators_for_work_form(@work)
+        check_for_stale_update(@work, params)
         if WorkCompareService.update_work(work: @work, update_params:, current_user:)
           if params[:save_only] == "true"
             render view_name

--- a/app/views/works/_form_hidden_fields.html.erb
+++ b/app/views/works/_form_hidden_fields.html.erb
@@ -16,4 +16,6 @@
   <input type="text" id="user_orcid" name="user_orcid" value="<%= current_user.orcid %>" class="hidden" />
   <input type="text" id="user_given_name" name="user_given_name" value="<%= current_user.given_name %>" class="hidden" />
   <input type="text" id="user_family_name" name="user_family_name" value="<%= current_user.family_name %>" class="hidden" />
+
+  <input type="text" id="last_updated_at" name="last_updated_at" value="<%= @work.updated_at %>" class="will-be-hidden" />
 </div>

--- a/app/views/works/_form_hidden_fields.html.erb
+++ b/app/views/works/_form_hidden_fields.html.erb
@@ -17,6 +17,6 @@
   <input type="text" id="user_given_name" name="user_given_name" value="<%= current_user.given_name %>" class="hidden" />
   <input type="text" id="user_family_name" name="user_family_name" value="<%= current_user.family_name %>" class="hidden" />
 
-  <input type="text" id="last_updated_at" name="last_updated_at" value="<%= @work.updated_at %>" class="will-be-hidden" />
-  <input type="text" id="loaded_at" name="loaded_at" value="<%= Time.now.to_s %>" class="will-be-hidden" />
+  <input type="text" id="last_updated_at" name="last_updated_at" value="<%= @work.updated_at %>" class="hidden" />
+  <input type="text" id="loaded_at" name="loaded_at" value="<%= Time.now.to_s %>" class="hidden" />
 </div>

--- a/app/views/works/_form_hidden_fields.html.erb
+++ b/app/views/works/_form_hidden_fields.html.erb
@@ -18,4 +18,5 @@
   <input type="text" id="user_family_name" name="user_family_name" value="<%= current_user.family_name %>" class="hidden" />
 
   <input type="text" id="last_updated_at" name="last_updated_at" value="<%= @work.updated_at %>" class="will-be-hidden" />
+  <input type="text" id="loaded_at" name="loaded_at" value="<%= Time.now.to_s %>" class="will-be-hidden" />
 </div>

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -1027,7 +1027,7 @@ RSpec.describe WorksController do
         context "when sending a nil group" do
           before do
             params[:group_id] = nil
-            params[:last_updated_at] = work.updated_at.to_s # Make sure we don't trigger the Honeybadger to stale data
+            params[:last_updated_at] = work.updated_at.to_s # Make sure we don't trigger the Honeybadger for stale data
             allow(Honeybadger).to receive(:notify)
           end
           it "uses the updators default group" do

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -1027,6 +1027,7 @@ RSpec.describe WorksController do
         context "when sending a nil group" do
           before do
             params[:group_id] = nil
+            params[:last_updated_at] = work.updated_at.to_s # Make sure we don't trigger the Honeybadger to stale data
             allow(Honeybadger).to receive(:notify)
           end
           it "uses the updators default group" do

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -953,7 +953,7 @@ RSpec.describe WorksController do
 
         context "when updating a record" do
           let(:form_params_stale) do
-            # Pretent the data submitted on the web form is older
+            # Pretend the data submitted on the web form is older
             # than the current data on the database
             params.merge(last_updated_at: (work.updated_at - 1.hour).to_s).with_indifferent_access
           end

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -953,8 +953,8 @@ RSpec.describe WorksController do
 
         context "when updating a record" do
           let(:form_params_stale) do
-            # Pretent the data submitted on the web form was updated
-            # an hour before the current data on the database
+            # Pretent the data submitted on the web form is older
+            # than the current data on the database
             params.merge(last_updated_at: (work.updated_at - 1.hour).to_s).with_indifferent_access
           end
 

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -951,6 +951,28 @@ RSpec.describe WorksController do
           end
         end
 
+        context "when updating a record" do
+          let(:form_params_stale) do
+            # Pretent the data submitted on the web form was updated
+            # an hour before the current data on the database
+            params.merge(last_updated_at: (work.updated_at - 1.hour).to_s).with_indifferent_access
+          end
+
+          let(:form_params_good) do
+            # The normal case is that the data on the web form matches the data
+            # on the database (i.e. we are updating with the latest data)
+            params.merge(last_updated_at: work.updated_at.to_s).with_indifferent_access
+          end
+
+          it "detects if the data submitted has stale data" do
+            stale = controller.send(:check_for_stale_update, work, form_params_stale)
+            expect(stale).to be true
+
+            stale = controller.send(:check_for_stale_update, work, form_params_good)
+            expect(stale).to be false
+          end
+        end
+
         context "a submitter trying to update the curator conrolled fields" do
           before do
             new_params = params.merge(doi: "10.34770/new-doi")


### PR DESCRIPTION
This does not fix the bug where funder information was removed during an update but *it will* help us determine if when saving a dataset the data will overwrite data written before. 

If we determine that the problem is users stepping on each other (or even the same user with two browser windows open over writting their own changes) we can decide how to handle this (e.g. warn a user that they will overwrite some changes)

Part of #1925 

This is an example of a Honeybadger entry for this kind of situation: https://app.honeybadger.io/projects/99214/faults/118747777