### PR TITLE
Rake task to output file snapshots for a work

### DIFF
--- a/lib/tasks/works.rake
+++ b/lib/tasks/works.rake
@@ -232,4 +232,25 @@ namespace :works do
       puts "Error dowloading file #{uri} for work id #{work.id} to #{filename}! Error: #{stdout_and_stderr_str}"
     end
   end
+
+  desc "Outputs the upload snapshot data for a work"
+  task :snapshots, [:work_id] => :environment do |_, args|
+    work_id = args[:work_id].to_i
+
+    puts "snapshot_id, snapshot_date, snapshot_files, user, checkshum, filename, upload_status"
+    snapshots = UploadSnapshot.where(work_id:).order(:created_at)
+    snapshots.each do |snapshot|
+      snapshot.files.each do |file|
+        tokens = []
+        tokens << snapshot.id
+        tokens << snapshot.created_at
+        tokens << snapshot.files.count
+        tokens << (file["user_id"] || "nil")
+        tokens << (file["checksum"] || "nil")
+        tokens << (file["filename"] || "nil")
+        tokens << (file["upload_status"] || "nil")
+        puts tokens.join(",")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds a rake task to output the data in our UploadSnapshots to get a view of what happened to the files uploaded to a work. This will help us see what was added and deleted and when.

Part of #2121