### PR TITLE
Updating for newer version of sidekiq testing API

### DIFF
--- a/spec/jobs/dspace_bitstream_copy_job_spec.rb
+++ b/spec/jobs/dspace_bitstream_copy_job_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require "rails_helper"
-require "sidekiq/testing/inline"
+require "sidekiq/testing"
+Sidekiq::Testing.inline!
 
 RSpec.describe DspaceBitstreamCopyJob, type: :job do
   include ActiveJob::TestHelper

--- a/spec/jobs/dspace_file_copy_job_spec.rb
+++ b/spec/jobs/dspace_file_copy_job_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require "rails_helper"
-require "sidekiq/testing/inline"
+require "sidekiq/testing"
+Sidekiq::Testing.inline!
 
 RSpec.describe DspaceFileCopyJob, type: :job do
   include ActiveJob::TestHelper

--- a/spec/requests/sidekiq_spec.rb
+++ b/spec/requests/sidekiq_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require "rails_helper"
 require "sidekiq/testing"
+Sidekiq.testing!(:fake)
 
 RSpec.describe "Sidekiq Dashboard", type: :request do
   before(:each) do


### PR DESCRIPTION
'require sidekiq/testing' is deprecated and will be removed in Sidekiq 9.0. See https://sidekiq.org/wiki/Testing#new-api