### PR TITLE
Updating the new submission to the new submission email to the depositor

### DIFF
--- a/app/models/work_state_transition/approved.rb
+++ b/app/models/work_state_transition/approved.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 module WorkStateTransition
   class Approved < Base
-    def self.add_work_activity(work_id, current_user_id, user_tags)
+    def self.add_work_activity(work_id, current_user_id)
       work_title = Work.find(work_id).title
       work_url = data_commons_url(work_id)
-      message = "#{user_tags} [#{work_title}](#{work_url}) has been approved."
+      message = "#{user_tags(work_id)} [#{work_title}](#{work_url}) has been approved."
       activity = Approved.new(work_id:, activity_type: WorkActivity::NOTIFICATION, message:, created_by_user_id: current_user_id)
       activity.save!
       activity.notify_users

--- a/app/models/work_state_transition/awaiting_approval.rb
+++ b/app/models/work_state_transition/awaiting_approval.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 module WorkStateTransition
   class AwaitingApproval < Base
-    def self.add_work_activity(work_id, current_user_id, user_tags)
+    def self.add_work_activity(work_id, current_user_id)
       work_title = Work.find(work_id).title
       work_url = data_commons_url(work_id)
-      message = "#{user_tags} [#{work_title}](#{work_url}) is ready for review."
+      message = "#{user_tags(work_id)} [#{work_title}](#{work_url}) is ready for review."
       activity = AwaitingApproval.new(work_id:, activity_type: WorkActivity::NOTIFICATION, message:, created_by_user_id: current_user_id)
       activity.save!
       activity.notify_users

--- a/app/models/work_state_transition/base.rb
+++ b/app/models/work_state_transition/base.rb
@@ -5,16 +5,32 @@ module WorkStateTransition
       @work ||= Work.find(work_id)
     end
 
+    def self.user_tags(work_id)
+      work = Work.find(work_id)
+      depositor = work.created_by_user
+      group = work.group
+      group_administrators = group.administrators
+      groups_users_for_tags = ["@#{group.code}"]
+      unless group_administrators.include?(depositor)
+        groups_users_for_tags << "@#{depositor.uid}"
+      end
+      groups_users_for_tags.join(", ")
+    end
+
     def notification_class
       "#{self.class.name}Notification".constantize
     end
 
     def notify_users
-      work.group.administrators.each do |admin|
+      group_users.each do |admin|
         next if work.created_by_user_id == admin.id
         notification_class.create(work_activity_id: id, user_id: admin.id)
       end
       notification_class.create(work_activity_id: id, user_id: work.created_by_user_id)
+    end
+
+    def group_users
+      work.group.administrators.reject { |admin| admin.id == work.created_by_user_id }
     end
 
     def self.data_commons_url(work_id)

--- a/app/models/work_state_transition/deletion_marker.rb
+++ b/app/models/work_state_transition/deletion_marker.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module WorkStateTransition
   class DeletionMarker < Base
-    def self.add_work_activity(work_id, current_user_id, _user_tags)
+    def self.add_work_activity(work_id, current_user_id)
       super(work_id, "deletion marker", current_user_id, activity_type: WorkActivity::NOTIFICATION)
     end
   end

--- a/app/models/work_state_transition/new_submission.rb
+++ b/app/models/work_state_transition/new_submission.rb
@@ -1,15 +1,22 @@
 # frozen_string_literal: true
 module WorkStateTransition
   class NewSubmission < Base
-    def self.add_work_activity(work_id, current_user_id, user_tags)
+    def self.add_work_activity(work_id, current_user_id)
       work_title = Work.find(work_id).title
       work_url = data_commons_url(work_id)
-      message = "#{user_tags} [#{work_title}](#{work_url}) has been created."
+      message = "[#{work_title}](#{work_url}) has been created."
       activity = NewSubmission.new(work_id:, activity_type: WorkActivity::NOTIFICATION, message:, created_by_user_id: current_user_id)
       activity.save!
       activity.notify_users
 
       activity
+    end
+
+    # explicitly email the submitter of the new submission activity the NewSubmissionNotification
+    #   additionally use the generic notification class to notify the group administrators that a submission has been created
+    def notify_users
+      group_users.each { |user| WorkActivityNotification.create(work_activity_id: id, user_id: user.id) }
+      NewSubmissionNotification.create(work_activity_id: id, user_id: work.created_by_user_id)
     end
   end
 end

--- a/app/models/work_state_transition/resubmission.rb
+++ b/app/models/work_state_transition/resubmission.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module WorkStateTransition
   class Resubmission < Base
-    def self.add_work_activity(work_id, current_user_id, _user_tags)
+    def self.add_work_activity(work_id, current_user_id)
       super(work_id, "resubmitted from withdrawn", current_user_id, activity_type: WorkActivity::NOTIFICATION)
     end
   end

--- a/app/models/work_state_transition/returned_to_draft.rb
+++ b/app/models/work_state_transition/returned_to_draft.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 module WorkStateTransition
   class ReturnedToDraft < Base
-    def self.add_work_activity(work_id, current_user_id, user_tags)
+    def self.add_work_activity(work_id, current_user_id)
       work_title = Work.find(work_id).title
       user_full_name = User.find(current_user_id).full_name
-      message = "#{user_tags} #{user_full_name} at #{Time.now.utc} returned the following submission to you for revision: #{work_title}"
-      activity = ReturnedToDraft.new(work_id:,  activity_type: WorkActivity::NOTIFICATION, message:, created_by_user_id: current_user_id)
+      message = "#{user_tags(work_id)} #{user_full_name} at #{Time.now.utc} returned the following submission to you for revision: #{work_title}"
+      activity = ReturnedToDraft.new(work_id:, activity_type: WorkActivity::NOTIFICATION, message:, created_by_user_id: current_user_id)
       activity.save!
       activity.notify_users
 

--- a/app/models/work_state_transition/withdrawn.rb
+++ b/app/models/work_state_transition/withdrawn.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module WorkStateTransition
   class Withdrawn < Base
-    def self.add_work_activity(work_id, current_user_id, _user_tags)
+    def self.add_work_activity(work_id, current_user_id)
       super(work_id, "withdrawn", current_user_id, activity_type: WorkActivity::NOTIFICATION)
     end
   end

--- a/app/models/work_state_transition_notification.rb
+++ b/app/models/work_state_transition_notification.rb
@@ -28,7 +28,7 @@ class WorkStateTransitionNotification
   end
 
   def send
-    class_for_transition.add_work_activity(id, current_user_id, user_tags)
+    class_for_transition.add_work_activity(id, current_user_id)
   end
 
     private
@@ -57,17 +57,6 @@ class WorkStateTransitionNotification
         end
       end
       # rubocop:enable Metrics/MethodLength
-
-      def user_tags
-        @user_tags = begin
-                      groups_users_for_tags = ["@#{group.code}"]
-                      unless group_administrators.include?(depositor)
-                        groups_users_for_tags << "@#{depositor.uid}"
-                      end
-
-                      groups_users_for_tags.join(", ")
-                    end
-      end
 
       # Make sure we use the official "datacommons" URL for production (and not pdc-describe-prod)
       def data_commons_url(work)

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -543,16 +543,20 @@ RSpec.describe Work, type: :model do
       expect { draft_work }
         .to change { WorkActivity.where(activity_type: WorkActivity::SYSTEM).count }.by(1)
         .and change { WorkActivity.where(activity_type: WorkActivity::NOTIFICATION).count }.by(1)
+        .and change { WorkActivityNotification.count }.by(2)
         .and have_enqueued_job(ActionMailer::MailDeliveryJob).twice
       expect(WorkActivity.where(activity_type: "SYSTEM").first.message).to eq("marked as Draft")
-      notification = WorkActivity.where(activity_type: WorkActivity::NOTIFICATION).last
-      user_notification = notification.message
-      expect(user_notification).to include("@#{curator_user.default_group.code}")
-      expect(user_notification).to include("@#{user.uid}")
-      expect(user_notification).to include(Rails.application.routes.url_helpers.work_url(draft_work))
-      notifications = WorkActivityNotification.where(work_activity_id: notification.id)
-      expect(notifications.first.user_id).to eq(curator_user.id)
-      expect(notifications.last.user_id).to eq(draft_work.created_by_user_id)
+      activity = WorkActivity.where(activity_type: WorkActivity::NOTIFICATION).last
+      message = activity.message
+      expect(message).to include("has been created")
+      expect(message).to include(Rails.application.routes.url_helpers.work_url(draft_work))
+      notifications = WorkActivityNotification.where(work_activity_id: activity.id)
+      curator_notification = notifications.first
+      user_notification = notifications.last
+      expect(curator_notification.user_id).to eq(curator_user.id)
+      expect(curator_notification.email_sent).to eq({ "email" => curator_user.email, "type" => "state_transition" })
+      expect(user_notification.user_id).to eq(draft_work.created_by_user_id)
+      expect(user_notification.email_sent).to eq({ "email" => user.email, "type" => "new_submission" })
     end
 
     context "when deploying the server without a DataCite user configured" do

--- a/spec/models/work_state_transition_notification_spec.rb
+++ b/spec/models/work_state_transition_notification_spec.rb
@@ -7,33 +7,35 @@ describe WorkStateTransitionNotification, type: :model do
   let(:transition_notification) { described_class.new(work, user.id) }
 
   describe "#send" do
-    let(:to_state) { :draft }
-    let(:from_state) { :none }
     before do
       aasm = work.aasm
       allow(aasm).to receive(:from_state).and_return(from_state)
       allow(aasm).to receive(:to_state).and_return(to_state)
     end
 
-    it "creates WorkActivityNotifications for each user" do
-      expect do
-        transition_notification.send
-      end.to change(WorkActivityNotification, :count)
-        .by(2).and change(WorkActivity, :count).by(1)
+    context "when the work is first submitted" do
+      let(:to_state) { :draft }
+      let(:from_state) { :none }
 
-      group_notification = WorkActivityNotification.first
-      user_notification = WorkActivityNotification.last
-      activity = user_notification.work_activity
-      expect(user_notification.work_activity).to eq(group_notification.work_activity)
-      expect(activity.message).to include("has been created")
-      expect(activity.activity_type).to eq(WorkActivity::NOTIFICATION)
-      expect(activity.work_id).to eq(work.id)
-      expect(group_notification.user_id).to eq(user.id)
-      expect(group_notification.email_sent).to eq({ "type" => "new_submission", "email" => user.email })
-      expect(user_notification.email_sent).to eq({ "type" => "new_submission", "email" => work.created_by_user.email })
-      expect(user_notification.user_id).to eq(work.created_by_user_id)
+      it "creates WorkActivityNotifications for each user" do
+        expect do
+          transition_notification.send
+        end.to change(WorkActivityNotification, :count)
+          .by(2).and change(WorkActivity, :count).by(1)
+
+        group_notification = WorkActivityNotification.first
+        user_notification = WorkActivityNotification.last
+        activity = user_notification.work_activity
+        expect(user_notification.work_activity).to eq(group_notification.work_activity)
+        expect(activity.message).to include("has been created")
+        expect(activity.activity_type).to eq(WorkActivity::NOTIFICATION)
+        expect(activity.work_id).to eq(work.id)
+        expect(group_notification.user_id).to eq(user.id)
+        expect(group_notification.email_sent).to eq({ "type" => "state_transition", "email" => user.email })
+        expect(user_notification.email_sent).to eq({ "type" => "new_submission", "email" => work.created_by_user.email })
+        expect(user_notification.user_id).to eq(work.created_by_user_id)
+      end
     end
-
     context "when the work is submitted for review" do
       let(:to_state) { :awaiting_approval }
       let(:from_state) { :draft }
@@ -109,7 +111,7 @@ describe WorkStateTransitionNotification, type: :model do
       let(:to_state) { :withdrawn }
       let(:from_state) { :awaiting_approval }
 
-      it "creates WorkActivityNotifications for each user" do
+      it "creates a work activity to note the transition" do
         expect do
           transition_notification.send
         end.to change(WorkActivityNotification, :count)
@@ -117,6 +119,40 @@ describe WorkStateTransitionNotification, type: :model do
 
         activity = WorkActivity.last
         expect(activity.message).to include("withdrawn")
+        expect(activity.activity_type).to eq(WorkActivity::NOTIFICATION)
+        expect(activity.work_id).to eq(work.id)
+      end
+    end
+
+    context "when the work is returned to draft after being withdrawn" do
+      let(:to_state) { :draft }
+      let(:from_state) { :withdrawn }
+
+      it "creates a work activity to note the transition" do
+        expect do
+          transition_notification.send
+        end.to change(WorkActivityNotification, :count)
+          .by(0).and change(WorkActivity, :count).by(1)
+
+        activity = WorkActivity.last
+        expect(activity.message).to eq("resubmitted from withdrawn")
+        expect(activity.activity_type).to eq(WorkActivity::NOTIFICATION)
+        expect(activity.work_id).to eq(work.id)
+      end
+    end
+
+    context "when the work is deleted after being withdrawn" do
+      let(:to_state) { :deletion_marker }
+      let(:from_state) { :withdrawn }
+
+      it "creates a work activity to note the transition" do
+        expect do
+          transition_notification.send
+        end.to change(WorkActivityNotification, :count)
+          .by(0).and change(WorkActivity, :count).by(1)
+
+        activity = WorkActivity.last
+        expect(activity.message).to eq("deletion marker")
         expect(activity.activity_type).to eq(WorkActivity::NOTIFICATION)
         expect(activity.work_id).to eq(work.id)
       end


### PR DESCRIPTION
And the generic state transition email to the curators

additionally move the user_tags method to the base class to clean up WorkStateTransitionNotification

fixes #2299 