### PR TITLE
Updating code to allow for multiple WorkActivity classes based on the transition

### DIFF
--- a/app/models/work_activity_notification.rb
+++ b/app/models/work_activity_notification.rb
@@ -6,6 +6,15 @@ class WorkActivityNotification < ApplicationRecord
 
   after_create do
     if send_message?
+      send_messages
+    else
+      update_email_sent("unsent")
+    end
+  end
+
+  private
+
+    def send_messages
       mailer = NotificationMailer.with(user:, work_activity:)
       # messages sent from the work
       if work_activity.activity_type == WorkActivity::MESSAGE
@@ -15,8 +24,8 @@ class WorkActivityNotification < ApplicationRecord
 
       # state transition notifications
       elsif work_activity.activity_type == WorkActivity::NOTIFICATION
-        message = build_state_transition_message(mailer)
-        message.deliver_later(wait: wait_time) unless Rails.env.development?
+        update_email_sent("state_transition")
+        mailer.build_message.deliver_later(wait: wait_time) unless Rails.env.development?
 
       # Error publishing DOI or Curator self assigned and assigned
       else
@@ -24,37 +33,7 @@ class WorkActivityNotification < ApplicationRecord
         message = mailer.build_message
         message.deliver_later
       end
-    else
-      update_email_sent("unsent")
     end
-  end
-
-  private
-
-    # this method is a bit long but it is handling a lot of different cases and I think it's clearer to have it all in one place rather than trying to break it up into multiple methods
-    # rubocop:disable Metrics/MethodLength
-    def build_state_transition_message(mailer)
-      work = work_activity.work
-      from_state = check_from_state(work)
-
-      if work.state == "draft" && from_state == :none # draft event
-        update_email_sent("new_submission")
-        mailer.new_submission_message
-      elsif work.state == "draft" && from_state == :awaiting_approval # revert_to_draft event
-        update_email_sent("reject")
-        mailer.reject_message
-      elsif work.state == "awaiting_approval" && from_state == :draft # complete_submission
-        update_email_sent("review")
-        mailer.review_message
-      elsif work.state == "approved" && from_state == :awaiting_approval # approve_submission
-        update_email_sent("publish")
-        mailer.publish_message
-      else # some other system transition that we don't have a specific message for, just send the generic message
-        update_email_sent("system_transition")
-        mailer.build_message
-      end
-    end
-    # rubocop:enable Metrics/MethodLength
 
     def update_email_sent(type)
       self.email_sent = { type:, email: user.email }

--- a/app/models/work_state_transition/approved.rb
+++ b/app/models/work_state_transition/approved.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module WorkStateTransition
+  class Approved < Base
+    def self.add_work_activity(work_id, current_user_id, user_tags)
+      work_title = Work.find(work_id).title
+      work_url = data_commons_url(work_id)
+      message = "#{user_tags} [#{work_title}](#{work_url}) has been approved."
+      activity = Approved.new(work_id:, activity_type: WorkActivity::NOTIFICATION, message:, created_by_user_id: current_user_id)
+      activity.save!
+      activity.notify_users
+
+      activity
+    end
+  end
+end

--- a/app/models/work_state_transition/approved_notification.rb
+++ b/app/models/work_state_transition/approved_notification.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+module WorkStateTransition
+  class ApprovedNotification < BaseNotification
+    private
+
+      def send_messages
+        update_email_sent("publish")
+        mailer = NotificationMailer.with(user:, work_activity:)
+        mailer.publish_message.deliver_later(wait: wait_time)
+      end
+  end
+end

--- a/app/models/work_state_transition/awaiting_approval.rb
+++ b/app/models/work_state_transition/awaiting_approval.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module WorkStateTransition
+  class AwaitingApproval < Base
+    def self.add_work_activity(work_id, current_user_id, user_tags)
+      work_title = Work.find(work_id).title
+      work_url = data_commons_url(work_id)
+      message = "#{user_tags} [#{work_title}](#{work_url}) is ready for review."
+      activity = AwaitingApproval.new(work_id:, activity_type: WorkActivity::NOTIFICATION, message:, created_by_user_id: current_user_id)
+      activity.save!
+      activity.notify_users
+
+      activity
+    end
+  end
+end

--- a/app/models/work_state_transition/awaiting_approval_notification.rb
+++ b/app/models/work_state_transition/awaiting_approval_notification.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+module WorkStateTransition
+  class AwaitingApprovalNotification < BaseNotification
+    private
+
+      def send_messages
+        update_email_sent("review")
+        mailer = NotificationMailer.with(user:, work_activity:)
+        mailer.review_message.deliver_later(wait: wait_time)
+      end
+  end
+end

--- a/app/models/work_state_transition/base.rb
+++ b/app/models/work_state_transition/base.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+module WorkStateTransition
+  class Base < WorkActivity
+    def work
+      @work ||= Work.find(work_id)
+    end
+
+    def notification_class
+      "#{self.class.name}Notification".constantize
+    end
+
+    def notify_users
+      work.group.administrators.each do |admin|
+        next if work.created_by_user_id == admin.id
+        notification_class.create(work_activity_id: id, user_id: admin.id)
+      end
+      notification_class.create(work_activity_id: id, user_id: work.created_by_user_id)
+    end
+
+    def self.data_commons_url(work_id)
+      url = if Rails.env.production?
+              path = Rails.application.routes.url_helpers.work_path(work_id)
+              "https://datacommons.princeton.edu#{path}"
+            else
+              Rails.application.routes.url_helpers.work_url(work_id)
+            end
+      url
+    end
+  end
+end

--- a/app/models/work_state_transition/base_notification.rb
+++ b/app/models/work_state_transition/base_notification.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+module WorkStateTransition
+  class BaseNotification < WorkActivityNotification
+    private
+
+      def wait_time
+        if Rails.env.development?
+          0
+        else
+          super
+        end
+      end
+  end
+end

--- a/app/models/work_state_transition/deletion_marker.rb
+++ b/app/models/work_state_transition/deletion_marker.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+module WorkStateTransition
+  class DeletionMarker < Base
+    def self.add_work_activity(work_id, current_user_id, _user_tags)
+      super(work_id, "deletion marker", current_user_id, activity_type: WorkActivity::NOTIFICATION)
+    end
+  end
+end

--- a/app/models/work_state_transition/deletion_marker_notification.rb
+++ b/app/models/work_state_transition/deletion_marker_notification.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+module WorkStateTransition
+  class WithdrawnNotification < BaseNotification
+  end
+end

--- a/app/models/work_state_transition/new_submission.rb
+++ b/app/models/work_state_transition/new_submission.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module WorkStateTransition
+  class NewSubmission < Base
+    def self.add_work_activity(work_id, current_user_id, user_tags)
+      work_title = Work.find(work_id).title
+      work_url = data_commons_url(work_id)
+      message = "#{user_tags} [#{work_title}](#{work_url}) has been created."
+      activity = NewSubmission.new(work_id:, activity_type: WorkActivity::NOTIFICATION, message:, created_by_user_id: current_user_id)
+      activity.save!
+      activity.notify_users
+
+      activity
+    end
+  end
+end

--- a/app/models/work_state_transition/new_submission_notification.rb
+++ b/app/models/work_state_transition/new_submission_notification.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+module WorkStateTransition
+  class NewSubmissionNotification < BaseNotification
+    private
+
+      def send_messages
+        update_email_sent("new_submission")
+        mailer = NotificationMailer.with(user:, work_activity:)
+        mailer.new_submission_message.deliver_later(wait: wait_time)
+      end
+  end
+end

--- a/app/models/work_state_transition/resubmission.rb
+++ b/app/models/work_state_transition/resubmission.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+module WorkStateTransition
+  class Resubmission < Base
+    def self.add_work_activity(work_id, current_user_id, _user_tags)
+      super(work_id, "resubmitted from withdrawn", current_user_id, activity_type: WorkActivity::NOTIFICATION)
+    end
+  end
+end

--- a/app/models/work_state_transition/resubmission_notification.rb
+++ b/app/models/work_state_transition/resubmission_notification.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+module WorkStateTransition
+  class WithdrawnNotification < BaseNotification
+  end
+end

--- a/app/models/work_state_transition/returned_to_draft.rb
+++ b/app/models/work_state_transition/returned_to_draft.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module WorkStateTransition
+  class ReturnedToDraft < Base
+    def self.add_work_activity(work_id, current_user_id, user_tags)
+      work_title = Work.find(work_id).title
+      user_full_name = User.find(current_user_id).full_name
+      message = "#{user_tags} #{user_full_name} at #{Time.now.utc} returned the following submission to you for revision: #{work_title}"
+      activity = ReturnedToDraft.new(work_id:,  activity_type: WorkActivity::NOTIFICATION, message:, created_by_user_id: current_user_id)
+      activity.save!
+      activity.notify_users
+
+      activity
+    end
+  end
+end

--- a/app/models/work_state_transition/returned_to_draft_notification.rb
+++ b/app/models/work_state_transition/returned_to_draft_notification.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+module WorkStateTransition
+  class ReturnedToDraftNotification < BaseNotification
+    private
+
+      def send_messages
+        update_email_sent("reject")
+        mailer = NotificationMailer.with(user:, work_activity:)
+        mailer.reject_message.deliver_later(wait: wait_time)
+      end
+  end
+end

--- a/app/models/work_state_transition/withdrawn.rb
+++ b/app/models/work_state_transition/withdrawn.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+module WorkStateTransition
+  class Withdrawn < Base
+    def self.add_work_activity(work_id, current_user_id, _user_tags)
+      super(work_id, "withdrawn", current_user_id, activity_type: WorkActivity::NOTIFICATION)
+    end
+  end
+end

--- a/app/models/work_state_transition/withdrawn_notification.rb
+++ b/app/models/work_state_transition/withdrawn_notification.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+module WorkStateTransition
+  class WithdrawnNotification < BaseNotification
+  end
+end

--- a/app/models/work_state_transition_notification.rb
+++ b/app/models/work_state_transition_notification.rb
@@ -25,32 +25,38 @@ class WorkStateTransitionNotification
 
     raise(NotImplementedError, "Invalid user ID provided.") if current_user_id.nil?
     @current_user_id = current_user_id
-    @notification = notification_for_transition
   end
 
   def send
-    return if notification.nil?
-
-    WorkActivity.add_work_activity(id, notification, current_user_id, activity_type: WorkActivity::NOTIFICATION)
+    class_for_transition.add_work_activity(id, current_user_id, user_tags)
   end
 
     private
 
-      def notification_for_transition
+      # rubocop:disable Metrics/MethodLength
+      # I want the factory to be all in one method
+      def class_for_transition
         case to_state
         when :awaiting_approval
-          "#{user_tags} [#{work_title}](#{work_url}) is ready for review."
+          WorkStateTransition::AwaitingApproval
         when :approved
-          "#{user_tags} [#{work_title}](#{work_url}) has been approved."
+          WorkStateTransition::Approved
         when :draft
           case from_state
           when :none
-            "#{user_tags} [#{work_title}](#{work_url}) has been created."
+            WorkStateTransition::NewSubmission
           when :awaiting_approval
-            "#{user_tags} #{User.find(@current_user_id).full_name} at #{Time.now.utc} returned the following submission to you for revision: #{work_title}"
+            WorkStateTransition::ReturnedToDraft
+          when :withdrawn
+            WorkStateTransition::Resubmission
           end
+        when :withdrawn
+          WorkStateTransition::Withdrawn
+        when :deletion_marker
+          WorkStateTransition::DeletionMarker
         end
       end
+      # rubocop:enable Metrics/MethodLength
 
       def user_tags
         @user_tags = begin

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -745,6 +745,7 @@ RSpec.describe WorksController do
         let(:fake_s3_service) { stub_s3(data:) }
         before do
           fake_s3_service
+          allow(Work).to receive(:find).with(work1.id).and_return(work1)
           allow(Work).to receive(:find).with(work1.id.to_s).and_return(work1)
           work1.complete_submission!(user)
           allow(fake_s3_service).to receive(:client_s3_files).and_return([])

--- a/spec/models/work_activity_notification_spec.rb
+++ b/spec/models/work_activity_notification_spec.rb
@@ -19,9 +19,9 @@ describe WorkActivityNotification, type: :model do
     end
 
     it "enqueues an e-mail message to be delivered for the notification" do
-      work_activity_notification = described_class.create(user:, work_activity:)
+      work_activity_notification = WorkStateTransition::WithdrawnNotification.create(user:, work_activity:)
       expect(message_delivery).to have_received(:deliver_later)
-      expect(work_activity_notification.email_sent).to eq({ "type" => "system_transition", "email" => user.email })
+      expect(work_activity_notification.email_sent).to eq({ "type" => "state_transition", "email" => user.email })
     end
 
     context "when the notification is for a Draft submission" do
@@ -34,7 +34,7 @@ describe WorkActivityNotification, type: :model do
       end
 
       it "enqueues an e-mail the news submission message to be delivered for the notification" do
-        work_activity_notification = described_class.create(user:, work_activity:)
+        work_activity_notification = WorkStateTransition::NewSubmissionNotification.create(user:, work_activity:)
         expect(message_delivery).not_to have_received(:deliver_later)
         expect(new_delivery).to have_received(:deliver_later)
         expect(work_activity_notification.email_sent).to eq({ "type" => "new_submission", "email" => user.email })
@@ -67,7 +67,7 @@ describe WorkActivityNotification, type: :model do
       end
 
       it "enqueues an e-mail the awaiting approval message to be delivered for the notification" do
-        work_activity_notification = described_class.create(user:, work_activity:)
+        work_activity_notification = WorkStateTransition::AwaitingApprovalNotification.create(user:, work_activity:)
         expect(message_delivery).not_to have_received(:deliver_later)
         expect(await_delivery).to have_received(:deliver_later)
         expect(work_activity_notification.email_sent).to eq({ "type" => "review", "email" => user.email })
@@ -101,7 +101,7 @@ describe WorkActivityNotification, type: :model do
       end
 
       it "enqueues an e-mail the news submission message to be delivered for the notification" do
-        work_activity_notification = described_class.create(user:, work_activity:)
+        work_activity_notification = WorkStateTransition::ReturnedToDraftNotification.create(user:, work_activity:)
         expect(message_delivery).not_to have_received(:deliver_later)
         expect(reject_delivery).to have_received(:deliver_later)
         expect(work_activity_notification.email_sent).to eq({ "type" => "reject", "email" => user.email })
@@ -134,7 +134,7 @@ describe WorkActivityNotification, type: :model do
       end
 
       it "enqueues an e-mail the news submission message to be delivered for the notification" do
-        work_activity_notification = described_class.create(user:, work_activity:)
+        work_activity_notification = WorkStateTransition::ApprovedNotification.create(user:, work_activity:)
         expect(message_delivery).not_to have_received(:deliver_later)
         expect(approve_delivery).to have_received(:deliver_later)
         expect(work_activity_notification.email_sent).to eq({ "type" => "publish", "email" => user.email })

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -549,10 +549,10 @@ RSpec.describe Work, type: :model do
       user_notification = notification.message
       expect(user_notification).to include("@#{curator_user.default_group.code}")
       expect(user_notification).to include("@#{user.uid}")
+      expect(user_notification).to include(Rails.application.routes.url_helpers.work_url(draft_work))
       notifications = WorkActivityNotification.where(work_activity_id: notification.id)
       expect(notifications.first.user_id).to eq(curator_user.id)
       expect(notifications.last.user_id).to eq(draft_work.created_by_user_id)
-      expect(user_notification). to include(Rails.application.routes.url_helpers.work_url(draft_work))
     end
 
     context "when deploying the server without a DataCite user configured" do
@@ -663,6 +663,8 @@ RSpec.describe Work, type: :model do
       notification = WorkActivity.where(activity_type: WorkActivity::NOTIFICATION).last
       curator_notification = notification.message
       expect(curator_notification).to include("@#{Group.research_data.code}")
+      expect(curator_notification).to include("ready for review")
+      expect(curator_notification).to include(Rails.application.routes.url_helpers.work_url(awaiting_approval_work))
       notifications = WorkActivityNotification.where(work_activity_id: notification.id)
       expect(notifications.first.user_id).to eq(curator.id)
       expect(notifications.last.user_id).to eq(awaiting_approval_work.created_by_user_id)

--- a/spec/models/work_state_transition_notification_spec.rb
+++ b/spec/models/work_state_transition_notification_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+describe WorkStateTransitionNotification, type: :model do
+  let(:user) { FactoryBot.create :user, groups_to_admin: [work.group] }
+  let(:work) { FactoryBot.create(:draft_work) }
+  let(:transition_notification) { described_class.new(work, user.id) }
+
+  describe "#send" do
+    let(:to_state) { :draft }
+    let(:from_state) { :none }
+    before do
+      aasm = work.aasm
+      allow(aasm).to receive(:from_state).and_return(from_state)
+      allow(aasm).to receive(:to_state).and_return(to_state)
+    end
+
+    it "creates WorkActivityNotifications for each user" do
+      expect do
+        transition_notification.send
+      end.to change(WorkActivityNotification, :count)
+        .by(2).and change(WorkActivity, :count).by(1)
+
+      group_notification = WorkActivityNotification.first
+      user_notification = WorkActivityNotification.last
+      activity = user_notification.work_activity
+      expect(user_notification.work_activity).to eq(group_notification.work_activity)
+      expect(activity.message).to include("has been created")
+      expect(activity.activity_type).to eq(WorkActivity::NOTIFICATION)
+      expect(activity.work_id).to eq(work.id)
+      expect(group_notification.user_id).to eq(user.id)
+      expect(group_notification.email_sent).to eq({ "type" => "new_submission", "email" => user.email })
+      expect(user_notification.email_sent).to eq({ "type" => "new_submission", "email" => work.created_by_user.email })
+      expect(user_notification.user_id).to eq(work.created_by_user_id)
+    end
+
+    context "when the work is submitted for review" do
+      let(:to_state) { :awaiting_approval }
+      let(:from_state) { :draft }
+
+      it "creates WorkActivityNotifications for each user" do
+        expect do
+          transition_notification.send
+        end.to change(WorkActivityNotification, :count)
+          .by(2).and change(WorkActivity, :count).by(1)
+
+        group_notification = WorkActivityNotification.first
+        user_notification = WorkActivityNotification.last
+        activity = user_notification.work_activity
+        expect(user_notification.work_activity).to eq(group_notification.work_activity)
+        expect(activity.message).to include("is ready for review")
+        expect(activity.activity_type).to eq(WorkActivity::NOTIFICATION)
+        expect(activity.work_id).to eq(work.id)
+        expect(group_notification.user_id).to eq(user.id)
+        expect(group_notification.email_sent).to eq({ "type" => "review", "email" => user.email })
+        expect(user_notification.email_sent).to eq({ "type" => "review", "email" => work.created_by_user.email })
+        expect(user_notification.user_id).to eq(work.created_by_user_id)
+      end
+    end
+
+    context "when the work is returned to draft" do
+      let(:to_state) { :draft }
+      let(:from_state) { :awaiting_approval }
+
+      it "creates WorkActivityNotifications for each user" do
+        expect do
+          transition_notification.send
+        end.to change(WorkActivityNotification, :count)
+          .by(2).and change(WorkActivity, :count).by(1)
+
+        group_notification = WorkActivityNotification.first
+        user_notification = WorkActivityNotification.last
+        activity = user_notification.work_activity
+        expect(user_notification.work_activity).to eq(group_notification.work_activity)
+        expect(activity.message).to include("returned the following submission to you for revision")
+        expect(activity.activity_type).to eq(WorkActivity::NOTIFICATION)
+        expect(activity.work_id).to eq(work.id)
+        expect(group_notification.user_id).to eq(user.id)
+        expect(group_notification.email_sent).to eq({ "type" => "reject", "email" => user.email })
+        expect(user_notification.email_sent).to eq({ "type" => "reject", "email" => work.created_by_user.email })
+        expect(user_notification.user_id).to eq(work.created_by_user_id)
+      end
+    end
+
+    context "when the work is approved" do
+      let(:to_state) { :approved }
+      let(:from_state) { :awaiting_approval }
+
+      it "creates WorkActivityNotifications for each user" do
+        expect do
+          transition_notification.send
+        end.to change(WorkActivityNotification, :count)
+          .by(2).and change(WorkActivity, :count).by(1)
+
+        group_notification = WorkActivityNotification.first
+        user_notification = WorkActivityNotification.last
+        activity = user_notification.work_activity
+        expect(user_notification.work_activity).to eq(group_notification.work_activity)
+        expect(activity.message).to include("has been approved")
+        expect(activity.activity_type).to eq(WorkActivity::NOTIFICATION)
+        expect(activity.work_id).to eq(work.id)
+        expect(group_notification.user_id).to eq(user.id)
+        expect(group_notification.email_sent).to eq({ "type" => "publish", "email" => user.email })
+        expect(user_notification.email_sent).to eq({ "type" => "publish", "email" => work.created_by_user.email })
+        expect(user_notification.user_id).to eq(work.created_by_user_id)
+      end
+    end
+    context "when the work is withdrawn" do
+      let(:to_state) { :withdrawn }
+      let(:from_state) { :awaiting_approval }
+
+      it "creates WorkActivityNotifications for each user" do
+        expect do
+          transition_notification.send
+        end.to change(WorkActivityNotification, :count)
+          .by(0).and change(WorkActivity, :count).by(1)
+
+        activity = WorkActivity.last
+        expect(activity.message).to include("withdrawn")
+        expect(activity.activity_type).to eq(WorkActivity::NOTIFICATION)
+        expect(activity.work_id).to eq(work.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We know that we need to be able to change the behavior of the notifications based on what state transition we are going through.

Instead of creating more branches as this gets more complex I decided to create classes for each transition.

You will note that there are very few changes to the tests as this is an effort to reorganize our code and create a seam for #2299.  Some changes were to make the tests more explicit, or just needed based on the organization changes.

Generally Work State Notifications were being handled by the WorkActivityNotification class and every notification that was sent out was based on the user tags set in the WorkStateTransitionNotification.

There are still some states (Withdrawn, Resubmitted, and Deletion Marker) that just use the base ActivityNotification but can easily be updated to implement their own send_message as the need arrises.