### PR TITLE
Changing the link in the publish email to the doi url

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -62,7 +62,7 @@ class NotificationMailer < ApplicationMailer
     @subject = "[pdc-describe] Submission Published"
     @message = @work_activity.message
     @message_html = @work_activity.to_html
-    @url = data_commons_url(@work_activity.work)
+    @doi_url = @work_activity.work.doi_url
 
     mail(to: @user.email, subject: @subject)
   end

--- a/app/views/notification_mailer/new_submission_message.html.erb
+++ b/app/views/notification_mailer/new_submission_message.html.erb
@@ -20,7 +20,7 @@
       <p>A curator will then be assigned to begin the curatorial review process.</p>
     </section>
     <section>
-      <p>Feedback? Answer this 2 minute survey to help PDC improve for users like you.</p>
+      <p>Feedback? Answer this <a href="https://princetonsurvey.az1.qualtrics.com/jfe/form/SV_8dmxZjvhlF41jD0">2 minute survey</a> to help PDC improve for users like you.</p>
     </section>
     <section>
       <p>

--- a/app/views/notification_mailer/new_submission_message.text.erb
+++ b/app/views/notification_mailer/new_submission_message.text.erb
@@ -1,13 +1,13 @@
 Hello <%= @user.given_name %>,
 
-Thank you for creating a new submission <%= link_to @work_title, @url %>, the DOI the system generated for you <%= @doi_url %> can be given to your paper publisher at this time although it will not be live until this data submission is accepted. When you are ready, please:
+Thank you for creating a new submission <%= @work_title %> (<%= @url %>), the DOI the system generated for you <%= @doi_url %> can be given to your paper publisher at this time although it will not be live until this data submission is accepted. When you are ready, please:
 
 * Complete your submission
 * Accept the distribution license and submit it
 
 A curator will then be assigned to begin the curatorial review process.
 
-Feedback? Answer this <%= link_to "2 minute survey", "https://princetonsurvey.az1.qualtrics.com/jfe/form/SV_8dmxZjvhlF41jD0" %> to help PDC improve for users like you.
+Feedback? Answer this 2 minute survey (https://princetonsurvey.az1.qualtrics.com/jfe/form/SV_8dmxZjvhlF41jD0) to help PDC improve for users like you.
 
 Gratefully,
 Research Data and Scholarship Services

--- a/app/views/notification_mailer/publish_message.html.erb
+++ b/app/views/notification_mailer/publish_message.html.erb
@@ -11,7 +11,7 @@
     </section>
     <section>
       <p>
-        <span>Congratulations! Your dataset, <%= @work_title %>, has been published. Your DOI https://datacommons.princeton.edu/discovery/catalog/doi-<%= @work_activity.work.doi%> will go live soon. Your page may take some time to appear depending on the size and quantity of files. If you notice your publication page has not appeared after 72 hours, please contact us so we can remedy it as soon as possible.</span>
+        <span>Congratulations! Your dataset, <%= @work_title %>, has been published. Your DOI <%= @doi_url %> will go live soon. Your page may take some time to appear depending on the size and quantity of files. If you notice your publication page has not appeared after 72 hours, please contact us so we can remedy it as soon as possible.</span>
         <span>Since the data has been published, you won't be able to change it within PDC. If you need to make a change, please contact us for assistance: prds@princeton.edu (Princeton researchers) or publications@pppl.gov (PPPL researchers).</span>
         <span>Please share your associated paper's DOI with us once you receive it so we can connect your data publication with your paper to increase the findability of your work.</span>
         <span>Thank you for publishing your dataset with Princeton Data Commons.</span>

--- a/app/views/notification_mailer/publish_message.text.erb
+++ b/app/views/notification_mailer/publish_message.text.erb
@@ -1,5 +1,5 @@
 Dear <%= @user.given_name %>,
-Congratulations! Your dataset, <%= @work_title %>, has been published. Your DOI https://datacommons.princeton.edu/discovery/catalog/doi-<%= @work_activity.work.doi%> will go live soon. Your page may take some time to appear depending on the size and quantity of files. If you notice your publication page has not appeared after 72 hours, please contact us so we can remedy it as soon as possible.
+Congratulations! Your dataset, <%= @work_title %>, has been published. Your DOI <%= @doi_url %> will go live soon. Your page may take some time to appear depending on the size and quantity of files. If you notice your publication page has not appeared after 72 hours, please contact us so we can remedy it as soon as possible.
 
 Since the data has been published, you won't be able to change it within PDC. If you need to make a change, please contact us for assistance: prds@princeton.edu (Princeton researchers) or publications@pppl.gov (PPPL researchers)
 

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -236,24 +236,11 @@ describe NotificationMailer, type: :mailer do
       expect(message.body.parts.last.content_type).to eq("text/html; charset=UTF-8")
       expect(message.body.encoded).to include("Dear #{user.given_name},")
       expect(message.body.encoded).to include("Congratulations! Your dataset, #{work_activity.work.title}, has been published.")
-
+      expect(message.body.encoded).to include(work.doi_url)
       text_part = message.text_part
       expect(text_part.encoded).to include("Dear #{user.given_name},")
       expect(text_part.encoded).to include("Congratulations! Your dataset, #{work_activity.work.title}, has been published.")
-    end
-
-    context "when we are in production" do
-      before do
-        allow(Rails.env).to receive(:production?).and_return(true)
-      end
-
-      it "shows the data commons url" do
-        message = message_delivery.message
-        text_part = message.text_part
-        html_part = message.html_part
-        expect(html_part.encoded).to include("Your DOI https://datacommons.princeton.edu/discovery/catalog/doi-#{work_activity.work.doi} will go live soon.")
-        expect(text_part.encoded).to include("Your DOI https://datacommons.princeton.edu/discovery/catalog/doi-#{work_activity.work.doi} will go live soon.")
-      end
+      expect(message.body.encoded).to include(work.doi_url)
     end
   end
 end

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -94,33 +94,10 @@ describe NotificationMailer, type: :mailer do
       expect(message.body.encoded).to include("PDC Describe: New Submission Created")
       expect(message.body.encoded).to include("Thank you for creating a new submission")
       expect(message.body.encoded).to include("A curator will then be assigned to begin the curatorial review process")
+      expect(message.body.encoded).to include("<a href=\"https://princetonsurvey.az1.qualtrics.com/jfe/form/SV_8dmxZjvhlF41jD0\">2 minute survey</a>")
       expect(message.body.encoded).to include("doi.org/#{work.doi}")
-    end
-
-    context "when the message has markdown" do
-      let(:work_activity) { FactoryBot.create(:work_activity, work:) }
-      it "generates the e-mail message" do
-        expect(message_delivery).to be_a(ActionMailer::Parameterized::MessageDelivery)
-        expect(message_delivery.message).to be_a(Mail::Message)
-        message = message_delivery.message
-        expect(message.to).to eq([user.email])
-        expect(message.from).to eq(["noreply@example.com"])
-        expect(message.subject).to eq("[pdc-describe] New Submission Created")
-        text_part = message.text_part
-        html_part = message.html_part
-        expect(html_part.content_type).to eq("text/html; charset=UTF-8")
-        expect(text_part.content_type).to eq("text/plain; charset=UTF-8")
-
-        expect(html_part.body.encoded).to include("Hello #{user.given_name},")
-        expect(html_part.body.encoded).to include("Thank you for creating a new submission")
-        expect(html_part.body.encoded).to include("A curator will then be assigned to begin the curatorial review process")
-        expect(html_part.body.encoded).to include("doi.org/#{work.doi}")
-
-        expect(text_part.body.encoded).to include("Hello #{user.given_name},")
-        expect(text_part.body.encoded).to include("Thank you for creating a new submission")
-        expect(text_part.body.encoded).to include("A curator will then be assigned to begin the curatorial review process")
-        expect(text_part.body.encoded).to include("doi.org/#{work.doi}")
-      end
+      text_part = message.text_part
+      expect(text_part.encoded).to include("2 minute survey (https://princetonsurvey.az1.qualtrics.com/jfe/form/SV_8dmxZjvhlF41jD0)")
     end
   end
 


### PR DESCRIPTION
The link no longer changes based on production or other locations so we have no need of the data commons test

fixes #2327

Additionally add the link to the survey in the new submission email
fixes #2326