### PR TITLE
Proposing PDCMetadata::ResourceMetadata Struct implementation to provide a reference for JSON resource metadata validation

### DIFF
--- a/app/decorators/form_resource_decorator.rb
+++ b/app/decorators/form_resource_decorator.rb
@@ -7,9 +7,16 @@ class FormResourceDecorator
   PPPL_FUNDER_ROR = "https://ror.org/01bj3aw27"
   PPPL_FUNDER_AWARD_NUMBER = "DE-AC02-09CH11466"
 
+  # This decorator provides methods for accessing the resource's funders,
+  #   contributors, and related objects, as well as a method for
+  #   determining if the work's DOI is mutable.
+  #
+  # @param work [Work] the work being edited
+  # @param current_user [User] the user doing the editing
+  # @return [FormResourceDecorator] a decorator for the work's resource
   def initialize(work, current_user)
-    @resource = work.resource
     @work = work
+    @resource = work.resource
     @current_user = current_user
   end
 

--- a/app/models/pdc_metadata/resource.rb
+++ b/app/models/pdc_metadata/resource.rb
@@ -7,6 +7,34 @@ module PDCMetadata
     obj.key.to_s == value or obj.value.casecmp(value).zero?
   end
 
+  # This defines the attributes when creating a Resource from a JSONB hash.
+  # Implementing validation with Dry::Schema.Params can utilize these.
+  ResourceMetadata = Struct.new(
+    :creators,
+    :titles,
+    :publication_year,
+    :publisher,
+    :resource_type,
+    :resource_type_general,
+    :description,
+    :doi,
+    :ark,
+    :rights_many,
+    :version_number,
+    :collection_tags,
+    :keywords,
+    :related_objects,
+    :funders,
+    :organizational_contributors,
+    :domains,
+    :migrated,
+    :communities,
+    :subcommunities,
+    # These map to Resource methods rather than attributes
+    :contributors,
+    :datacite_serialization
+  )
+
   # rubocop:disable Metrics/ClassLength
   class Resource
     attr_accessor :creators, :titles, :publisher, :publication_year, :resource_type, :resource_type_general,
@@ -84,6 +112,9 @@ module PDCMetadata
       # Creates a PDCMetadata::Resource from a JSONB postgres field
       #  This jsonb_hash can be created by running JSON.parse(pdc_metadata_resource.to_json)
       #   or by loading it from the work.metadata jsonb field
+      #
+      # @param jsonb_hash [Hash] the hash to create the resource from
+      # @return [PDCMetadata::Resource] the created resource
       def new_from_jsonb(jsonb_hash)
         resource = PDCMetadata::Resource.new
         return resource if jsonb_hash.blank?

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -125,7 +125,19 @@ class Work < ApplicationRecord
 
   before_save do |work|
     # Ensure that the metadata JSONB postgres field is persisted properly
-    work.metadata = JSON.parse(work.resource.to_json)
+    work_resource = work.resource
+    # JSON.parse(resource_json) returns a hash with string keys, so PDCMetadata::ResourceMetadata.new(**resource_attr.to_h)
+    # will raise in Ruby 3.4 (keyword splat requires symbol keys). Convert to symbol keys (e.g., symbolize_keys / deep_symbolize_keys)
+    # before **, and consider using work_resource.as_json directly instead of to_json + JSON.parse to avoid the encode/decode roundtrip.
+
+    resource_attr = work_resource.as_json
+    # Dry::Schema could be used here to validate the resource_attr before creating the ResourceMetadata object.
+    resource_metadata = PDCMetadata::ResourceMetadata.new(**resource_attr.to_h.deep_symbolize_keys)
+    # Avoid persisting the memoized @datacite_serialization object
+    work_metadata = resource_metadata.to_h.except(:datacite_serialization)
+    values = work_metadata.deep_stringify_keys
+
+    work.metadata = values
   end
 
   after_save do |work|
@@ -198,12 +210,18 @@ class Work < ApplicationRecord
     nil
   end
 
+  # This method sets the resource for the work and also ensures that the metadata JSONB field is updated accordingly.
+  # @param [PDCMetadata::Resource] resource the resource object to be associated with this work
   def resource=(resource)
     @resource = resource
     # Ensure that the metadata JSONB postgres field is persisted properly
     self.metadata = JSON.parse(resource.to_json)
   end
 
+  # Building PDCMetadata::Resource from the database JSONB metadata field.
+  # @note: This method memoizes the resource object so that it is only built
+  #   once per instance of the Work.
+  # @return [PDCMetadata::Resource] the resource object for this work
   def resource
     @resource ||= PDCMetadata::Resource.new_from_jsonb(metadata)
   end
@@ -580,6 +598,7 @@ class Work < ApplicationRecord
 
     # This must be protected, NOT private for ActiveRecord to work properly with this attribute.
     #   Protected will still keep others from setting the metatdata, but allows ActiveRecord the access it needs
+    # @param metadata [Hash] the metadata hash to be set on the work, which will also be used to build the resource object
     def metadata=(metadata)
       super
       @resource = PDCMetadata::Resource.new_from_jsonb(metadata)

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -126,18 +126,9 @@ class Work < ApplicationRecord
   before_save do |work|
     # Ensure that the metadata JSONB postgres field is persisted properly
     work_resource = work.resource
-    # JSON.parse(resource_json) returns a hash with string keys, so PDCMetadata::ResourceMetadata.new(**resource_attr.to_h)
-    # will raise in Ruby 3.4 (keyword splat requires symbol keys). Convert to symbol keys (e.g., symbolize_keys / deep_symbolize_keys)
-    # before **, and consider using work_resource.as_json directly instead of to_json + JSON.parse to avoid the encode/decode roundtrip.
-
     resource_attr = work_resource.as_json
-    # Dry::Schema could be used here to validate the resource_attr before creating the ResourceMetadata object.
-    resource_metadata = PDCMetadata::ResourceMetadata.new(**resource_attr.to_h.deep_symbolize_keys)
-    # Avoid persisting the memoized @datacite_serialization object
-    work_metadata = resource_metadata.to_h.except(:datacite_serialization)
-    values = work_metadata.deep_stringify_keys
 
-    work.metadata = values
+    work.update_metadata(**resource_attr)
   end
 
   after_save do |work|
@@ -210,12 +201,27 @@ class Work < ApplicationRecord
     nil
   end
 
+  # This method is used to update the metadata JSONB field on the Work, which is used to build the Resource object.
+  # This method is called in the before_save callback to ensure that the metadata is always up to date with the Resource object.
+  # @param metadata [Hash] the metadata hash to be set on the work, which will also be used to build the resource object
+  # @return [void]
+  def update_metadata(metadata)
+    # Dry::Schema could be used here to validate the resource_attr before creating the ResourceMetadata object.
+    resource_metadata = PDCMetadata::ResourceMetadata.new(**metadata)
+    # Avoid persisting the memoized @datacite_serialization object
+    updated_metadata = resource_metadata.to_h.except(:datacite_serialization)
+    values = updated_metadata.deep_stringify_keys
+
+    self.metadata = values
+  end
+
   # This method sets the resource for the work and also ensures that the metadata JSONB field is updated accordingly.
   # @param [PDCMetadata::Resource] resource the resource object to be associated with this work
   def resource=(resource)
     @resource = resource
     # Ensure that the metadata JSONB postgres field is persisted properly
-    self.metadata = JSON.parse(resource.to_json)
+    resource_json = resource.as_json
+    update_metadata(resource_json)
   end
 
   # Building PDCMetadata::Resource from the database JSONB metadata field.
@@ -597,10 +603,16 @@ class Work < ApplicationRecord
     end
 
     # This must be protected, NOT private for ActiveRecord to work properly with this attribute.
-    #   Protected will still keep others from setting the metatdata, but allows ActiveRecord the access it needs
+    #   Protected will still keep others from setting the metadata, but allows ActiveRecord the access it needs
     # @param metadata [Hash] the metadata hash to be set on the work, which will also be used to build the resource object
     def metadata=(metadata)
       super
+      # resource_attr = work_resource.as_json
+      # resource_metadata = PDCMetadata::ResourceMetadata.new(**resource_attr.to_h.deep_symbolize_keys)
+      # work_metadata = resource_metadata.to_h.except(:datacite_serialization)
+      # values = work_metadata.deep_stringify_keys
+      # work.metadata = values
+
       @resource = PDCMetadata::Resource.new_from_jsonb(metadata)
     end
 

--- a/spec/models/pdc_metadata/resource_spec.rb
+++ b/spec/models/pdc_metadata/resource_spec.rb
@@ -100,7 +100,11 @@ RSpec.describe PDCMetadata::Resource, type: :model do
 
   it "creates the expected json" do
     work = FactoryBot.create(:shakespeare_and_company_work)
-    expect(work.metadata).to eq(work.resource.as_json)
+
+    resource_metadata = PDCMetadata::ResourceMetadata.new(**work.resource.as_json)
+    work_metadata = resource_metadata.to_h.except(:datacite_serialization).stringify_keys
+
+    expect(work.metadata).to eq(work_metadata)
     expect(work.metadata).to eq(work.as_json["resource"])
   end
 


### PR DESCRIPTION
This also provides a potential pathway for integrating validation of metadata JSON using Dry::Schema 