### PR TITLE
Showing the datacommons url in emails

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -9,9 +9,8 @@ class NotificationMailer < ApplicationMailer
     @subject = "[pdc-describe] New Notification"
     @message = @work_activity.message
     @message_html = @work_activity.to_html
-    @url = work_url(@work_activity.work)
+    @url = data_commons_url(@work_activity.work)
 
-    @url = check_url(@url)
     mail(to: @user.email, subject: @subject)
   end
 
@@ -22,9 +21,8 @@ class NotificationMailer < ApplicationMailer
     @subject = "[pdc-describe] New Submission Created"
     @message = @work_activity.message
     @message_html = @work_activity.to_html
-    @url = work_url(@work_activity.work)
+    @url = data_commons_url(@work_activity.work)
 
-    @url = check_url(@url)
     mail(to: @user.email, subject: @subject)
   end
 
@@ -35,9 +33,8 @@ class NotificationMailer < ApplicationMailer
     @subject = "[pdc-describe] Submission Ready for Review"
     @message = @work_activity.message
     @message_html = @work_activity.to_html
-    @url = work_url(@work_activity.work)
+    @url = data_commons_url(@work_activity.work)
 
-    @url = check_url(@url)
     mail(to: @user.email, subject: @subject)
   end
 
@@ -48,10 +45,20 @@ class NotificationMailer < ApplicationMailer
     @subject = "[pdc-describe] Submission Returned"
     @message = @work_activity.message
     @message_html = @work_activity.to_html
-    @url = work_url(@work_activity.work)
+    @url = data_commons_url(@work_activity.work)
 
-    @url = check_url(@url)
     mail(to: @user.email, subject: @subject)
+  end
+
+  def data_commons_url(work)
+    url = if Rails.env.production?
+            path = work_path(work)
+
+            "https://datacommons.princeton.edu#{path}"
+          else
+            work_url(work)
+          end
+    check_url(url)
   end
 
   def check_url(url)

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -52,6 +52,20 @@ describe NotificationMailer, type: :mailer do
         expect(text_part.encoded).to include("To view the notification, please browse to http://www.example.com/works/#{work.id}.")
       end
     end
+
+    context "when we are in production" do
+      before do
+        allow(Rails.env).to receive(:production?).and_return(true)
+      end
+
+      it "shows the data commons url" do
+        message = message_delivery.message
+        text_part = message.text_part
+        html_part = message.html_part
+        expect(html_part.encoded).to include("To view the notification, please browse <a href='https://datacommons.princeton.edu/works/#{work.id}'>here<a>.")
+        expect(text_part.encoded).to include("To view the notification, please browse to https://datacommons.princeton.edu/works/#{work.id}.")
+      end
+    end
   end
 
   describe "#new_submission_message" do


### PR DESCRIPTION
fixes #2212