### PR TITLE
Move files to embargo bucket for approved embargoed works

### DIFF
--- a/app/controllers/work_downloader_controller.rb
+++ b/app/controllers/work_downloader_controller.rb
@@ -4,7 +4,7 @@ class WorkDownloaderController < ApplicationController
     work = Work.find(params[:id])
     if current_user && work.editable_by?(current_user)
       file_name = params[:filename]
-      service = S3QueryService.new(work, work.files_bucket_name_aws)
+      service = S3QueryService.new(work, work.files_bucket_name)
       uri = service.file_url(file_name)
       redirect_to uri
     else

--- a/app/controllers/work_downloader_controller.rb
+++ b/app/controllers/work_downloader_controller.rb
@@ -4,8 +4,7 @@ class WorkDownloaderController < ApplicationController
     work = Work.find(params[:id])
     if current_user && work.editable_by?(current_user)
       file_name = params[:filename]
-      mode = work.approved? ? "postcuration" : "precuration"
-      service = S3QueryService.new(work, mode)
+      service = S3QueryService.new(work, work.files_bucket_name_aws)
       uri = service.file_url(file_name)
       redirect_to uri
     else

--- a/app/controllers/work_downloader_controller.rb
+++ b/app/controllers/work_downloader_controller.rb
@@ -4,7 +4,7 @@ class WorkDownloaderController < ApplicationController
     work = Work.find(params[:id])
     if current_user && work.editable_by?(current_user)
       file_name = params[:filename]
-      service = S3QueryService.new(work, work.files_bucket_name)
+      service = S3QueryService.new(work, work.files_mode)
       uri = service.file_url(file_name)
       redirect_to uri
     else

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -138,7 +138,7 @@ class WorksController < ApplicationController
   def approve
     @work = Work.find(params[:id])
     @work.approve!(current_user)
-    flash[:notice] = "Your files are being moved to the #{@work.files_bucket_name} bucket in the background. Depending on the file sizes this may take some time."
+    flash[:notice] = "Your files are being moved to the #{@work.files_bucket_name_human} bucket in the background. Depending on the file sizes this may take some time."
     redirect_to work_path(@work)
   end
 

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -138,12 +138,7 @@ class WorksController < ApplicationController
   def approve
     @work = Work.find(params[:id])
     @work.approve!(current_user)
-    target_bucket = if @work.embargoed?
-                      PULS3Client::EMBARGO
-                    else
-                      PULS3Client::POSTCURATION
-                    end
-    flash[:notice] = "Your files are being moved to the #{target_bucket} bucket in the background. Depending on the file sizes this may take some time."
+    flash[:notice] = "Your files are being moved to the #{@work.files_bucket_name} bucket in the background. Depending on the file sizes this may take some time."
     redirect_to work_path(@work)
   end
 

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -138,7 +138,12 @@ class WorksController < ApplicationController
   def approve
     @work = Work.find(params[:id])
     @work.approve!(current_user)
-    flash[:notice] = "Your files are being moved to the post-curation bucket in the background. Depending on the file sizes this may take some time."
+    target_bucket = if @work.embargoed?
+                      PULS3Client::EMBARGO
+                    else
+                      PULS3Client::POSTCURATION
+                    end
+    flash[:notice] = "Your files are being moved to the #{target_bucket} bucket in the background. Depending on the file sizes this may take some time."
     redirect_to work_path(@work)
   end
 

--- a/app/jobs/approved_file_move_job.rb
+++ b/app/jobs/approved_file_move_job.rb
@@ -37,7 +37,7 @@ class ApprovedFileMoveJob < ApplicationJob
   end
 
   def service
-    @service ||= S3QueryService.new(work, "postcuration")
+    @service ||= S3QueryService.new(work, work.files_bucket_name)
   end
 
   def snapshot

--- a/app/jobs/approved_file_move_job.rb
+++ b/app/jobs/approved_file_move_job.rb
@@ -37,7 +37,7 @@ class ApprovedFileMoveJob < ApplicationJob
   end
 
   def service
-    @service ||= S3QueryService.new(work, work.files_bucket_name)
+    @service ||= S3QueryService.new(work, work.files_mode)
   end
 
   def snapshot

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -564,6 +564,18 @@ class Work < ApplicationRecord
     end
   end
 
+  def files_bucket_name_aws
+    if approved?
+      if embargoed?
+        PULS3Client::EMBARGO
+      else
+        PULS3Client::POSTCURATION
+      end
+    else
+      PULS3Client::PRECURATION
+    end
+  end
+
   protected
 
     def work_validator

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -397,8 +397,7 @@ class Work < ApplicationRecord
   def post_curation_uploads(force_post_curation: false)
     if force_post_curation
       # Always use the post-curation data regardless of the work's status
-      # TODO: we probably also need to account for embargoes here...but not sure.
-      post_curation_s3_query_service = S3QueryService.new(self, "postcuration")
+      post_curation_s3_query_service = S3QueryService.new(self, PULS3Client::POSTCURATION)
       post_curation_s3_query_service.data_profile.fetch(:objects, [])
     else
       # Return the list based of files honoring the work status

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -397,6 +397,7 @@ class Work < ApplicationRecord
   def post_curation_uploads(force_post_curation: false)
     if force_post_curation
       # Always use the post-curation data regardless of the work's status
+      # TODO: we probably also need to account for embargoes here...but not sure.
       post_curation_s3_query_service = S3QueryService.new(self, "postcuration")
       post_curation_s3_query_service.data_profile.fetch(:objects, [])
     else
@@ -548,7 +549,7 @@ class Work < ApplicationRecord
   # Returns a human friendly name for the bucket where the files for the work are located.
   # Notice that we don't use the values from PULS3Client because those are not human friendly
   # (e.g. the lack dashes between words)
-  def files_bucket_name
+  def files_bucket_name_human
     if approved?
       if embargoed?
         "embargo"
@@ -560,7 +561,7 @@ class Work < ApplicationRecord
     end
   end
 
-  def files_bucket_name_aws
+  def files_bucket_name
     if approved?
       if embargoed?
         PULS3Client::EMBARGO

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -470,7 +470,7 @@ class Work < ApplicationRecord
   # S3QueryService object associated with this Work
   # @return [S3QueryService]
   def s3_query_service
-    @s3_query_service ||= S3QueryService.new(self, files_bucket_name)
+    @s3_query_service ||= S3QueryService.new(self, files_mode)
   end
 
   def past_snapshots

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -470,16 +470,7 @@ class Work < ApplicationRecord
   # S3QueryService object associated with this Work
   # @return [S3QueryService]
   def s3_query_service
-    mode = if approved?
-             if embargoed?
-               PULS3Client::EMBARGO
-             else
-               PULS3Client::POSTCURATION
-             end
-           else
-             PULS3Client::PRECURATION
-           end
-    @s3_query_service ||= S3QueryService.new(self, mode)
+    @s3_query_service ||= S3QueryService.new(self, files_bucket_name)
   end
 
   def past_snapshots
@@ -560,6 +551,7 @@ class Work < ApplicationRecord
     end
   end
 
+  # Returns the bucket name where the files are stored for this work.
   def files_bucket_name
     if approved?
       if embargoed?

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -552,7 +552,7 @@ class Work < ApplicationRecord
   end
 
   # Returns the bucket name where the files are stored for this work.
-  def files_bucket_name
+  def files_mode
     if approved?
       if embargoed?
         PULS3Client::EMBARGO

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -549,8 +549,8 @@ class Work < ApplicationRecord
     embargo_date >= current_date
   end
 
-  # Returns the location of the files for this work
-  def files_location
+  # Returns the bucket name for the files in the work
+  def files_bucket
     if approved?
       if embargoed?
         "embargo"
@@ -623,6 +623,7 @@ class Work < ApplicationRecord
                  PULS3Client::POSTCURATION
                end
 
+      target = "postcuration"
       s3_target_query_service = S3QueryService.new(self, target)
 
       s3_dir = find_bucket_s3_dir(bucket_name: s3_target_query_service.bucket_name)

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -475,14 +475,14 @@ class Work < ApplicationRecord
   # @return [S3QueryService]
   def s3_query_service
     mode = if approved?
-      if embargoed?
-        PULS3Client::EMBARGO
-      else
-        PULS3Client::POSTCURATION
-      end
-    else
-      PULS3Client::PRECURATION
-    end
+             if embargoed?
+               PULS3Client::EMBARGO
+             else
+               PULS3Client::POSTCURATION
+             end
+           else
+             PULS3Client::PRECURATION
+           end
     @s3_query_service ||= S3QueryService.new(self, mode)
   end
 
@@ -605,10 +605,10 @@ class Work < ApplicationRecord
     def publish_precurated_files(user)
       # We need to explicitly check for the target bucket here (postcuration or embargo).
       target = if embargoed?
-        PULS3Client::EMBARGO
-      else
-        PULS3Client::POSTCURATION
-      end
+                 PULS3Client::EMBARGO
+               else
+                 PULS3Client::POSTCURATION
+               end
 
       s3_target_query_service = S3QueryService.new(self, target)
 

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -549,7 +549,9 @@ class Work < ApplicationRecord
     embargo_date >= current_date
   end
 
-  # Returns the bucket name for the files in the work
+  # Returns a human friendly name for the bucket where the files for the work are located.
+  # Notice that we don't use the values from PULS3Client because those are not human friendly
+  # (e.g. the lack dashes between words)
   def files_bucket_name
     if approved?
       if embargoed?

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -550,7 +550,7 @@ class Work < ApplicationRecord
   end
 
   # Returns the bucket name for the files in the work
-  def files_bucket
+  def files_bucket_name
     if approved?
       if embargoed?
         "embargo"
@@ -623,7 +623,6 @@ class Work < ApplicationRecord
                  PULS3Client::POSTCURATION
                end
 
-      target = "postcuration"
       s3_target_query_service = S3QueryService.new(self, target)
 
       s3_dir = find_bucket_s3_dir(bucket_name: s3_target_query_service.bucket_name)

--- a/app/services/s3_query_service.rb
+++ b/app/services/s3_query_service.rb
@@ -142,12 +142,16 @@ class S3QueryService
   end
 
   ##
-  # Copies the existing files from the pre-curation bucket to the post-curation bucket.
+  # Copies the existing files from the pre-curation bucket to the target bucket (postcuration or embargo).
   # Notice that the copy process happens at AWS (i.e. the files are not downloaded and re-uploaded).
-  # Returns an array with the files that were copied.
   def publish_files(current_user)
     source_bucket = PULS3Client.pre_curation_config[:bucket]
-    target_bucket = PULS3Client.post_curation_config[:bucket]
+    target_bucket = if model.embargoed?
+                      PULS3Client.embargo_config[:bucket]
+                    else
+                      PULS3Client.post_curation_config[:bucket]
+                    end
+
     empty_files = client_s3_empty_files(reload: true, bucket_name: source_bucket)
     # Do not move the empty files, however, ensure that it is noted that the
     #   presence of empty files is specified in the provenance log.

--- a/app/services/s3_query_service.rb
+++ b/app/services/s3_query_service.rb
@@ -16,7 +16,7 @@ class S3QueryService
   # @param [String] mode Valid values are PULS3Client::PRECURATION, PULS3Client::POSTCURATION
   #                          PULS3Client::PRESERVATION, and PULS3Client::EMBARGO.
   #                      This value controls the AWS S3 bucket used to access the files.
-  # @example S3QueryService.new(Work.find(1), "precuration")
+  # @example S3QueryService.new(Work.find(1), PULS3Client::PRECURATION)
   def initialize(model, mode = PULS3Client::PRECURATION, bucket_name: nil)
     @model = model
     @doi = model.doi

--- a/app/services/work_preservation_service.rb
+++ b/app/services/work_preservation_service.rb
@@ -74,8 +74,7 @@ class WorkPreservationService
     end
 
     def s3_query_service
-      # TODO: account for embargoes
-      @s3_query_service ||= S3QueryService.new(@work, "preservation")
+      @s3_query_service ||= S3QueryService.new(@work, PULS3Client::PRESERVATION)
     end
 
     def bucket_name

--- a/app/services/work_preservation_service.rb
+++ b/app/services/work_preservation_service.rb
@@ -74,6 +74,7 @@ class WorkPreservationService
     end
 
     def s3_query_service
+      # TODO: account for embargoes
       @s3_query_service ||= S3QueryService.new(@work, "preservation")
     end
 

--- a/app/views/works/_s3_resources.html.erb
+++ b/app/views/works/_s3_resources.html.erb
@@ -4,7 +4,7 @@
       <div class="files card-body">
         <h3>
           <div id="total-file-count-spinner" class="spinner-border spinner-border-sm" role="status"></div>
-          <span id="total-file-count-in-table"></span> Files or Directories in <%= @work.files_location %> storage
+          <span id="total-file-count-in-table"></span> Files or Directories in <%= @work.files_bucket %> storage
         </h3>
         <table id="files-table" class="table">
           <thead>

--- a/app/views/works/_s3_resources.html.erb
+++ b/app/views/works/_s3_resources.html.erb
@@ -4,7 +4,7 @@
       <div class="files card-body">
         <h3>
           <div id="total-file-count-spinner" class="spinner-border spinner-border-sm" role="status"></div>
-          <span id="total-file-count-in-table"></span> Files or Directories in <%= @work.files_bucket_name %> storage
+          <span id="total-file-count-in-table"></span> Files or Directories in <%= @work.files_bucket_name_human %> storage
         </h3>
         <table id="files-table" class="table">
           <thead>

--- a/app/views/works/_s3_resources.html.erb
+++ b/app/views/works/_s3_resources.html.erb
@@ -4,7 +4,7 @@
       <div class="files card-body">
         <h3>
           <div id="total-file-count-spinner" class="spinner-border spinner-border-sm" role="status"></div>
-          <span id="total-file-count-in-table"></span> Files or Directories in <%= @work.approved? ? "post-curation" : "pre-curation" %> storage
+          <span id="total-file-count-in-table"></span> Files or Directories in <%= @work.files_location %> storage
         </h3>
         <table id="files-table" class="table">
           <thead>

--- a/app/views/works/_s3_resources.html.erb
+++ b/app/views/works/_s3_resources.html.erb
@@ -4,7 +4,7 @@
       <div class="files card-body">
         <h3>
           <div id="total-file-count-spinner" class="spinner-border spinner-border-sm" role="status"></div>
-          <span id="total-file-count-in-table"></span> Files or Directories in <%= @work.files_bucket %> storage
+          <span id="total-file-count-in-table"></span> Files or Directories in <%= @work.files_bucket_name %> storage
         </h3>
         <table id="files-table" class="table">
           <thead>

--- a/docs/how_to_delete_a_work.md
+++ b/docs/how_to_delete_a_work.md
@@ -2,12 +2,12 @@ Deleting a work and its content on Amazon is not as easy as running `work.destro
 These steps assume the work is assigned to a variable called `work`.
 1. Delete the pre curation uploads
    * ```
-     service = S3QueryService.new(work, "postcuration")
+     service = S3QueryService.new(work, PULS3Client::POSTCURATION)
      work.pre_curation_uploads.each{|upload| service.client.delete_object({ bucket: service.bucket_name, key: upload.key})}
      ```
 1. Delete the post curation uploads
    * ```
-     service = S3QueryService.new(work, "postcuration")
+     service = S3QueryService.new(work, PULS3Client::POSTCURATION)
      work.post_curation_uploads.each{|upload| service.client.delete_object({ bucket: service.bucket_name, key: upload.key})}
      ```
 1. Finally destroy the work
@@ -15,7 +15,7 @@ These steps assume the work is assigned to a variable called `work`.
 
 Full script below...
 ```ruby
-service = S3QueryService.new(work, "postcuration")
+service = S3QueryService.new(work, PULS3Client::POSTCURATION)
 work.pre_curation_uploads.each{|upload| service.client.delete_object({ bucket: service, bucket_name, key: upload.key})}
 work.post_curation_uploads.each{|upload| service.client.delete_object({ bucket: service.bucket_name, key: upload.key})}
 work.destroy

--- a/lib/tasks/works.rake
+++ b/lib/tasks/works.rake
@@ -35,7 +35,7 @@ namespace :works do
     end
     works = Work.where(created_by_user_id: user.id)
     works.each do |work|
-      service = S3QueryService.new(work, "postcuration")
+      service = S3QueryService.new(work, work.files_bucket_name)
       work.post_curation_uploads.each { |upload| service.client.delete_object({ bucket: service.bucket_name, key: upload.key }) }
       work.destroy
     end
@@ -51,7 +51,7 @@ namespace :works do
     work_exclusion_ids = works_str.split("+").map(&:to_i)
     works = Work.where.not(id: work_exclusion_ids)
     works.each do |work|
-      service = S3QueryService.new(work, "postcuration")
+      service = S3QueryService.new(work, work.files_bucket_name)
       work.pre_curation_uploads.each { |upload| service.client.delete_object({ bucket: service.bucket_name, key: upload.key }) }
       work.post_curation_uploads.each { |upload| service.client.delete_object({ bucket: service.bucket_name, key: upload.key }) }
       work.destroy
@@ -209,7 +209,7 @@ namespace :works do
 
     work = Work.find(work_id)
     bucket = work.bucket_name
-    service = S3QueryService.new(work, "precuration")
+    service = S3QueryService.new(work, work.files_bucket_name)
     uri = service.file_url("#{service.prefix}renamed_files.txt")
     filename = "/tmp/#{work.id}renamed_files.txt"
     stdout_and_stderr_str, status = Open3.capture2e("wget -c '#{uri}' -O '#{filename}'")

--- a/lib/tasks/works.rake
+++ b/lib/tasks/works.rake
@@ -209,7 +209,7 @@ namespace :works do
 
     work = Work.find(work_id)
     bucket = work.bucket_name
-    service = S3QueryService.new(work, work.files_bucket_name)
+    service = S3QueryService.new(work, work.files_mode)
     uri = service.file_url("#{service.prefix}renamed_files.txt")
     filename = "/tmp/#{work.id}renamed_files.txt"
     stdout_and_stderr_str, status = Open3.capture2e("wget -c '#{uri}' -O '#{filename}'")

--- a/lib/tasks/works.rake
+++ b/lib/tasks/works.rake
@@ -35,7 +35,7 @@ namespace :works do
     end
     works = Work.where(created_by_user_id: user.id)
     works.each do |work|
-      service = S3QueryService.new(work, work.files_bucket_name)
+      service = S3QueryService.new(work, work.files_mode)
       work.post_curation_uploads.each { |upload| service.client.delete_object({ bucket: service.bucket_name, key: upload.key }) }
       work.destroy
     end

--- a/lib/tasks/works.rake
+++ b/lib/tasks/works.rake
@@ -51,7 +51,7 @@ namespace :works do
     work_exclusion_ids = works_str.split("+").map(&:to_i)
     works = Work.where.not(id: work_exclusion_ids)
     works.each do |work|
-      service = S3QueryService.new(work, work.files_bucket_name)
+      service = S3QueryService.new(work, work.files_mode)
       work.pre_curation_uploads.each { |upload| service.client.delete_object({ bucket: service.bucket_name, key: upload.key }) }
       work.post_curation_uploads.each { |upload| service.client.delete_object({ bucket: service.bucket_name, key: upload.key }) }
       work.destroy

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -690,7 +690,7 @@ RSpec.describe WorksController do
         expect(response.status).to be 302
         expect(response.location).to eq "http://test.host/works/#{work.id}"
         expect(work.reload).to be_approved
-        expect(controller.flash[:notice]).to eq("Your files are being moved to the post-curation bucket in the background. Depending on the file sizes this may take some time.")
+        expect(controller.flash[:notice]).to eq("Your files are being moved to the postcuration bucket in the background. Depending on the file sizes this may take some time.")
       end
 
       context "invalid response from doi publish" do

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -690,7 +690,7 @@ RSpec.describe WorksController do
         expect(response.status).to be 302
         expect(response.location).to eq "http://test.host/works/#{work.id}"
         expect(work.reload).to be_approved
-        expect(controller.flash[:notice]).to eq("Your files are being moved to the postcuration bucket in the background. Depending on the file sizes this may take some time.")
+        expect(controller.flash[:notice]).to eq("Your files are being moved to the post-curation bucket in the background. Depending on the file sizes this may take some time.")
       end
 
       context "invalid response from doi publish" do

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -173,16 +173,20 @@ RSpec.describe Work, type: :model do
 
     let(:fake_s3_service_pre) { stub_s3 }
     let(:fake_s3_service_post) { stub_s3(data: [file1, file2]) }
+    let(:fake_s3_service_embargo) { stub_s3(data: [file1, file2]) }
 
     before do
       # initialize so the next allows happen after the stubs
       fake_s3_service_post
       fake_s3_service_pre
+      fake_s3_service_embargo
 
       allow(S3QueryService).to receive(:new).with(instance_of(Work), "precuration").and_return(fake_s3_service_pre)
       allow(S3QueryService).to receive(:new).with(instance_of(Work), "postcuration").and_return(fake_s3_service_post)
+      allow(S3QueryService).to receive(:new).with(instance_of(Work), "embargo").and_return(fake_s3_service_embargo)
       allow(fake_s3_service_pre.client).to receive(:head_object).with({ bucket: "example-post-bucket", key: work.s3_object_key }).and_raise(Aws::S3::Errors::NotFound.new("blah", "error"))
       allow(fake_s3_service_post).to receive(:bucket_name).and_return("example-post-bucket")
+      allow(fake_s3_service_embargo).to receive(:bucket_name).and_return("example-bucket-embargo")
       allow(fake_s3_service_pre).to receive(:bucket_name).and_return("example-pre-bucket")
       allow(fake_s3_service_pre).to receive(:client_s3_files).and_return([readme], [readme, file1, file2])
     end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -185,6 +185,7 @@ RSpec.describe Work, type: :model do
       allow(S3QueryService).to receive(:new).with(instance_of(Work), "postcuration").and_return(fake_s3_service_post)
       allow(S3QueryService).to receive(:new).with(instance_of(Work), "embargo").and_return(fake_s3_service_embargo)
       allow(fake_s3_service_pre.client).to receive(:head_object).with({ bucket: "example-post-bucket", key: work.s3_object_key }).and_raise(Aws::S3::Errors::NotFound.new("blah", "error"))
+      allow(fake_s3_service_pre.client).to receive(:head_object).with({ bucket: "example-bucket-embargo", key: work.s3_object_key }).and_raise(Aws::S3::Errors::NotFound.new("blah", "error"))
       allow(fake_s3_service_post).to receive(:bucket_name).and_return("example-post-bucket")
       allow(fake_s3_service_embargo).to receive(:bucket_name).and_return("example-bucket-embargo")
       allow(fake_s3_service_pre).to receive(:bucket_name).and_return("example-pre-bucket")


### PR DESCRIPTION
Moves files to the the embargo bucket (instead of post-curation) for embargoed works.

Closes #2055 

Co-authored-by: Robert-Anthony Lee-Faison <leefaisonr@users.noreply.github.com>