### PR TITLE
Adding in a Work Preservation Audit to make sure all approved works have made it to preservation

### DIFF
--- a/app/services/work_preservation_audit_service.rb
+++ b/app/services/work_preservation_audit_service.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+class WorkAuditError < ::StandardError; end
+
+# A service to create and store the preservation data for a given work.
+# Currently it assumes this data will be stored in an AWS S3 bucket accessible with our AWS credentials.
+# This preservation bucket is configured in our s3.yml file and we store it in a different availability region
+# to make sure the data is properly distributed.
+class WorkPreservationAuditService
+  include Rails.application.routes.url_helpers
+
+  attr_reader :date
+
+  # @param date date works were approved to audit.
+  def initialize(date: Time.zone.yesterday)
+    @date = date
+  end
+
+  # Audits all works approved on the date and validates that their directory exists in preservation
+  # @return [Boolean] true if all works from the date were present in preservation
+  def audit!
+    works = list_works
+    work_status_list = works.map { |work| check_work(work) }
+    empty_works = work_status_list.select { |work_status| work_status[:empty] }.pluck(:work)
+
+    if empty_works.count > 0
+      raise WorkAuditError, error_message(empty_works)
+    end
+
+    true
+  end
+
+  private
+
+    def list_works
+      approve_activities = WorkActivity.where(message: "marked as Approved", activity_type: WorkActivity::SYSTEM, created_at: date.all_day)
+      approve_activities.map(&:work)
+    end
+
+    def check_work(work)
+      s3service = S3QueryService.new(work, PULS3Client::PRESERVATION)
+      status = s3service.directory_empty(bucket: s3service.bucket_name, key: s3service.prefix)
+      { work:, empty: status }
+    end
+
+    def error_message(empty_works)
+      return unless empty_works.count > 0
+
+      error_links = empty_works.map { |work| work_link(work) }
+      "Works Missing from preservation: #{error_links.join(', ')}"
+    end
+
+    def work_link(work)
+      "<a href=\"#{work_url(work)}\">#{work.title} (#{work.doi})</a>"
+    end
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -26,6 +26,10 @@ every :day, at: "12:05am", roles: [:cron] do
   rake "embargo:release"
 end
 
+every :day, at: "11:45pm", roles: [:cron] do
+  rake "works:preservation_audit"
+end
+
 every :day, at: "12:05am", roles: [:one] do
   restart_passenger "na"
 end

--- a/lib/tasks/works.rake
+++ b/lib/tasks/works.rake
@@ -109,6 +109,13 @@ namespace :works do
     puts work_preservation.preserve!
   end
 
+  desc "Audit preservations from yesterday"
+  task preservation_audit: :environment do
+    auditor = WorkPreservationAuditService.new
+    auditor.audit!
+    puts "All works approved yesterday are in preservation!"
+  end
+
   # Artificially add a lot of notifications to a work
   # (Will be used to test https://github.com/pulibrary/pdc_describe/issues/1978 in staging )
   task :big_provenance, [:work_id] => :environment do |_, args|

--- a/spec/services/work_preservation_audit_service_spec.rb
+++ b/spec/services/work_preservation_audit_service_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe WorkPreservationAuditService do
+  describe "audit preserve S3" do
+    let(:work) { FactoryBot.create :approved_work, doi: "10.34770/pe9w-x904" }
+    let(:path) { work.s3_query_service.prefix }
+    let(:preservation_directory) { path + "princeton_data_commons/" }
+    let(:file1) { FactoryBot.build :s3_file, filename: "#{work.doi}/#{work.id}/anyfile1_readme.txt", last_modified: Time.parse("2022-04-21T18:29:40.000Z") }
+    let(:file2) { FactoryBot.build :s3_file, filename: "#{work.doi}/#{work.id}/folder1/anyfile2.txt", last_modified: Time.parse("2022-04-21T18:29:40.000Z") }
+    let(:preservation_file1) do
+      FactoryBot.build(
+        :s3_file,
+        filename: "#{work.doi}/#{work.id}//princeton_data_commons/metadata.json",
+        last_modified: Time.parse("2022-04-21T18:29:40.000Z")
+      )
+    end
+    let(:files) { [file1, file2, preservation_file1] }
+    let(:fake_s3_service) { stub_s3(data: files, bucket_name: "example-bucket-preservation", prefix: "10.34770/pe9w-x904/#{work.id}/") }
+
+    before do
+      # Add the approval work activity, since the factory does not
+      curator_user = FactoryBot.create :user, groups_to_admin: [work.group]
+      WorkActivity.add_work_activity(work.id, "marked as #{work.state.to_s.titleize}", curator_user.id, activity_type: WorkActivity::SYSTEM)
+      allow(fake_s3_service).to receive(:directory_empty).and_return(false)
+    end
+
+    it "audits that a work has been stored in the correct preservation bucket in S3" do
+      subject = described_class.new(date: Time.zone.today)
+      expect(subject.audit!).to be_truthy
+      expect(fake_s3_service).to have_received(:directory_empty).with(key: "10.34770/pe9w-x904/#{work.id}/", bucket: "example-bucket-preservation")
+    end
+
+    it "returns true if no works were approved that day" do
+      subject = described_class.new
+      expect(subject.audit!).to be_truthy
+      expect(fake_s3_service).not_to have_received(:directory_empty).with(key: "10.34770/pe9w-x904/#{work.id}/", bucket: "example-bucket-preservation")
+    end
+
+    context "when the directory is empty" do
+      before do
+        allow(Honeybadger).to receive(:notify)
+        allow(fake_s3_service).to receive(:directory_empty).and_return(true)
+      end
+      it "audits that a work has not been stored in the correct preservation bucket in S3" do
+        subject = described_class.new(date: Time.zone.today)
+        expect { subject.audit! }.to raise_error(WorkAuditError, "Works Missing from preservation: <a href=\"http://www.example.com/works/#{work.id}\">#{work.title} (10.34770/pe9w-x904)</a>")
+        expect(fake_s3_service).to have_received(:directory_empty).with(key: "10.34770/pe9w-x904/#{work.id}/", bucket: "example-bucket-preservation")
+      end
+    end
+  end
+end


### PR DESCRIPTION


Scheduled at the end of each day to verify that the works created the previous day made it into preservation fixes #2219