### PR TITLE
Upgrade sidekiq to 8.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem "actioncable"
 gem "pg"
 gem "rails", "~> 8.0"
 # Use Puma as the app server
-gem "puma", "~> 5.6"
+gem "puma"
 # Use SCSS for stylesheets
 gem "sass-rails"
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gem "aws-sdk-s3"
 # https://github.com/sul-dlss/cocina-models
 # Required by latest datacite library
 gem "cocina-models" #
-gem "connection_pool", "~> 2.0"
 gem "csv"
 gem "datacite-mapping"
 gem "dogstatsd-ruby"
@@ -39,7 +38,7 @@ gem "nokogiri", ">= 1.13.4"
 gem "retryable"
 gem "rolify"
 gem "rspec-rails"
-gem "sidekiq", "~> 7.2"
+gem "sidekiq", "< 9"
 gem "sqlite3", force_ruby_platform: true # requires bundler >= 2.3.18
 gem "vite_rails"
 gem "whenever"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -374,7 +374,7 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     net-ssh (7.3.0)
-    nio4r (2.7.4)
+    nio4r (2.7.5)
     nokogiri (1.19.2)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
@@ -416,7 +416,7 @@ GEM
       date
       stringio
     public_suffix (6.0.1)
-    puma (5.6.9)
+    puma (8.0.1)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)
@@ -725,7 +725,7 @@ DEPENDENCIES
   pg
   pry-byebug
   pry-rails
-  puma (~> 5.6)
+  puma
   rack-mini-profiler (~> 2.0)
   rails (~> 8.0)
   rails-controller-testing

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,7 +191,7 @@ GEM
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.3.6)
-    connection_pool (2.5.5)
+    connection_pool (3.0.2)
     coveralls_reborn (0.28.0)
       simplecov (~> 0.22.0)
       term-ansicolor (~> 1.7)
@@ -272,9 +272,6 @@ GEM
       logger
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
-    faye-websocket (0.11.3)
-      eventmachine (>= 0.12.0)
-      websocket-driver (>= 0.5.1)
     ffaker (2.23.0)
     ffi (1.17.3)
     ffi (1.17.3-x86_64-darwin)
@@ -284,6 +281,10 @@ GEM
       activerecord (>= 4.0.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    haml (7.2.0)
+      temple (>= 0.8.2)
+      thor
+      tilt
     hana (1.3.7)
     hashdiff (1.1.1)
     hashie (3.6.0)
@@ -329,15 +330,16 @@ GEM
       net-imap
       net-pop
       net-smtp
-    mailcatcher (0.10.0)
-      eventmachine (~> 1.0)
-      faye-websocket (~> 0.11.1)
-      mail (~> 2.3)
-      net-smtp
-      rack (~> 2.2)
-      sinatra (~> 3.2)
-      sqlite3 (~> 1.3)
-      thin (~> 1.8)
+    mailcatcher (0.2.4)
+      eventmachine
+      haml
+      i18n
+      json
+      mail
+      sinatra
+      skinny (>= 0.1.2)
+      sqlite3-ruby
+      thin
     marcel (1.0.4)
     matrix (0.4.2)
     method_source (1.1.0)
@@ -351,15 +353,14 @@ GEM
       prism (~> 1.5)
     msgpack (1.7.2)
     multi_json (1.20.1)
-    mustermann (3.0.4)
-      ruby2_keywords (~> 0.0.1)
+    mustermann (3.1.1)
     mutex_m (0.3.0)
     net-ftp (0.3.7)
       net-protocol
       time
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.5.12)
+    net-imap (0.6.4)
       date
       net-protocol
     net-pop (0.1.2)
@@ -418,21 +419,22 @@ GEM
     puma (5.6.9)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (2.2.23)
+    rack (3.2.6)
     rack-mini-profiler (2.3.4)
       rack (>= 1.2.0)
-    rack-protection (3.2.0)
+    rack-protection (4.2.1)
       base64 (>= 0.1.0)
-      rack (~> 2.2, >= 2.2.4)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
     rack-proxy (0.7.7)
       rack
-    rack-session (1.0.2)
-      rack (< 3)
+    rack-session (2.1.2)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
     rack-test (2.2.0)
       rack (>= 1.3)
-    rackup (1.0.1)
-      rack (< 3)
-      webrick
+    rackup (2.3.1)
+      rack (>= 3)
     rails (8.0.2.1)
       actioncable (= 8.0.2.1)
       actionmailbox (= 8.0.2.1)
@@ -476,7 +478,7 @@ GEM
       psych (>= 4.0.0)
       tsort
     redis (4.8.1)
-    redis-client (0.22.2)
+    redis-client (0.28.0)
       connection_pool
     regexp_parser (2.12.0)
     reline (0.6.3)
@@ -536,7 +538,6 @@ GEM
     rubocop-rspec (2.11.1)
       rubocop (~> 1.19)
     ruby-progressbar (1.13.0)
-    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -555,12 +556,12 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    sidekiq (7.3.2)
-      concurrent-ruby (< 2)
-      connection_pool (>= 2.3.0)
-      logger
-      rack (>= 2.2.4)
-      redis-client (>= 0.22.2)
+    sidekiq (8.1.3)
+      connection_pool (>= 3.0.0)
+      json (>= 2.16.0)
+      logger (>= 1.7.0)
+      rack (>= 3.2.0)
+      redis-client (>= 0.26.0)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -568,11 +569,16 @@ GEM
     simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
     simpleidn (0.2.3)
-    sinatra (3.2.0)
+    sinatra (4.2.1)
+      logger (>= 1.6.0)
       mustermann (~> 3.0)
-      rack (~> 2.2, >= 2.2.4)
-      rack-protection (= 3.2.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.2.1)
+      rack-session (>= 2.0.0, < 3)
       tilt (~> 2.0)
+    skinny (0.2.2)
+      eventmachine (~> 1.0)
+      thin
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -580,8 +586,10 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
-    sqlite3 (1.7.3)
+    sqlite3 (2.9.3)
       mini_portile2 (~> 2.8.0)
+    sqlite3-ruby (1.3.3)
+      sqlite3 (>= 1.3.3)
     sshkit (1.24.0)
       base64
       logger
@@ -595,18 +603,20 @@ GEM
       diff-lcs
       patience_diff
     sync (0.5.0)
+    temple (0.10.4)
     term-ansicolor (1.11.2)
       tins (~> 1.0)
-    thin (1.8.2)
+    thin (2.0.1)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
-      rack (>= 1, < 3)
+      logger
+      rack (>= 1, < 4)
     thor (1.5.0)
     thread_safe (0.3.6)
-    tilt (2.6.1)
+    tilt (2.7.0)
     time (0.4.0)
       date
-    timeout (0.5.0)
+    timeout (0.6.1)
     tins (1.33.0)
       bigdecimal
       sync
@@ -644,7 +654,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.9.2)
     websocket (1.2.11)
     websocket-driver (0.8.0)
       base64
@@ -683,7 +692,6 @@ DEPENDENCIES
   capistrano-rails (~> 1.4)
   capybara
   cocina-models
-  connection_pool (~> 2.0)
   coveralls_reborn (~> 0.28)
   csv
   database_cleaner-active_record
@@ -730,7 +738,7 @@ DEPENDENCIES
   rspec-retry
   sass-rails
   selenium-webdriver
-  sidekiq (~> 7.2)
+  sidekiq (< 9)
   simplecov (~> 0.22)
   sinatra
   sqlite3


### PR DESCRIPTION
* Sidekiq 8 offers performance improvements, better security, and better visibility into performance tuning our background jobs.

* Doing this will let us stop pinning an old version of `connection_pool`

See [the sidekiq 8 release notes](https://github.com/sidekiq/sidekiq/blob/main/docs/8.0-Upgrade.md) for more details. 

The new dashboard is nice, and I tested that this runs correctly in staging.
<img width="1207" height="745" alt="Screenshot 2026-04-30 at 1 26 12 PM" src="https://github.com/user-attachments/assets/58ead691-6b18-4115-88fb-704ce9439d1c" />
